### PR TITLE
Improve Codespeed submission error and make release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## [Unreleased]
 
+ - 
+
+## [0.10.0] - 2018-06-08
+
+ - Restructure command-line options in help, and use argparse (#73)
  - Add support for Python 3 and PyPy (#65)
+ - Add support for extra criteria (things beside run time) (#64)
+ - Add support for path names in ReBenchLog benchmark names
 
 ## [0.9.1] - 2017-12-21
 
@@ -49,8 +56,9 @@
  - [0.6.0] - 2014-05-19
  - [0.5.0] - 2014-03-25
 
-[Unreleased]: https://github.com/smarr/ReBench/compare/v0.9.1...HEAD
-[0.9.0]: https://github.com/smarr/ReBench/compare/v0.9.0...v0.9.1
+[Unreleased]: https://github.com/smarr/ReBench/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/smarr/ReBench/compare/v0.9.1...v0.10.0
+[0.9.1]: https://github.com/smarr/ReBench/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/smarr/ReBench/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/smarr/ReBench/compare/v0.7.5...v0.8.0
 [0.7.5]: https://github.com/smarr/ReBench/compare/v0.7.4...v0.7.5

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -42,7 +42,7 @@ from .configuration_error import ConfigurationError
 class ReBench:
     
     def __init__(self):
-        self.version = "0.9.1"
+        self.version = "0.10.0"
         self.options = None
         self._config = None
     

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -397,7 +397,7 @@ class CodespeedReporter(Reporter):
         fh = urlopen(self._cfg.url, payload)
         response = fh.read()
         fh.close()
-        logging.info("Results were sent to codespeed, response was: "
+        logging.info("Results were sent to Codespeed, response was: "
                      + response)
 
     def _send_to_codespeed(self, results):
@@ -406,17 +406,24 @@ class CodespeedReporter(Reporter):
         try:
             self._send_payload(payload)
         except (IOError, HTTPException):
-            # sometimes codespeed fails to accept a request because something
+            # sometimes Codespeed fails to accept a request because something
             # is not yet properly initialized, let's try again for those cases
             try:
                 self._send_payload(payload)
             except (IOError, HTTPException) as error:
                 logging.error(str(error) + " This is most likely caused by "
                               "either a wrong URL in the config file, or an "
-                              "environment not configured in codespeed. URL: "
+                              "environment not configured in Codespeed. URL: "
                               + self._cfg.url)
+                envs = set([i['environment'] for i in payload])
+                projects = set([i['project'] for i in payload])
+                benchmarks = set([i['benchmark'] for i in payload])
+                executables = set([i['executable'] for i in payload])
+                logging.error("Sent data included environments: %s "
+                              "projects: %s benchmarks: %s executables: %s"
+                              % (envs, projects, benchmarks, executables))
 
-        logging.info("Sent %d results to codespeed." % len(results))
+        logging.info("Sent %d results to Codespeed." % len(results))
 
     def _prepare_result(self, run_id):
         stats = StatisticProperties(run_id.get_total_values())


### PR DESCRIPTION
Include additional information in error message when data submission to Codespeed failed.
Also bump version info for an intermediate release on the way to v1.0.