### PR TITLE
Added support for extra criteria in ReBench

### DIFF
--- a/rebench/tests/interop/rebench_log_adapter_test.py
+++ b/rebench/tests/interop/rebench_log_adapter_test.py
@@ -103,3 +103,31 @@ LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms""",
             "core-lib/Benchmarks/Join/FibSeq.ns: iterations=1 runtime: 129us",
             None)
         self._assert_basics(d, 0.129, 'ms', 'total', True)
+
+    def test_other_data(self):
+        l = RebenchLogAdapter(True)
+        data = l.parse_data("""Savina.Chameneos: trace size:    3903398byte
+Savina.Chameneos: external data: 40byte
+Savina.Chameneos: iterations=1 runtime: 64208us
+Savina.Chameneos: trace size:    3903414byte
+Savina.Chameneos: external data: 40byte
+Savina.Chameneos: iterations=1 runtime: 48581us""", None)
+
+        self.assertEqual(2, len(data))
+        dp = data[0]
+        self.assertEqual(64.208, dp.get_total_value())
+
+        self.assertEqual(3, len(dp.get_measurements()))
+        m1 = dp.get_measurements()[0]
+
+        self.assertFalse(m1.is_total())
+        self.assertEqual(3903398, m1.value)
+        self.assertEqual('trace size', m1.criterion)
+        self.assertEqual('byte', m1.unit)
+
+        m2 = dp.get_measurements()[1]
+        self.assertFalse(m2.is_total())
+        self.assertEqual(40, m2.value)
+        self.assertEqual('external data', m2.criterion)
+        self.assertEqual('byte', m2.unit)
+


### PR DESCRIPTION
This changes allows us to process output such as:

```
Savina.Chameneos: trace size:    3903351byte
Savina.Chameneos: external data: 40byte
Savina.Chameneos: iterations=1 runtime: 46370us
Savina.Chameneos: trace size:    3903351byte
Savina.Chameneos: external data: 40byte
Savina.Chameneos: iterations=1 runtime: 52693us
Savina.Chameneos: trace size:    3903358byte
Savina.Chameneos: external data: 40byte
Savina.Chameneos: iterations=1 runtime: 55802us
Savina.Chameneos: trace size:    3903351byte
Savina.Chameneos: external data: 40byte
Savina.Chameneos: iterations=1 runtime: 53581us
```