### PR TITLE
Support Python 3 and PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
 language: python
 
-python:
-  - "2.7"
+matrix:
+  include:
+    - python: "2.7"
+      virtualenv:
+        system_site_packages: true
+      addons:
+        apt:
+          packages:
+            - python-scipy
+
+    - python: "3.6"
+    # PyPy versions
+    - python: pypy
+    - python: pypy3
 
 dist: trusty
 sudo: false
@@ -9,20 +21,11 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-scipy
-    - time
-
-# install dependencies
-before_install:
-  - cp -R /usr/lib/python2.7/dist-packages/scipy* /home/travis/virtualenv/python2.7/lib/python2.7/site-packages/
-  - cp -R /usr/lib/python2.7/dist-packages/numpy* /home/travis/virtualenv/python2.7/lib/python2.7/site-packages/
-  # - cp -R /usr/lib/python2.7/dist-packages/PIL* /home/travis/virtualenv/python2.7/lib/python2.7/site-packages/
+      - time
 
 install:
-  - pip -q install PyYAML
+  - pip install .
   - pip install coveralls
-# TODO: check whether we can do something like the proposed:
-#   "pip install -r requirements.txt --use-mirrors"
 
 # command to run tests
 script: nosetests --with-coverage --cover-package=rebench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
- -
+ - Add support for Python 3 and PyPy (#65)
 
 ## [0.9.1] - 2017-12-21
 

--- a/rebench/__init__.py
+++ b/rebench/__init__.py
@@ -1,3 +1,3 @@
-from rebench import ReBench, main_func
+from .rebench import ReBench, main_func
 
 __version__ = ReBench().version

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -193,7 +193,7 @@ class Configurator:
     
     def get_runs(self):
         runs = set()
-        for exp in self._experiments.values():
+        for exp in list(self._experiments.values()):
             runs |= exp.get_runs()
         return runs
     

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -119,7 +119,7 @@ class Configurator:
     def _load_config(file_name):
         import yaml
         try:
-            f = file(file_name, 'r')
+            f = open(file_name, 'r')
             return yaml.load(f)
         except IOError:
             logging.error("An error occurred on opening the config file (%s)."

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -162,6 +162,8 @@ class Configurator:
     def _can_set_niceness():
         output = subprocess.check_output(["nice", "-n-20", "echo", "test"],
                                          stderr=subprocess.STDOUT)
+        if type(output) != str:
+            output = output.decode('utf-8')
         if "cannot set niceness" in output or "Permission denied" in output:
             return False
         else:

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -261,7 +261,7 @@ class Executor:
             for line in build:
                 tmp_file.write(line)
                 tmp_file.write('\n')
-        os.chmod(file_name, 0700)
+        os.chmod(file_name, 0o700)
         return file_name, True
 
     def _build_vm(self, run_id):

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -32,7 +32,7 @@ import sys
 from tempfile  import mkstemp
 from threading import Thread, RLock
 
-import subprocess_with_timeout as subprocess_timeout
+from . import subprocess_with_timeout as subprocess_timeout
 from .statistics  import StatisticProperties
 from .interop.adapter import ExecutionDeliveredNoResults
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -17,7 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from __future__ import with_statement
+from __future__ import with_statement, print_function
 
 from collections import deque
 from math import floor
@@ -179,7 +179,7 @@ class ParallelScheduler(RunScheduler):
                 exceptions.append(thread.exception)
 
         if len(exceptions) > 0:
-            print exceptions
+            print(exceptions)
             if len(exceptions) == 1:
                 raise exceptions[0]
             else:
@@ -373,7 +373,7 @@ class Executor:
 
     def _generate_data_point(self, cmdline, gauge_adapter, run_id,
                              termination_check):
-        print cmdline
+        print(cmdline)
         # execute the external program here
         (return_code, output, _) = subprocess_timeout.run(
             cmdline, cwd=run_id.location, stdout=subprocess.PIPE,

--- a/rebench/interop/jgf_adapter.py
+++ b/rebench/interop/jgf_adapter.py
@@ -28,7 +28,7 @@
 #                 time = float(m.group(2))
 #                 val = Measurement(time, None)
 #                 result.append(val)
-#                 #print "DEBUG OUT:" + time
+#                 #print("DEBUG OUT:" + time)
 #
 #         if time is None:
 #             raise OutputNotParseable(data)

--- a/rebench/model/__init__.py
+++ b/rebench/model/__init__.py
@@ -69,7 +69,7 @@ def value_or_list_as_list(value):
 def value_with_optional_details(value, default_details = None):
     if isinstance(value, dict):
         assert len(value) == 1
-        (value, details) = value.items()[0]
+        (value, details) = list(value.items())[0]
     else:
         details = default_details
     

--- a/rebench/model/__init__.py
+++ b/rebench/model/__init__.py
@@ -58,7 +58,7 @@ Glossary:
 
 
 def value_or_list_as_list(value):
-    if type(value) is list:
+    if isinstance(value, list):
         return value
     elif value is None:
         return []
@@ -67,7 +67,7 @@ def value_or_list_as_list(value):
 
 
 def value_with_optional_details(value, default_details = None):
-    if type(value) is dict:
+    if isinstance(value, dict):
         assert len(value) == 1
         (value, details) = value.items()[0]
     else:

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -182,7 +182,7 @@ class _DataPointPersistence(object):
                     run_id.loaded_data_point(data_point)
                     data_point = DataPoint(run_id)
             
-            except ValueError, e:
+            except ValueError as e:
                 msg = str(e)
                 if msg not in errors:
                     # Configuration is not available, skip data point

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -38,7 +38,7 @@ class DataStore:
         self._bench_cfgs = {}
 
     def load_data(self):
-        for persistence in self._files.values():
+        for persistence in list(self._files.values()):
             persistence._load_data()
 
     def get(self, filename, discard_old_data):

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -21,14 +21,20 @@ from __future__ import with_statement, print_function
 from collections import deque
 
 from datetime import datetime
-from httplib import HTTPException
 from time import time
 from math import floor
 import logging
 import json
-import urllib2
-import urllib
 import re
+
+try:
+    from urllib.request import urlopen
+    from urllib.parse import urlencode
+    from http.client import HTTPException
+except ImportError:
+    from httplib import HTTPException
+    from urllib import urlencode
+    from urllib2 import urlopen
 
 from .statistics import StatisticProperties
 
@@ -388,14 +394,14 @@ class CodespeedReporter(Reporter):
         return result
 
     def _send_payload(self, payload):
-        fh = urllib2.urlopen(self._cfg.url, payload)
+        fh = urlopen(self._cfg.url, payload)
         response = fh.read()
         fh.close()
         logging.info("Results were sent to codespeed, response was: "
                      + response)
 
     def _send_to_codespeed(self, results):
-        payload = urllib.urlencode({'json': json.dumps(results)})
+        payload = urlencode({'json': json.dumps(results)})
 
         try:
             self._send_payload(payload)

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -337,7 +337,7 @@ class CodespeedReporter(Reporter):
             self._send_and_empty_cache()
 
     def _send_and_empty_cache(self):
-        self._send_to_codespeed(self._cache.values())
+        self._send_to_codespeed(list(self._cache.values()))
         self._cache = {}
     
     def _result_data_template(self):

--- a/rebench/statistics.py
+++ b/rebench/statistics.py
@@ -20,6 +20,7 @@
 import copy
 import math
 import operator
+from functools import reduce
 
 
 def mean(values):

--- a/rebench/statistics.py
+++ b/rebench/statistics.py
@@ -27,14 +27,11 @@ def mean(values):
 
 
 def median(values):
-    values_ = copy.deepcopy(values)
-    values_.sort()
-
+    values_ = sorted(copy.deepcopy(values))
+    index = int(len(values_) / 2)
     if len(values_) % 2 == 0:
-        index = len(values_) / 2
         return float(values_[index] + values_[index - 1]) / 2
     else:
-        index = len(values_) / 2
         return values_[index]
 
 

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from os         import kill
 from select     import select
 from signal     import SIGKILL
@@ -91,7 +93,7 @@ def run(args, cwd = None, shell = False, kill_tree = True, timeout = -1,
                     break
                 diff = time() - start
                 if diff < timeout:
-                    print "Keep alive, current job runs for %dmin" % (diff / 60)
+                    print("Keep alive, current job runs for %dmin" % (diff / 60))
 
     if timeout != -1 and thread.is_alive():
         assert thread.pid is not None

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -120,7 +120,11 @@ def kill_process(pid, recursively, thread):
         pids.extend(get_process_children(pid))
 
     for p in pids:
-        kill(p, SIGKILL)
+        try:
+            kill(p, SIGKILL)
+        except ProcessLookupError:
+            # it's a race condition, so let's simply ignore it
+            pass
 
     thread.join()
 

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -116,7 +116,7 @@ def kill_process(pid, recursively, thread):
 
 
 def get_process_children(pid):
-    p = Popen('ps --no-headers -o pid --ppid %d' % pid, shell = True,
+    p = Popen('pgrep -P %d' % pid, shell = True,
               stdout = PIPE, stderr = PIPE)
     stdout, _stderr = p.communicate()
     result = [int(p) for p in stdout.split()]

--- a/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
+++ b/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
@@ -34,9 +34,9 @@ class Issue27InvalidRunNotHandled(ReBenchTestCase):
                            DataStore(),
                            standard_data_file = self._tmp_file)
         runs = list(cnf.get_runs())
-        self.assertEquals(runs[0].get_number_of_data_points(), 0)
+        self.assertEqual(runs[0].get_number_of_data_points(), 0)
 
         ex = Executor([runs[0]], False)
         ex.execute()
 
-        self.assertEquals(runs[0].get_number_of_data_points(), 0)
+        self.assertEqual(runs[0].get_number_of_data_points(), 0)

--- a/rebench/tests/bugs/issue_27_vm.py
+++ b/rebench/tests/bugs/issue_27_vm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-## simple script emulating a failing benchmark
+# simple script emulating a failing benchmark
+from __future__ import print_function
 
-print "Starting Richards benchmark ..."
-print "Results are incorrect"
+print("Starting Richards benchmark ...")
+print("Results are incorrect")

--- a/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
+++ b/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
@@ -56,8 +56,8 @@ class Issue4RunEquality(unittest.TestCase):
         hard_coded = self._create_hardcoded_run_id()
         template   = self._create_template_run_id()
 
-        self.assertEquals(hard_coded.cmdline(), template.cmdline())
-        self.assertEquals(hard_coded, template)
+        self.assertEqual(hard_coded.cmdline(), template.cmdline())
+        self.assertEqual(hard_coded, template)
         self.assertTrue(hard_coded == template)
         self.assertFalse(hard_coded is template)
 

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -62,7 +62,7 @@ class ExecutorTest(ReBenchTestCase):
 
     def test_broken_command_format(self):
         def test_exit(val):
-            self.assertEquals(-1, val, "got the correct error code")
+            self.assertEqual(-1, val, "got the correct error code")
             raise RuntimeError("TEST-PASSED")
         sys.exit = test_exit
 
@@ -80,7 +80,7 @@ class ExecutorTest(ReBenchTestCase):
     
     def test_broken_command_format_with_TypeError(self):
         def test_exit(val):
-            self.assertEquals(-1, val, "got the correct error code")
+            self.assertEqual(-1, val, "got the correct error code")
             raise RuntimeError("TEST-PASSED")
         sys.exit = test_exit
         
@@ -98,18 +98,18 @@ class ExecutorTest(ReBenchTestCase):
 
     def _basic_execution(self, cnf):
         runs = cnf.get_runs()
-        self.assertEquals(8, len(runs))
+        self.assertEqual(8, len(runs))
         ex = Executor(cnf.get_runs(), cnf.use_nice)
         ex.execute()
         for run in runs:
             data_points = run.get_data_points()
-            self.assertEquals(10, len(data_points))
+            self.assertEqual(10, len(data_points))
             for data_point in data_points:
                 measurements = data_point.get_measurements()
-                self.assertEquals(4, len(measurements))
+                self.assertEqual(4, len(measurements))
                 self.assertIsInstance(measurements[0], Measurement)
                 self.assertTrue(measurements[3].is_total())
-                self.assertEquals(data_point.get_total_value(),
+                self.assertEqual(data_point.get_total_value(),
                                   measurements[3].value)
 
     def test_basic_execution(self):

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -74,9 +74,9 @@ class ExecutorTest(ReBenchTestCase):
             ex = Executor(cnf.get_runs(), cnf.use_nice)
             ex.execute()
         except RuntimeError as e:
-            self.assertEqual("TEST-PASSED", e.message)
+            self.assertEqual("TEST-PASSED", str(e))
         except BenchmarkThreadExceptions as e:
-            self.assertEqual("TEST-PASSED", e.exceptions[0].message)
+            self.assertEqual("TEST-PASSED", str(e.exceptions[0]))
     
     def test_broken_command_format_with_TypeError(self):
         def test_exit(val):
@@ -92,9 +92,9 @@ class ExecutorTest(ReBenchTestCase):
             ex = Executor(cnf.get_runs(), cnf.use_nice)
             ex.execute()
         except RuntimeError as e:
-            self.assertEqual("TEST-PASSED", e.message)
+            self.assertEqual("TEST-PASSED", str(e))
         except BenchmarkThreadExceptions as e:
-            self.assertEqual("TEST-PASSED", e.exceptions[0].message)
+            self.assertEqual("TEST-PASSED", str(e.exceptions[0]))
 
     def _basic_execution(self, cnf):
         runs = cnf.get_runs()

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -38,7 +38,7 @@ class ExecutorTest(ReBenchTestCase):
 
     def test_setup_and_run_benchmark(self):
         # before executing the benchmark, we override stuff in subprocess for testing
-        subprocess.Popen =  Popen_override
+        subprocess.Popen = Popen_override
         options = ReBench().shell_options().parse_args([])[0]
         
         cnf  = Configurator(self._path + '/test.conf', DataStore(), options,
@@ -126,12 +126,29 @@ class ExecutorTest(ReBenchTestCase):
 def Popen_override(cmdline, stdout, stderr=None, shell=None):
     class Popen:
         returncode = 0
-        def communicate(self):
-            return "", ""
+
+        def __init__(self, args):
+            self.args = args
+
+        def communicate(self, *args, **kwargs):
+            return "", b""
+
         def poll(self):
             return self.returncode
+
+        def kill(self):
+            pass
+
+        def wait(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _type, _value, _traceback):
+            pass
     
-    return Popen()
+    return Popen(cmdline)
 
 
 def test_suite():

--- a/rebench/tests/features/issue_15_vm.py
+++ b/rebench/tests/features/issue_15_vm.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
-## simple script emulating a VM generating benchmark results
+# simple script emulating a VM generating benchmark results
+from __future__ import print_function
+
 import sys
 import random
 
-print sys.argv
+print(sys.argv)
 
-print "Harness Name: ", sys.argv[1]
-print "Bench Name:",    sys.argv[2]
-print "Warmup: ",       sys.argv[3]
+print("Harness Name: ", sys.argv[1])
+print("Bench Name:",    sys.argv[2])
+print("Warmup: ",       sys.argv[3])
 
 warmup = int(sys.argv[3])
 
 for i in range(0, warmup):
-    print "RESULT-total: ", random.triangular(700, 850) * 2
+    print("RESULT-total: ", random.triangular(700, 850) * 2)
 
-print "RESULT-total: ", random.triangular(700, 850)
+print("RESULT-total: ", random.triangular(700, 850))

--- a/rebench/tests/features/issue_15_warm_up_support_test.py
+++ b/rebench/tests/features/issue_15_warm_up_support_test.py
@@ -48,12 +48,12 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         cnf = Configurator(self._path + '/issue_15.conf', DataStore(),
                            standard_data_file = self._tmp_file)
         runs = list(cnf.get_runs())
-        self.assertEquals(runs[0].get_number_of_data_points(), 0)
-        self.assertEquals(runs[0].warmup_iterations, 13)
+        self.assertEqual(runs[0].get_number_of_data_points(), 0)
+        self.assertEqual(runs[0].warmup_iterations, 13)
 
         ex = Executor([runs[0]], False)
         ex.execute()
 
-        self.assertEquals(runs[0].get_number_of_data_points(),
+        self.assertEqual(runs[0].get_number_of_data_points(),
                           runs[0].run_config.number_of_data_points)
         self.assertLessEqual(runs[0].get_total_values()[0], 850)

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -39,9 +39,9 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
                            standard_data_file=self._tmp_file)
         ex = Executor(cnf.get_runs(), False)
         ex.execute()
-        self.assertEquals(1, len(cnf.get_runs()))
+        self.assertEqual(1, len(cnf.get_runs()))
         run = iter(cnf.get_runs()).next()
-        self.assertEquals(num_data_points, len(run.get_data_points()))
+        self.assertEqual(num_data_points, len(run.get_data_points()))
         return run.get_data_points()
 
     def test_records_multiple_data_points_from_single_execution_10(self):
@@ -53,9 +53,9 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
     def test_associates_measurements_and_data_points_correctly(self):
         data_points = self._records_data_points('Test1', 10)
         for dp, i in zip(data_points, range(0, 10)):
-            self.assertEquals(4, dp.number_of_measurements())
+            self.assertEqual(4, dp.number_of_measurements())
 
             for criterion, measurement in zip(["bar", "baz", "foo", "total"],
                                               dp.get_measurements()):
-                self.assertEquals(criterion, measurement.criterion)
-                self.assertEquals(i,         int(measurement.value))
+                self.assertEqual(criterion, measurement.criterion)
+                self.assertEqual(i,         int(measurement.value))

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -40,7 +40,7 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
         ex = Executor(cnf.get_runs(), False)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
-        run = iter(cnf.get_runs()).next()
+        run = next(iter(cnf.get_runs()))
         self.assertEqual(num_data_points, len(run.get_data_points()))
         return run.get_data_points()
 

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -52,7 +52,7 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
 
     def test_associates_measurements_and_data_points_correctly(self):
         data_points = self._records_data_points('Test1', 10)
-        for dp, i in zip(data_points, range(0, 10)):
+        for dp, i in zip(data_points, list(range(0, 10))):
             self.assertEqual(4, dp.number_of_measurements())
 
             for criterion, measurement in zip(["bar", "baz", "foo", "total"],

--- a/rebench/tests/features/issue_16_vm.py
+++ b/rebench/tests/features/issue_16_vm.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
-## simple script emulating a VM generating benchmark results
+# simple script emulating a VM generating benchmark results
+from __future__ import print_function
+
 import sys
 
-print sys.argv
+print(sys.argv)
 
-print "Harness Name: ", sys.argv[1]
-print "Bench Name:",    sys.argv[2]
-print "Input Size: ",   sys.argv[3]
+print("Harness Name: ", sys.argv[1])
+print("Bench Name:",    sys.argv[2])
+print("Input Size: ",   sys.argv[3])
 
 input_size = int(sys.argv[3])
 
 for i in range(0, input_size):
-    print "RESULT-bar:   %d.%d" % (i, i)
-    print "RESULT-baz:   %d.%d" % (i, i)
-    print "RESULT-foo:   %d.%d" % (i, i)
-    print "RESULT-total: %d.%d" % (i, i)
+    print("RESULT-bar:   %d.%d" % (i, i))
+    print("RESULT-baz:   %d.%d" % (i, i))
+    print("RESULT-foo:   %d.%d" % (i, i))
+    print("RESULT-total: %d.%d" % (i, i))

--- a/rebench/tests/features/issue_19_one_data_point_test.py
+++ b/rebench/tests/features/issue_19_one_data_point_test.py
@@ -17,6 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from __future__ import print_function
+
 from ...configurator     import Configurator
 from ...executor         import Executor, RoundRobinScheduler
 from ...persistence      import DataStore
@@ -64,12 +66,12 @@ class OneMeasurementAtATime(Issue19OneDataPointAtATime):
         self._run_count = {}
 
     def run_completed(self, run_id):
-        print "completed", run_id
+        print("completed", run_id)
         self.assertIs(self._run_id, run_id)
 
     def start_run(self, run_id):
         """ Make sure that we do not do the same run twice in a row. """
-        print "start", run_id
+        print("start", run_id)
         self.assertIsNot(self._run_id, run_id)
         self._run_id = run_id
         self._run_count[run_id] = self._run_count.get(run_id, 0) + 1

--- a/rebench/tests/features/issue_19_one_data_point_test.py
+++ b/rebench/tests/features/issue_19_one_data_point_test.py
@@ -87,5 +87,5 @@ class OneMeasurementAtATime(Issue19OneDataPointAtATime):
         ex.execute()
 
         for run in cnf.get_runs():
-            self.assertEquals(10, run.get_number_of_data_points())
-            self.assertEquals(10, self._run_count[run])
+            self.assertEqual(10, run.get_number_of_data_points())
+            self.assertEqual(10, self._run_count[run])

--- a/rebench/tests/features/issue_19_vm.py
+++ b/rebench/tests/features/issue_19_vm.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
-## simple script emulating a VM generating benchmark results
+# simple script emulating a VM generating benchmark results
+from __future__ import print_function
+
 import sys
 import random
 
-print sys.argv
+print(sys.argv)
 
-print "Harness Name: ", sys.argv[1]
-print "Bench Name:",    sys.argv[2]
-print "Input Size: ",   sys.argv[3]
+print("Harness Name: ", sys.argv[1])
+print("Bench Name:",    sys.argv[2])
+print("Input Size: ",   sys.argv[3])
 
-print "RESULT-total: ", random.triangular(700, 850)
+print("RESULT-total: ", random.triangular(700, 850))

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -17,6 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from __future__ import print_function
+
 from ...configurator           import Configurator
 from ...executor               import Executor
 from ...persistence            import DataStore
@@ -53,10 +55,10 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
 
     def test_associates_measurements_and_data_points_correctly(self):
         """
-        print "%d:RESULT-bar:ms:   %d.%d" % (i, i, i)
-        print "%d:RESULT-total:    %d.%d" % (i, i, i)
-        print "%d:RESULT-baz:kbyte:   %d" % (i, i)
-        print "%d:RESULT-foo:kerf: %d.%d" % (i, i, i)
+        print("%d:RESULT-bar:ms:   %d.%d" % (i, i, i))
+        print("%d:RESULT-total:    %d.%d" % (i, i, i))
+        print("%d:RESULT-baz:kbyte:   %d" % (i, i))
+        print("%d:RESULT-foo:kerf: %d.%d" % (i, i, i))
         """
         data_points = self._records_data_points('Test1', 10)
         for dp, i in zip(data_points, range(0, 10)):

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -39,9 +39,9 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
                            standard_data_file=self._tmp_file)
         ex = Executor(cnf.get_runs(), False)
         ex.execute()
-        self.assertEquals(1, len(cnf.get_runs()))
+        self.assertEqual(1, len(cnf.get_runs()))
         run = iter(cnf.get_runs()).next()
-        self.assertEquals(num_data_points, len(run.get_data_points()))
+        self.assertEqual(num_data_points, len(run.get_data_points()))
         return run.get_data_points()
 
     def test_records_multiple_data_points_from_single_execution_10(self):
@@ -62,21 +62,21 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         """
         data_points = self._records_data_points('Test1', 10)
         for dp, i in zip(data_points, range(0, 10)):
-            self.assertEquals(4, dp.number_of_measurements())
+            self.assertEqual(4, dp.number_of_measurements())
 
             for criterion, unit, measurement in zip(["bar", "total", "baz", "foo"],
                                                     ["ms", "ms", "kbyte", "kerf"],
                                                     dp.get_measurements()):
-                self.assertEquals(criterion, measurement.criterion)
-                self.assertEquals(i,         int(measurement.value))
-                self.assertEquals(unit,      measurement.unit)
+                self.assertEqual(criterion, measurement.criterion)
+                self.assertEqual(i,         int(measurement.value))
+                self.assertEqual(unit,      measurement.unit)
 
     def test_is_compatible_to_issue16_format(self):
         data_points = self._records_data_points('Test3', 10)
         for dp, i in zip(data_points, range(0, 10)):
-            self.assertEquals(4, dp.number_of_measurements())
+            self.assertEqual(4, dp.number_of_measurements())
 
             for criterion, measurement in zip(["bar", "baz", "foo", "total"],
                                               dp.get_measurements()):
-                self.assertEquals(criterion, measurement.criterion)
-                self.assertEquals(i,         int(measurement.value))
+                self.assertEqual(criterion, measurement.criterion)
+                self.assertEqual(i,         int(measurement.value))

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -40,7 +40,7 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         ex = Executor(cnf.get_runs(), False)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
-        run = iter(cnf.get_runs()).next()
+        run = next(iter(cnf.get_runs()))
         self.assertEqual(num_data_points, len(run.get_data_points()))
         return run.get_data_points()
 

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -61,7 +61,7 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         print("%d:RESULT-foo:kerf: %d.%d" % (i, i, i))
         """
         data_points = self._records_data_points('Test1', 10)
-        for dp, i in zip(data_points, range(0, 10)):
+        for dp, i in zip(data_points, list(range(0, 10))):
             self.assertEqual(4, dp.number_of_measurements())
 
             for criterion, unit, measurement in zip(["bar", "total", "baz", "foo"],
@@ -73,7 +73,7 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
 
     def test_is_compatible_to_issue16_format(self):
         data_points = self._records_data_points('Test3', 10)
-        for dp, i in zip(data_points, range(0, 10)):
+        for dp, i in zip(data_points, list(range(0, 10))):
             self.assertEqual(4, dp.number_of_measurements())
 
             for criterion, measurement in zip(["bar", "baz", "foo", "total"],

--- a/rebench/tests/features/issue_31_vm.py
+++ b/rebench/tests/features/issue_31_vm.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
-## simple script emulating a VM generating benchmark results
+# simple script emulating a VM generating benchmark results
+from __future__ import print_function
+
 import sys
 
-print sys.argv
+print(sys.argv)
 
-print "Harness Name: ", sys.argv[1]
-print "Bench Name:",    sys.argv[2]
-print "Input Size: ",   sys.argv[3]
+print("Harness Name: ", sys.argv[1])
+print("Bench Name:",    sys.argv[2])
+print("Input Size: ",   sys.argv[3])
 
 input_size = int(sys.argv[3])
 
 for i in range(0, input_size):
-    print "%d:RESULT-bar:ms:   %d.%d" % (i, i, i)
-    print "%d:RESULT-total:    %d.%d" % (i, i, i)
-    print "%d:RESULT-baz:kbyte:   %d" % (i, i)
-    print "%d:RESULT-foo:kerf: %d.%d" % (i, i, i)
+    print("%d:RESULT-bar:ms:   %d.%d" % (i, i, i))
+    print("%d:RESULT-total:    %d.%d" % (i, i, i))
+    print("%d:RESULT-baz:kbyte:   %d" % (i, i))
+    print("%d:RESULT-foo:kerf: %d.%d" % (i, i, i))

--- a/rebench/tests/features/issue_34_vm.py
+++ b/rebench/tests/features/issue_34_vm.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import sys
 
-print sys.argv
+print(sys.argv)
 
-print "Harness Name: ", sys.argv[1]
-print "Bench Name:",    sys.argv[2]
-print "Input Size: ",   sys.argv[3]
+print("Harness Name: ", sys.argv[1])
+print("Bench Name:",    sys.argv[2])
+print("Input Size: ",   sys.argv[3])
 
 name = sys.argv[2]
-print "RESULT-total: ", ("%s.%s" % (sys.argv[3], sys.argv[3]))
+print("RESULT-total: ", ("%s.%s" % (sys.argv[3], sys.argv[3])))
 
 if name == "error-code":
     sys.exit(1)
 elif name == "invalid":
-    print "FAILED"
+    print("FAILED")
 
 sys.exit(0)

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -17,6 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from __future__ import print_function
+
 from ...configurator     import Configurator
 from ...executor         import Executor
 from ...persistence      import DataStore
@@ -86,7 +88,7 @@ class Issue58BuildVM(ReBenchTestCase):
 
         self.assertEqual("Bench1", runs[0].bench_cfg.name)
         self.assertEqual(0, runs[0].get_number_of_data_points())
-        print self._path + '/vm_58a.sh'
+        print(self._path + '/vm_58a.sh')
         self.assertTrue(os.path.isfile(self._path + '/vm_58a.sh'))
         os.remove(self._path + '/vm_58a.sh')
 

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -54,9 +54,9 @@ class PersistencyTest(ReBenchTestCase):
         serialized = measurement.as_str_list()
         deserialized = Measurement.from_str_list(data_store, serialized)
 
-        self.assertEquals(deserialized.criterion, measurement.criterion)
-        self.assertEquals(deserialized.value,     measurement.value)
-        self.assertEquals(deserialized.unit,      measurement.unit)
-        self.assertAlmostEquals(deserialized.timestamp, measurement.timestamp)
+        self.assertEqual(deserialized.criterion, measurement.criterion)
+        self.assertEqual(deserialized.value,     measurement.value)
+        self.assertEqual(deserialized.unit,      measurement.unit)
+        self.assertAlmostEqual(deserialized.timestamp, measurement.timestamp)
 
-        self.assertEquals(deserialized.run_id,    measurement.run_id)
+        self.assertEqual(deserialized.run_id,    measurement.run_id)

--- a/rebench/tests/stats_test.py
+++ b/rebench/tests/stats_test.py
@@ -37,7 +37,7 @@ except ImportError:
 class StatsTest(unittest.TestCase):
     
     def setUp(self):
-        self._integers = range(1, 50)
+        self._integers = list(range(1, 50))
         self._floats   = [float(x)        for x in self._integers]
         self._floats2  = [float(x) + 2.31 for x in self._integers]
         

--- a/rebench/tests/subprocess_timeout_test.py
+++ b/rebench/tests/subprocess_timeout_test.py
@@ -70,5 +70,6 @@ class SubprocessTimeoutTest(unittest.TestCase):
 def test_suite():
     return unittest.makeSuite(SubprocessTimeoutTest)
 
+
 if __name__ == "__main__":
     unittest.main(defaultTest='test_suite')

--- a/rebench/tests/subprocess_timeout_test.py
+++ b/rebench/tests/subprocess_timeout_test.py
@@ -37,6 +37,7 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              stderr=subprocess.STDOUT,
                                              shell=True, timeout=10)
 
+        output = output.decode('utf-8')
         self.assertEqual(       0, return_code)
         self.assertEqual("Done\n",      output)
         self.assertEqual(    None,         err)
@@ -47,7 +48,8 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              stdout=subprocess.PIPE,
                                              stderr=subprocess.STDOUT,
                                              shell=True, timeout=1)
-        
+
+        output = output.decode('utf-8')
         self.assertEqual(-9,   return_code)
         self.assertEqual("",   output)
         self.assertEqual(None, err)
@@ -58,7 +60,8 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              stdout=subprocess.PIPE,
                                              stderr=subprocess.STDOUT,
                                              shell=True, timeout=5)
-        
+
+        output = output.decode('utf-8')
         self.assertEqual(-9, return_code)
         self.assertEqual("", output)
         self.assertEqual(None, err)

--- a/rebench/tests/test-vm1.py
+++ b/rebench/tests/test-vm1.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python
-## simple script emulating a VM generating benchmark results
+# simple script emulating a VM generating benchmark results
+from __future__ import print_function
+
 import sys
 import random
 
-print sys.argv
+print(sys.argv)
 
-print "NumCores:", sys.argv[1]
-print "BenchmarkHarness: ", sys.argv[2]
-print "Benchmark: ", sys.argv[3]
-print "InputSize: ", sys.argv[4]
-print "FreeVar: ", sys.argv[5]
+print("NumCores:", sys.argv[1])
+print("BenchmarkHarness: ", sys.argv[2])
+print("Benchmark: ", sys.argv[3])
+print("InputSize: ", sys.argv[4])
+print("FreeVar: ", sys.argv[5])
 
 if sys.argv[1] == 4 or sys.argv[1] == 13:
-    print "FAILED"
+    print("FAILED")
 else:
-    print "RESULT-part1: ", random.triangular(100, 110)
-    print "RESULT-part2: ", random.triangular(400, 440)
-    print "RESULT-part3: ", random.triangular(200, 300)
-    print "RESULT-total: ", random.triangular(700, 850)
+    print("RESULT-part1: ", random.triangular(100, 110))
+    print("RESULT-part2: ", random.triangular(400, 440))
+    print("RESULT-part3: ", random.triangular(200, 300))
+    print("RESULT-total: ", random.triangular(700, 850))

--- a/rebench/tests/test-vm1.py
+++ b/rebench/tests/test-vm1.py
@@ -16,7 +16,7 @@ print("FreeVar: ", sys.argv[5])
 if sys.argv[1] == 4 or sys.argv[1] == 13:
     print("FAILED")
 else:
-    print("RESULT-part1: ", random.triangular(100, 110))
-    print("RESULT-part2: ", random.triangular(400, 440))
-    print("RESULT-part3: ", random.triangular(200, 300))
-    print("RESULT-total: ", random.triangular(700, 850))
+    print("RESULT-part1: " + str(random.triangular(100, 110)))
+    print("RESULT-part2: " + str(random.triangular(400, 440)))
+    print("RESULT-part3: " + str(random.triangular(200, 300)))
+    print("RESULT-total: " + str(random.triangular(700, 850)))

--- a/rebench/tests/test-vm2.py
+++ b/rebench/tests/test-vm2.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
-## simple script emulating a VM generating benchmark results
+# simple script emulating a VM generating benchmark results
 import sys
-import time
 import random
+from __future__ import print_function
 
-print "test-vm2.py: args=", sys.argv
+print("test-vm2.py: args=", sys.argv)
 
-print "RESULT-part1: ", random.uniform(100, 110)
-print "RESULT-part2: ", random.uniform(400, 440)
-print "RESULT-part3: ", random.uniform(200, 300)
-print "RESULT-total: ", random.uniform(700, 850)
+print("RESULT-part1: ", random.uniform(100, 110))
+print("RESULT-part2: ", random.uniform(400, 440))
+print("RESULT-part3: ", random.uniform(200, 300))
+print("RESULT-total: ", random.uniform(700, 850))

--- a/rebench/tests/test-vm2.py
+++ b/rebench/tests/test-vm2.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # simple script emulating a VM generating benchmark results
+from __future__ import print_function
 import sys
 import random
-from __future__ import print_function
 
-print("test-vm2.py: args=", sys.argv)
+print("test-vm2.py: args=" + str(sys.argv))
 
-print("RESULT-part1: ", random.uniform(100, 110))
-print("RESULT-part2: ", random.uniform(400, 440))
-print("RESULT-part3: ", random.uniform(200, 300))
-print("RESULT-total: ", random.uniform(700, 850))
+print("RESULT-part1: " + str(random.uniform(100, 110)))
+print("RESULT-part2: " + str(random.uniform(400, 440)))
+print("RESULT-part3: " + str(random.uniform(200, 300)))
+print("RESULT-total: " + str(random.uniform(700, 850)))

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from rebench import ReBench
 
 rebench = ReBench()
@@ -31,7 +31,7 @@ setup(name='ReBench',
       author='Stefan Marr',
       author_email='rebench@stefan-marr.de',
       url='https://github.com/smarr/ReBench',
-      packages=['rebench', 'rebench.model', 'rebench.interop'],
+      packages=find_packages(exclude=['*.tests']),
       install_requires=[
           'PyYAML>=3.08'
       ],


### PR DESCRIPTION
This PR adapts ReBench to be compatible with Python 3.

With this change, we support and test now:

 - Python 2.7
 - Python 3.5

This includes CPython as well as PyPy.