### PR TITLE
Defining a Schema for ReBench configuration files

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -21,6 +21,8 @@ import sys
 import logging
 import subprocess
 import traceback
+from os.path import dirname
+
 from .model.runs_config import RunsConfig, QuickRunsConfig
 from .model.experiment  import Experiment
 
@@ -118,9 +120,18 @@ class Configurator:
     @staticmethod
     def _load_config(file_name):
         import yaml
+        from pykwalify.core import Core
+
+        # Disable most logging for pykwalify
+        logging.getLogger('pykwalify').setLevel(logging.ERROR)
+
         try:
-            f = open(file_name, 'r')
-            return yaml.load(f)
+            with open(file_name, 'r') as f:
+                data = yaml.safe_load(f)
+                c = Core(source_data=data,
+                         schema_files=[dirname(__file__) + "/rebench-schema.yml"])
+                c.validate(raise_exception=True)
+                return data
         except IOError:
             logging.error("An error occurred on opening the config file (%s)."
                           % file_name)

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -130,7 +130,12 @@ class Configurator:
                 data = yaml.safe_load(f)
                 c = Core(source_data=data,
                          schema_files=[dirname(__file__) + "/rebench-schema.yml"])
-                c.validate(raise_exception=True)
+                c.validate(raise_exception=False)
+                if c.validation_errors and len(c.validation_errors) > 0:
+                    logging.error(
+                        "Validation of " + file_name + " failed. " +
+                        (" ".join(c.validation_errors)))
+                    sys.exit(-1)
                 return data
         except IOError:
             logging.error("An error occurred on opening the config file (%s)."

--- a/rebench/model/__init__.py
+++ b/rebench/model/__init__.py
@@ -57,15 +57,6 @@ Glossary:
 """
 
 
-def value_or_list_as_list(value):
-    if isinstance(value, list):
-        return value
-    elif value is None:
-        return []
-    else:
-        return [value]
-
-
 def value_with_optional_details(value, default_details = None):
     if isinstance(value, dict):
         assert len(value) == 1

--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -17,7 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-from . import value_or_list_as_list
 import logging
 
 
@@ -38,12 +37,10 @@ class BenchmarkSuite(object):
         
         self._location        = global_suite_cfg.get('location', vm.path)
         self._cores           = global_suite_cfg.get('cores',    vm.cores)
-        self._variable_values = value_or_list_as_list(global_suite_cfg.get(
-                                                'variable_values', [None]))
+        self._variable_values = global_suite_cfg.get('variable_values', [None])
 
         self._vm                 = vm
-        self._benchmarks         = value_or_list_as_list(
-                                                global_suite_cfg['benchmarks'])
+        self._benchmarks         = global_suite_cfg['benchmarks']
         self._gauge_adapter      = global_suite_cfg['gauge_adapter']
 
         self._command            = global_suite_cfg['command']

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -21,7 +21,7 @@ from .virtual_machine  import VirtualMachine
 from .benchmark_suite  import BenchmarkSuite
 from .benchmark_config import BenchmarkConfig
 from .reporting        import Reporting
-from . import value_or_list_as_list, value_with_optional_details
+from . import value_with_optional_details
 
 
 class Experiment:
@@ -72,11 +72,9 @@ class Experiment:
         return runs
     
     def _compile_virtual_machines(self, global_vms_cfg):
-        benchmarks  = value_or_list_as_list(self._raw_definition.
-                                            get( 'benchmark', None))
-        input_sizes = value_or_list_as_list(self._raw_definition.
-                                            get('input_sizes', None))
-        executions  = value_or_list_as_list(self._raw_definition['executions'])
+        benchmarks  = self._raw_definition.get( 'benchmark', None)
+        input_sizes = self._raw_definition.get('input_sizes', None)
+        executions  = self._raw_definition['executions']
         
         vms = []
         
@@ -102,7 +100,7 @@ class Experiment:
     def _compile_benchmarks(self):
         bench_cfgs = []
         for suite in self._suites:
-            for bench in value_or_list_as_list(suite.benchmarks):
+            for bench in suite.benchmarks:
                 bench_cfgs.append(BenchmarkConfig.compile(
                     bench, suite, self._data_store))
         return bench_cfgs

--- a/rebench/model/virtual_machine.py
+++ b/rebench/model/virtual_machine.py
@@ -19,8 +19,6 @@
 # IN THE SOFTWARE.
 import os
 
-from . import value_or_list_as_list
-
 
 class VirtualMachine(object):
     
@@ -30,12 +28,9 @@ class VirtualMachine(object):
            the VM definitions
         """
         if vm_details:
-            benchmarks  = value_or_list_as_list(vm_details.get('benchmark',
-                                                               _benchmarks))
-            input_sizes = value_or_list_as_list(vm_details.get('input_sizes',
-                                                               _input_sizes))
-            cores       = value_or_list_as_list(vm_details.get('cores',
-                                                               None))
+            benchmarks  = vm_details.get('benchmark', _benchmarks)
+            input_sizes = vm_details.get('input_sizes', _input_sizes)
+            cores       = vm_details.get('cores', None)
         else:
             benchmarks  = _benchmarks
             input_sizes = _input_sizes

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -1,0 +1,287 @@
+name: ReBench Configuration
+desc: Specifies the elements of the YAML-based configuration format.
+
+schema;runs_type:
+  type: map
+  mapping:
+    number_of_data_points:
+      type: int
+      desc: Benchmarks are executed until we have this number of data points
+    min_runtime:
+      type: int
+      desc: Give a warning if the average run time is below this value in milliseconds
+    parallel_interference_factor:
+      type: float
+      desc: |
+        A higher factor means a lower degree of parallelism.
+        TODO: should probably be removed
+        TODO: then again, we might want this for research on the impact
+
+schema;reporting_type:
+  type: map
+  mapping:
+    csv_file:
+      type: str
+      desc: Statistics are written to a CSV file
+    csv_locale:
+      type: str
+      desc: |
+        The local influences separators.
+        Setting it might make work with Excel easier.
+    csv_raw:
+      type: str
+      desc: |
+        Raw data file. TODO: what was this again? probable needs to be removed.
+    codespeed:
+      type: map
+      desc: Send results to Codespeed for continuous performance tracking.
+      mapping:
+        project:
+          type: str
+          desc: The Codespeed project corresponding to the results.
+        url:
+          type: str
+          desc: |
+            The URL to the /result/add/json/ rest endpoint for submitting
+            results (the full URL).
+
+schema;statistics_type:
+  type: map
+  desc: |
+    Configuration for statistical reporting.
+    TODO: also abort condition? if so, needs to be removed
+  mapping:
+    min_runs:
+      type: int
+      desc: "Minimum number of runs? TODO: remove? 'run' outdated terminology?"
+    max_runs:
+      type: int
+      desc: "Maximum number of runs? TODO: remove? 'run' outdated terminology?"
+    max_time:
+      type: int
+      desc: "Time in second after which an invocation is terminated. TODO: remove?"
+    confidence_level:
+      type: float
+      desc: |
+        The desired confidence interval.
+        TODO: remove, it's measuring until goal reached, which is problematic.
+    error_margin:
+      type: float
+      desc: |
+        Desired error margin.
+        TODO: remove, not proper definition of experiment.
+        Need to define it up front
+    stop_criterium:
+      type: str
+      enum:
+        - percentage
+    stop_threshold:
+      type: int
+      desc: "TODO: what was this???"
+
+
+schema;quick_runs_type:
+  type: map
+  desc: Settings for quick runs, useful for fast feedback.
+  mapping:
+    number_of_data_points:
+      type: int
+      desc: |
+        Benchmarks are executed until we have this number of data points
+        TODO: keep consistent with `runs_type`
+    min_runs:
+      type: int
+      desc: "Minimum number of runs? TODO: remove? 'run' outdated terminology?"
+    max_runs:
+      type: int
+      desc: "Maximum number of runs? TODO: remove? 'run' outdated terminology?"
+    max_time:
+      type: int
+      desc: "Time in second after which an invocation is terminated. TODO: remove?"
+
+schema;benchmark_type_str:
+  type: str
+  desc: The name of a benchmark, can be simply the name.
+schema;benchmark_type_map:
+  type: map
+  desc: |
+    The name of a benchmark and additional information.
+  matching-rule: 'any'
+  mapping:
+    regex;(.+):
+      type: map
+      mapping:
+        extra_args:
+          type: scalar
+          desc: This extra argument is appended to the benchmark's command line.
+        warmup:
+          type: int
+          desc: |
+            Consider the first N iterations as warmup.
+            This is used by reporters, for instance to discard these
+            N measurements before calculating statistics.
+        command:
+          type: str
+          desc: use this command instead of the name for the command line.
+        codespeed_name:
+          type: str
+          desc: |
+            A name used for this benchmark when sending data to Codespeed.
+            This is useful to have a name different from the one relevant
+            at the suite level.
+
+schema;benchmark_suite_type:
+  type: map
+  mapping:
+    gauge_adapter:
+      type: str
+      desc: |
+        Name of the parser that interpreters the output of the benchmark harness
+    command:
+      type: str
+      desc: |
+        The command for the benchmark harness. It's going to be combined with the
+        VM's command line. It supports various format variables, including:
+         - benchmark (the benchmark's name)
+         - input (the input variable's value)
+         - variable (another variable's value)
+         - cores (the number of cores to be used by the benchmark)
+    location:
+      type: str
+      desc: |
+        The path to the benchmark harness. Execution use this location as
+        working directory. It overrides the location/path of a VM.
+    build:
+      desc: TODO make more precise
+      type: str
+    input_sizes:
+      type: seq
+      desc: |
+        Many benchmark harnesses and benchmarks take an input size as a
+        configuration parameter. It might identify a data file, or some other
+        way to adjust the amount of computation performed.
+      sequence:
+        - type: scalar
+    cores:
+      type: seq
+      desc: The cores to be used by the benchmark.
+      sequence:
+        - type: scalar
+    benchmarks:
+      type: seq
+      matching: any
+      sequence:
+        - include: benchmark_type_str
+        - include: benchmark_type_map
+    max_runtime:
+      type: int
+      desc: "max runtime in seconds. TODO: all time values should use the same unit"
+    variable_values:
+      type: seq
+      desc: Another dimension by which the benchmark execution can be varied.
+      sequence:
+        - type: scalar
+    description:
+      type: str
+      desc: A description of the benchmark.
+    desc:
+      type: str
+      desc: A description of the benchmark.
+
+schema;vm_type:
+  type: map
+  mapping:
+    path:
+      type: str
+      required: no
+      desc: |
+        Path to the binary.
+        If not given, it's up to the shell to find the binary
+    binary:
+      type: str
+      required: yes
+      desc: the name of the binary to be used
+    args:
+      type: str
+      desc: |
+        The arguments when assembling the command line.
+        TODO: do we support format string parameters here?
+              if so, which?
+    cores:
+      type: seq
+      sequence:
+        - type: scalar
+    desc:
+      type: str
+    description:
+      type: str
+    build:
+      desc: TODO make more precise
+      type: str
+    execute_exclusively:
+      type: bool
+      desc: |
+        TODO: probably needs to be removed, not sure. parallel exec of
+        benchmarks introduced a lot of noise
+
+schema;experiment_type:
+  description:
+    type: str
+    desc: Description of the experiment
+  desc:
+    type: str
+    desc: Description of the experiment
+  actions:
+    type: str
+    enum: [benchmark]
+    desc: |
+      Different possible actions.
+      TODO: this should probably be removed.
+      Don't think this was ever really used.
+  benchmark:
+    type: str
+    desc: Benchmark Suite to be used
+  executions:
+    type: seq
+    desc: The VMs used for execution
+    sequence:
+      - str
+
+
+type: map
+mapping:
+  standard_experiment:
+    type:     str
+    required: no
+    default:  all
+  standard_data_file:
+    type:     str
+    required: no
+  runs:
+    include: runs_type
+  reporting:
+    include: reporting_type
+  quick_runs:
+    include: quick_runs_type
+  statistics:
+    include: statistics_type
+  benchmark_suites:
+    type: map
+    mapping:
+      regex;(.+):
+        include: benchmark_suite_type
+  virtual_machines:
+    type: map
+    mapping:
+      regex;(.+):
+        include: vm_type
+  experiments:
+    type: map
+    mapping:
+      regex;(.+):
+        include: experiment_type
+
+  ## Random Elements:
+  ## TODO: find a nice way to accomodate such use cases
+  are_we_fast_yet:
+    type: any

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -289,6 +289,9 @@ schema;experiment_type:
 
 type: map
 mapping:
+  regex;(\..+):
+    type: any
+    desc: dot properties, for example `.test` are going to be ignored
   standard_experiment:
     type:     str
     default:  all
@@ -319,8 +322,3 @@ mapping:
     mapping:
       regex;(.+):
         include: experiment_type
-
-  ## Random Elements:
-  ## TODO: find a nice way to accomodate such use cases
-  are_we_fast_yet:
-    type: any

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -3,7 +3,7 @@ desc: Specifies the elements of the YAML-based configuration format.
 
 schema;runs_type:
   type: map
-  mapping:
+  mapping: &EXP_RUN_DETAILS
     number_of_data_points:
       type: int
       desc: Benchmarks are executed until we have this number of data points
@@ -50,6 +50,7 @@ schema;statistics_type:
   desc: |
     Configuration for statistical reporting.
     TODO: also abort condition? if so, needs to be removed
+    TODO: unify with runs_type? or remove overlap!
   mapping:
     min_runs:
       type: int
@@ -130,9 +131,36 @@ schema;benchmark_type_map:
             This is useful to have a name different from the one relevant
             at the suite level.
 
+schema;variables:
+  desc: |
+    defining variables for an experiment. not, this is not a type used by the
+    schema. instead, we use YAML to reuse this definition
+  type: map
+  mapping: &EXP_VARIABLES
+    input_sizes:
+      type: seq
+      desc: |
+        Many benchmark harnesses and benchmarks take an input size as a
+        configuration parameter. It might identify a data file, or some other
+        way to adjust the amount of computation performed.
+      sequence:
+        - type: scalar
+    cores:
+      type: seq
+      desc: The cores to be used by the benchmark.
+      sequence:
+        - type: scalar
+    variable_values:
+      type: seq
+      desc: Another dimension by which the benchmark execution can be varied.
+      sequence:
+        - type: scalar
+
+
 schema;benchmark_suite_type:
   type: map
   mapping:
+    <<: *EXP_VARIABLES
     gauge_adapter:
       type: str
       desc: |
@@ -154,19 +182,6 @@ schema;benchmark_suite_type:
     build:
       desc: TODO make more precise
       type: str
-    input_sizes:
-      type: seq
-      desc: |
-        Many benchmark harnesses and benchmarks take an input size as a
-        configuration parameter. It might identify a data file, or some other
-        way to adjust the amount of computation performed.
-      sequence:
-        - type: scalar
-    cores:
-      type: seq
-      desc: The cores to be used by the benchmark.
-      sequence:
-        - type: scalar
     benchmarks:
       type: seq
       matching: any
@@ -176,11 +191,6 @@ schema;benchmark_suite_type:
     max_runtime:
       type: int
       desc: "max runtime in seconds. TODO: all time values should use the same unit"
-    variable_values:
-      type: seq
-      desc: Another dimension by which the benchmark execution can be varied.
-      sequence:
-        - type: scalar
     description:
       type: str
       desc: A description of the benchmark.
@@ -191,6 +201,7 @@ schema;benchmark_suite_type:
 schema;vm_type:
   type: map
   mapping:
+    <<: *EXP_VARIABLES
     path:
       type: str
       required: no
@@ -207,10 +218,6 @@ schema;vm_type:
         The arguments when assembling the command line.
         TODO: do we support format string parameters here?
               if so, which?
-    cores:
-      type: seq
-      sequence:
-        - type: scalar
     desc:
       type: str
     description:
@@ -224,39 +231,71 @@ schema;vm_type:
         TODO: probably needs to be removed, not sure. parallel exec of
         benchmarks introduced a lot of noise
 
-schema;experiment_type:
-  description:
-    type: str
-    desc: Description of the experiment
-  desc:
-    type: str
-    desc: Description of the experiment
-  actions:
-    type: str
-    enum: [benchmark]
-    desc: |
-      Different possible actions.
-      TODO: this should probably be removed.
-      Don't think this was ever really used.
-  benchmark:
-    type: str
-    desc: Benchmark Suite to be used
-  executions:
-    type: seq
-    desc: The VMs used for execution
-    sequence:
-      - str
+schema;exp_suite_type:
+  desc: A list of suites
+  type: seq
+  sequence:
+    - type: str
 
+schema;exp_exec_type:
+  desc: A VM and a set of benchmarks
+  type: map
+  mapping:
+    regex;(.+):
+      type: map
+      mapping:
+        <<: *EXP_VARIABLES
+        benchmark:
+          include: exp_suite_type
+
+schema;experiment_type:
+  desc: Defined an experiment for a specific VM
+  type: map
+  mapping:
+    <<: *EXP_RUN_DETAILS
+    <<: *EXP_VARIABLES
+    description:
+      type: str
+      desc: Description of the experiment
+    desc:
+      type: str
+      desc: Description of the experiment
+    actions:
+      type: str
+      enum: [benchmark, profile]
+      desc: |
+        Different possible actions.
+        TODO: this should probably be removed.
+        Don't think this was ever really used.
+    benchmark:
+      desc: |
+        Benchmark Suite to be used
+        TODO: should this be renamed into suites
+      include: exp_suite_type
+    data_file:
+      desc: The data for this experiment goes into a separate file
+      type: str
+    executions:
+      type: seq
+      desc: |
+        The VMs used for execution, possibly with specific suites assigned
+      sequence:
+        - type: str
+        - include: exp_exec_type
+    statistics:
+      include: statistics_type
+    reporting:
+      include: reporting_type
 
 type: map
 mapping:
   standard_experiment:
     type:     str
-    required: no
     default:  all
   standard_data_file:
     type:     str
-    required: no
+  build_log:
+    type:     str
   runs:
     include: runs_type
   reporting:

--- a/rebench/tests/bugs/issue_27.conf
+++ b/rebench/tests/bugs/issue_27.conf
@@ -7,7 +7,8 @@ benchmark_suites:
     Suite:
         gauge_adapter: RebenchLog
         command: TestBenchMarks %(benchmark)s %(warmup)s
-        benchmarks: Bench1
+        benchmarks:
+          - Bench1
 
 virtual_machines:
     TestRunner1:
@@ -16,5 +17,7 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
-        executions: TestRunner1
+        benchmark:
+          - Suite
+        executions:
+          - TestRunner1

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -107,9 +107,11 @@ class ConfiguratorTest(ReBenchTestCase):
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
 
+
 # allow command-line execution 
 def test_suite():
     return unittest.makeSuite(ConfiguratorTest)
+
 
 if __name__ == "__main__":
     unittest.main(defaultTest='test_suite')

--- a/rebench/tests/features/issue_15.conf
+++ b/rebench/tests/features/issue_15.conf
@@ -8,7 +8,7 @@ benchmark_suites:
         gauge_adapter: TestVM
         command: TestBenchMarks %(benchmark)s %(warmup)s
         benchmarks:
-            Bench1:
+            - Bench1:
                 warmup: 13
 
 virtual_machines:
@@ -18,5 +18,7 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
-        executions: TestRunner1
+        benchmark:
+         - Suite
+        executions:
+         - TestRunner1

--- a/rebench/tests/features/issue_16.conf
+++ b/rebench/tests/features/issue_16.conf
@@ -7,7 +7,8 @@ benchmark_suites:
     Suite:
         gauge_adapter: TestVM
         command: TestBenchMarks %(benchmark)s %(input)s
-        benchmarks: Bench1
+        benchmarks:
+          - Bench1
 
 virtual_machines:
     TestRunner:
@@ -16,12 +17,16 @@ virtual_machines:
 
 experiments:
     Test1:
-        benchmark: Suite
+        benchmark:
+            - Suite
         executions:
             - TestRunner:
-                input_sizes: 10
+                input_sizes:
+                  - 10
     Test2:
-        benchmark: Suite
+        benchmark:
+            - Suite
         executions:
             - TestRunner:
-                input_sizes: 20
+                input_sizes:
+                  - 20

--- a/rebench/tests/features/issue_19.conf
+++ b/rebench/tests/features/issue_19.conf
@@ -20,5 +20,7 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
-        executions: TestRunner
+        benchmark:
+          - Suite
+        executions:
+          - TestRunner

--- a/rebench/tests/features/issue_31.conf
+++ b/rebench/tests/features/issue_31.conf
@@ -7,7 +7,8 @@ benchmark_suites:
     Suite:
         gauge_adapter: Multivariate
         command: TestBenchMarks %(benchmark)s %(input)s
-        benchmarks: Bench1
+        benchmarks:
+          - Bench1
 
 virtual_machines:
     TestRunner:
@@ -19,17 +20,23 @@ virtual_machines:
 
 experiments:
     Test1:
-        benchmark: Suite
+        benchmark:
+            - Suite
         executions:
             - TestRunner:
-                input_sizes: 10
+                input_sizes:
+                  - 10
     Test2:
-        benchmark: Suite
+        benchmark:
+            - Suite
         executions:
             - TestRunner:
-                input_sizes: 20
+                input_sizes:
+                  - 20
     Test3:
-        benchmark: Suite
+        benchmark:
+            - Suite
         executions:
             - TestRunnerCompat:
-                input_sizes: 10
+                input_sizes:
+                  - 10

--- a/rebench/tests/features/issue_34.conf
+++ b/rebench/tests/features/issue_34.conf
@@ -20,5 +20,7 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
-        executions: TestRunner
+        benchmark:
+          - Suite
+        executions:
+          - TestRunner

--- a/rebench/tests/features/issue_40.conf
+++ b/rebench/tests/features/issue_40.conf
@@ -35,5 +35,7 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
-        executions: TestRunner
+        benchmark:
+          - Suite
+        executions:
+          - TestRunner

--- a/rebench/tests/features/issue_57.conf
+++ b/rebench/tests/features/issue_57.conf
@@ -8,7 +8,7 @@ benchmark_suites:
         gauge_adapter: Time
         command: " "
         benchmarks:
-            Bench1
+          - Bench1
 
 virtual_machines:
     Bash:
@@ -17,5 +17,7 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
-        executions: Bash
+        benchmark:
+          - Suite
+        executions:
+          - Bash

--- a/rebench/tests/features/issue_58.conf
+++ b/rebench/tests/features/issue_58.conf
@@ -20,18 +20,18 @@ virtual_machines:
     BashB:
         binary: ./vm_58b.sh
         args: foo bar 2
-        build:
-          - echo "#!/bin/bash" >  vm_58b.sh
-          - echo "echo \$@"    >> vm_58b.sh
-          - echo error 1>&2
-          - echo standard
-          - chmod +x vm_58b.sh
+        build: |
+          echo "#!/bin/bash" >  vm_58b.sh
+          echo "echo \$@"    >> vm_58b.sh
+          echo error 1>&2
+          echo standard
+          chmod +x vm_58b.sh
     BashC:
         binary: ./vm_58a.sh
         args: foo bar 3
-        build:
-           - ./issue_58_buildvm_a.sh
-           - exit 1
+        build: |
+           ./issue_58_buildvm_a.sh
+           exit 1
 
 experiments:
     Test:

--- a/rebench/tests/features/issue_58.conf
+++ b/rebench/tests/features/issue_58.conf
@@ -10,7 +10,7 @@ benchmark_suites:
         gauge_adapter: Time
         command: " "
         benchmarks:
-            Bench1
+          - Bench1
 
 virtual_machines:
     BashA:
@@ -35,16 +35,23 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
+        benchmark:
+          - Suite
         executions:
           - BashA
           - BashB
     A:
-        benchmark: Suite
-        executions: BashA
+        benchmark:
+          - Suite
+        executions:
+          - BashA
     B:
-        benchmark: Suite
-        executions: BashB
+        benchmark:
+          - Suite
+        executions:
+          - BashB
     C:
-        benchmark: Suite
-        executions: BashC
+        benchmark:
+          - Suite
+        executions:
+          - BashC

--- a/rebench/tests/small.conf
+++ b/rebench/tests/small.conf
@@ -19,7 +19,8 @@ benchmark_suites:
         gauge_adapter: TestVM
         command: TestBenchMarks %(benchmark)s %(input)s %(variable)s
         input_sizes: [2, 10]
-        variable_values: val1
+        variable_values:
+            - val1
         benchmarks:
             - Bench1
             - Bench2
@@ -35,7 +36,8 @@ virtual_machines:
 
 experiments:
     Test:
-        benchmark: Suite
+        benchmark:
+            - Suite
         executions:
             - TestRunner1
             - TestRunner2

--- a/rebench/tests/test.conf
+++ b/rebench/tests/test.conf
@@ -71,11 +71,6 @@ benchmark_suites:
         input_sizes: [1]
         cores: [1]
         benchmarks: [Bench1]
-    TestWarningForRemovedUlimitUsageSuite:
-        gauge_adapter: TestVM
-        command: TestBenchMarks
-        benchmarks: [Bench1]
-        ulimit: 1
 
 # VMs have a name and are specified by a path and the binary to be executed
 # optional: the number of cores for which the runs have to be executed

--- a/rebench/tests/test.conf
+++ b/rebench/tests/test.conf
@@ -120,10 +120,12 @@ experiments:
             #the following example is equivalent to the global run definition,
             #but needs to be tested...
             - TestRunner1:
-                benchmark: TestSuite1
+                benchmark:
+                  - TestSuite1
                 cores: [42]
             - TestRunner1:
-                benchmark: TestSuite2
+                benchmark:
+                  - TestSuite2
             - TestRunner2
         # visualization:
         #     fileName:   test_%s_%s.png       # fileName needs placeholders for the dimensions specified by separateBy
@@ -137,18 +139,27 @@ experiments:
         #     labelYAxis: ''
     Test-variable-values:
         description: to test for a bug
-        benchmark:  TestSuite2
-        executions: TestRunner2
+        benchmark:
+           - TestSuite2
+        executions:
+           - TestRunner2
     TestBrokenCommandFormat:
         description: to test for a proper error when conversions are not properly indicated in the config
-        benchmark:  TestBrokenCommandFormatSuite
-        executions: TestRunner2
+        benchmark:
+           - TestBrokenCommandFormatSuite
+        executions:
+           - TestRunner2
     TestBrokenCommandFormat2:
         description: to test for a proper error when conversions are not properly indicated in the config
-        benchmark:  TestBrokenCommandFormatSuite2
-        executions: TestRunner2
+        benchmark:
+           - TestBrokenCommandFormatSuite2
+        executions:
+           - TestRunner2
     TestWarningForRemovedUlimitUsage:
         description: make sure the usage of ulimit in a configuration triggers a warning
-        benchmark:   TestWarningForRemovedUlimitUsageSuite
-        executions:  TestRunner2
-        input_sizes: 1
+        benchmark:
+           - TestWarningForRemovedUlimitUsageSuite
+        executions:
+           - TestRunner2
+        input_sizes:
+           - 1

--- a/rebench/tests/test.conf
+++ b/rebench/tests/test.conf
@@ -122,16 +122,6 @@ experiments:
                 benchmark:
                   - TestSuite2
             - TestRunner2
-        # visualization:
-        #     fileName:   test_%s_%s.png       # fileName needs placeholders for the dimensions specified by separateBy
-        #     separateBy: [cores, input_sizes] # generates different diagrams per 'cores' value
-        #     groupBy: variable_values
-        #     sortBy: {stats : median}  # median is used for sorting, since the mean would emphasize outliers much more
-        #     criterion: total # use only the total criterion for the diagrams
-        #     columnName: '{0} on {1}' # is determined from the remaining characteristics with are indexable
-        #     title: 'Test Plot: Just Testing'
-        #     labelXAxis: ''
-        #     labelYAxis: ''
     Test-variable-values:
         description: to test for a bug
         benchmark:
@@ -150,11 +140,3 @@ experiments:
            - TestBrokenCommandFormatSuite2
         executions:
            - TestRunner2
-    TestWarningForRemovedUlimitUsage:
-        description: make sure the usage of ulimit in a configuration triggers a warning
-        benchmark:
-           - TestWarningForRemovedUlimitUsageSuite
-        executions:
-           - TestRunner2
-        input_sizes:
-           - 1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(name='ReBench',
       url='https://github.com/smarr/ReBench',
       packages=find_packages(exclude=['*.tests']),
       install_requires=[
-          'PyYAML>=3.08'
+          'PyYAML>=3.12',
+          'pykwalify>=1.6.1'
       ],
       entry_points = {
           'console_scripts' : ['rebench = rebench:main_func']


### PR DESCRIPTION
As part of approaching #6 (warning about unused stuff in config files) as well as in support of #66 (improving documentation), this PR adds a schema that can be used to validate ReBench's configuration files.

Currently, it includes a number of todos for cleanup, clarification, etc. So, pretty much work in progress. The `experiments` definition is also not yet at a point where it covers all relevant use cases.

Overall it is a little stricter, but is able to validate all test files I found with only minor changes (for instance renaming of old stuff), or avoiding using scalars where lists are expected (it's a little sad that this simplification might not be possible in some cases though).