### PR TITLE
[Issue 59] Add build support for suites and ensure one-time execution 

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -193,6 +193,10 @@ class Configurator:
     @property
     def use_nice(self):
         return self.options is not None and self.options.use_nice
+
+    @property
+    def do_builds(self):
+        return self.options is not None and self.options.do_builds
         
     def experiment_name(self):
         return self._exp_name or self._raw_config['standard_experiment']

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -107,6 +107,7 @@ class Configurator:
         self.quick_runs  = QuickRunsConfig(**self._raw_config.get('quick_runs', {}))
 
         self._data_store = data_store
+        self._build_commands = dict()
         self._experiments = self._compile_experiments(cli_reporter,
                                                       _RunFilter(run_filter))
 
@@ -235,14 +236,16 @@ class Configurator:
 
     def _compile_experiment(self, exp_name, cli_reporter, run_filter):
         exp_def = self._raw_config['experiments'][exp_name]
-        run_cfg = (self.quick_runs if (self.options and self.options.quick)
-                                   else self.runs)
+        run_cfg = (self.quick_runs
+                   if (self.options and self.options.quick)
+                   else self.runs)
         
         return Experiment(exp_name, exp_def, run_cfg,
                           self._raw_config['virtual_machines'],
                           self._raw_config['benchmark_suites'],
                           self._raw_config.get('reporting', {}),
                           self._data_store,
+                          self._build_commands,
                           self._raw_config.get('standard_data_file', None),
                           self._options.clean if self._options else False,
                           cli_reporter,

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -212,10 +212,11 @@ class ParallelScheduler(RunScheduler):
 
 class Executor:
     
-    def __init__(self, runs, use_nice, include_faulty = False, verbose = False,
-                 scheduler = BatchScheduler, build_log = None):
+    def __init__(self, runs, use_nice, do_builds, include_faulty = False,
+                 verbose = False, scheduler = BatchScheduler, build_log = None):
         self._runs     = runs
         self._use_nice = use_nice
+        self._do_builds = do_builds
         self._include_faulty = include_faulty
         self._verbose   = verbose
         self._scheduler = self._create_scheduler(scheduler)
@@ -339,7 +340,7 @@ class Executor:
         cmdline = self._construct_cmdline(run_id, gauge_adapter)
         
         terminate = self._check_termination_condition(run_id, termination_check)
-        if not terminate:
+        if not terminate and self._do_builds:
             self._build_vm_and_suite(run_id)
 
         stats = StatisticProperties(run_id.get_total_values())

--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -19,10 +19,12 @@
 # IN THE SOFTWARE.
 import logging
 
+from .build_cmd import BuildCommand
+
 
 class BenchmarkSuite(object):
 
-    def __init__(self, suite_name, vm, global_suite_cfg):
+    def __init__(self, suite_name, vm, global_suite_cfg, build_commands):
         """Specialize the benchmark suite for the given VM"""
         
         self._name = suite_name
@@ -46,6 +48,15 @@ class BenchmarkSuite(object):
         self._command            = global_suite_cfg['command']
         self._max_runtime        = global_suite_cfg.get('max_runtime', -1)
 
+        build = global_suite_cfg.get('build', None)
+        if build:
+            build_command = BuildCommand(build, self._location)
+            if build_command in build_commands:
+                build_command = build_commands[build_command]
+            self._build = build_command
+        else:
+            self._build = None
+
         # TODO: remove in ReBench 1.0
         if 'performance_reader' in global_suite_cfg:
             logging.warning("Found deprecated 'performance_reader' key in"
@@ -64,6 +75,10 @@ class BenchmarkSuite(object):
     @property
     def cores(self):
         return self._cores
+
+    @property
+    def build(self):
+        return self._build
     
     @property
     def variable_values(self):

--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -37,6 +37,7 @@ class BenchmarkSuite(object):
         if self._input_sizes is None:
             self._input_sizes = [None]
         
+        # TODO: should the _location be made absolute as the vm._path??
         self._location        = global_suite_cfg.get('location', vm.path)
         self._cores           = global_suite_cfg.get('cores',    vm.cores)
         self._variable_values = global_suite_cfg.get('variable_values', [None])

--- a/rebench/model/build_cmd.py
+++ b/rebench/model/build_cmd.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2018 Stefan Marr <http://www.stefan-marr.de/>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+
+class BuildCommand(object):
+    def __init__(self, cmd, location):
+        self._cmd = cmd
+        self._location = location
+        self._built = False
+        self._build_failed = False
+
+    @property
+    def command(self):
+        return self._cmd
+
+    @property
+    def location(self):
+        return self._location
+
+    @property
+    def is_built(self):
+        return self._built
+
+    @property
+    def is_failed_build(self):
+        return self._build_failed
+
+    def mark_succeeded(self):
+        self._built = True
+
+    def mark_failed(self):
+        self._build_failed = True
+
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__) and
+                self._cmd == other._cmd and
+                self._location == other._location)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self._cmd, self._location))

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -180,7 +180,11 @@ schema;benchmark_suite_type:
         The path to the benchmark harness. Execution use this location as
         working directory. It overrides the location/path of a VM.
     build:
-      desc: TODO make more precise
+      desc: |
+        The given string is executed by the system's shell and can be used to
+        build a benchmark suite. It is executed once before any benchmarks are
+        executed. If `location` is set, it is used as working directory.
+        Otherwise, it is the current working directory of ReBench.
       type: str
     benchmarks:
       type: seq
@@ -223,7 +227,11 @@ schema;vm_type:
     description:
       type: str
     build:
-      desc: TODO make more precise
+      desc: |
+        The given string is executed by the system's shell and can be used to
+        build a VM. It is executed once before any benchmarks are executed with
+        the VM. If `path` is set, it is used as working directory. Otherwise,
+        it is the current working directory of ReBench.
       type: str
     execute_exclusively:
       type: bool

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -91,6 +91,10 @@ Argument:
             help='Used for debugging and environments without the tool nice.',
             default=True)
         execution.add_argument(
+            '-B', '--without-building', action='store_false', dest='do_builds',
+            help='Disables execution of build commands for VMs and suites.',
+            default=True)
+        execution.add_argument(
             '-s', '--scheduler', action='store', dest='scheduler',
             default='batch',
             help='execution order of benchmarks: '
@@ -197,7 +201,7 @@ Argument:
         if self._config.options.do_rerun:
             DataStore.discard_data_of_runs(runs)
 
-        executor = Executor(runs, self._config.use_nice,
+        executor = Executor(runs, self._config.use_nice, self._config.do_builds,
                             self._config.options.include_faulty,
                             self._config.options.verbose,
                             scheduler_class,

--- a/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
+++ b/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
@@ -36,7 +36,7 @@ class Issue27InvalidRunNotHandled(ReBenchTestCase):
         runs = list(cnf.get_runs())
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
 
-        ex = Executor([runs[0]], False)
+        ex = Executor([runs[0]], False, False)
         ex.execute()
 
         self.assertEqual(runs[0].get_number_of_data_points(), 0)

--- a/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
+++ b/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
@@ -33,10 +33,10 @@ class Issue4RunEquality(unittest.TestCase):
     def _create_template_run_id(self):
         vm        = VirtualMachine("MyVM", None, {'path':   'foo_bar_path',
                                                   'binary': 'foo_bar_bin'},
-                                   None, [1], None)
+                                   None, [1], None, None)
         suite     = BenchmarkSuite("MySuite", vm, {
             'benchmarks': [], 'gauge_adapter': '',
-            'command': '%(benchmark)s %(cores)s %(input)s'})
+            'command': '%(benchmark)s %(cores)s %(input)s'}, None)
         bench_cfg = BenchmarkConfig("TestBench", "TestBench", None, suite, vm,
                                     '3', 0, None, DataStore())
         return RunId(bench_cfg, 1, 2, None)
@@ -44,10 +44,10 @@ class Issue4RunEquality(unittest.TestCase):
     def _create_hardcoded_run_id(self):
         vm        = VirtualMachine("MyVM", None, {'path':   'foo_bar_path',
                                                   'binary': 'foo_bar_bin'},
-                                   None, [1], None)
+                                   None, [1], None, None)
         suite     = BenchmarkSuite("MySuite", vm, {
             'benchmarks': [], 'gauge_adapter': '',
-            'command': '%(benchmark)s %(cores)s 2 3'})
+            'command': '%(benchmark)s %(cores)s 2 3'}, None)
         bench_cfg = BenchmarkConfig("TestBench", "TestBench", None, suite, vm,
                                     None, 0, None, DataStore())
         return RunId(bench_cfg, 1, None, None)

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -44,7 +44,7 @@ class ExecutorTest(ReBenchTestCase):
         cnf  = Configurator(self._path + '/test.conf', DataStore(), options,
                             None, 'Test', standard_data_file = self._tmp_file)
         
-        ex = Executor(cnf.get_runs(), cnf.use_nice)
+        ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
         ex.execute()
         
 ### should test more details
@@ -71,7 +71,7 @@ class ExecutorTest(ReBenchTestCase):
             cnf = Configurator(self._path + '/test.conf', DataStore(), options,
                                None, 'TestBrokenCommandFormat',
                                standard_data_file=self._tmp_file)
-            ex = Executor(cnf.get_runs(), cnf.use_nice)
+            ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
             ex.execute()
         except RuntimeError as e:
             self.assertEqual("TEST-PASSED", str(e))
@@ -89,7 +89,7 @@ class ExecutorTest(ReBenchTestCase):
             cnf = Configurator(self._path + '/test.conf', DataStore(), options,
                                None, 'TestBrokenCommandFormat2',
                                standard_data_file=self._tmp_file)
-            ex = Executor(cnf.get_runs(), cnf.use_nice)
+            ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
             ex.execute()
         except RuntimeError as e:
             self.assertEqual("TEST-PASSED", str(e))
@@ -99,7 +99,7 @@ class ExecutorTest(ReBenchTestCase):
     def _basic_execution(self, cnf):
         runs = cnf.get_runs()
         self.assertEqual(8, len(runs))
-        ex = Executor(cnf.get_runs(), cnf.use_nice)
+        ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
         ex.execute()
         for run in runs:
             data_points = run.get_data_points()

--- a/rebench/tests/features/issue_15_warm_up_support_test.py
+++ b/rebench/tests/features/issue_15_warm_up_support_test.py
@@ -51,7 +51,7 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
         self.assertEqual(runs[0].warmup_iterations, 13)
 
-        ex = Executor([runs[0]], False)
+        ex = Executor([runs[0]], False, False)
         ex.execute()
 
         self.assertEqual(runs[0].get_number_of_data_points(),

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -37,7 +37,7 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
         cnf = Configurator(self._path + '/issue_16.conf', DataStore(),
                            exp_name=exp_name,
                            standard_data_file=self._tmp_file)
-        ex = Executor(cnf.get_runs(), False)
+        ex = Executor(cnf.get_runs(), False, False)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_19_one_data_point_test.py
+++ b/rebench/tests/features/issue_19_one_data_point_test.py
@@ -83,7 +83,8 @@ class OneMeasurementAtATime(Issue19OneDataPointAtATime):
         for run in cnf.get_runs():
             run.add_reporter(reporter)
 
-        ex = Executor(cnf.get_runs(), False, False, False, RoundRobinScheduler)
+        ex = Executor(cnf.get_runs(), False, False, False, False,
+                      RoundRobinScheduler)
         ex.execute()
 
         for run in cnf.get_runs():

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -37,7 +37,7 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         cnf = Configurator(self._path + '/issue_31.conf', DataStore(),
                            exp_name=exp_name,
                            standard_data_file=self._tmp_file)
-        ex = Executor(cnf.get_runs(), False)
+        ex = Executor(cnf.get_runs(), False, False)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_34_accept_faulty_runs_test.py
+++ b/rebench/tests/features/issue_34_accept_faulty_runs_test.py
@@ -35,7 +35,7 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False)
+        ex = Executor(runs, False, False, False)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].bench_cfg.name)
@@ -61,7 +61,7 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, True)
+        ex = Executor(runs, False, False, True)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].bench_cfg.name)

--- a/rebench/tests/features/issue_57_binary_on_path_test.py
+++ b/rebench/tests/features/issue_57_binary_on_path_test.py
@@ -36,7 +36,7 @@ class Issue57BinaryOnPath(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False)
+        ex = Executor(runs, False, False, False)
         ex.execute()
 
         self.assertEqual("Bench1", runs[0].bench_cfg.name)

--- a/rebench/tests/features/issue_58.conf
+++ b/rebench/tests/features/issue_58.conf
@@ -17,6 +17,10 @@ virtual_machines:
         binary: ./vm_58a.sh
         args: foo bar 1
         build: ./issue_58_buildvm_a.sh
+    BashAA:
+        binary: ./vm_58a.sh
+        args: foo bar 1
+        build: ./issue_58_buildvm_a.sh
     BashB:
         binary: ./vm_58b.sh
         args: foo bar 2
@@ -45,6 +49,12 @@ experiments:
           - Suite
         executions:
           - BashA
+    AandAA:
+        benchmark:
+          - Suite
+        executions:
+          - BashA
+          - BashAA
     B:
         benchmark:
           - Suite

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -48,7 +48,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -67,7 +67,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -96,7 +96,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -119,7 +119,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, build_log=cnf.build_log)
         ex.execute()
 
         os.remove(self._path + '/vm_58a.sh')

--- a/rebench/tests/features/issue_59.conf
+++ b/rebench/tests/features/issue_59.conf
@@ -1,0 +1,48 @@
+standard_experiment: Test
+standard_data_file: test.data
+
+build_log: build.log
+
+runs:
+    number_of_data_points:  2
+
+benchmark_suites:
+    Suite1:
+        build: ./issue_59_build_suite.sh
+        location: .
+        gauge_adapter: Time
+        command: " "
+        benchmarks:
+          - Bench1
+    Suite2:
+        build: ./issue_59_build_suite.sh
+        location: .
+        gauge_adapter: Time
+        command: " "
+        benchmarks:
+          - Bench1
+
+virtual_machines:
+    BashA:
+        binary: cat issue_59_cnt
+    BashB:
+        binary: cat issue_59_cnt
+
+experiments:
+    Test:
+        benchmark:
+          - Suite1
+          - Suite2
+        executions:
+          - BashA
+          - BashB
+    A:
+        benchmark:
+          - Suite1
+        executions:
+          - BashA
+    B:
+        benchmark:
+          - Suite1
+        executions:
+          - BashB

--- a/rebench/tests/features/issue_59_build_suite.sh
+++ b/rebench/tests/features/issue_59_build_suite.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+touch issue_59_cnt
+echo `cat issue_59_cnt`
+
+echo I >> issue_59_cnt

--- a/rebench/tests/features/issue_59_build_suite_test.py
+++ b/rebench/tests/features/issue_59_build_suite_test.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2018 Stefan Marr <http://www.stefan-marr.de/>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+from __future__ import print_function
+
+from ...configurator     import Configurator
+from ...executor         import Executor
+from ...persistence      import DataStore
+from ..rebench_test_case import ReBenchTestCase
+
+import os
+
+
+class Issue59BuildSuite(ReBenchTestCase):
+
+    def setUp(self):
+        super(Issue59BuildSuite, self).setUp(__file__)
+
+    def test_build_suite1(self):
+        cnf = Configurator(self._path + '/issue_59.conf', DataStore(),
+                           standard_data_file = self._tmp_file,
+                           exp_name='A')
+        runs = list(cnf.get_runs())
+        runs = sorted(runs, key=lambda e: e.bench_cfg.name)
+
+        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex.execute()
+
+        try:
+            self.assertEqual("Bench1", runs[0].bench_cfg.name)
+            self.assertEqual(2, runs[0].get_number_of_data_points())
+            self.assertTrue(os.path.isfile(self._path + '/issue_59_cnt'))
+        finally:
+            os.remove(self._path + '/issue_59_cnt')
+
+    def test_build_suite_same_command_executed_once_only(self):
+        cnf = Configurator(self._path + '/issue_59.conf', DataStore(),
+                           standard_data_file = self._tmp_file,
+                           exp_name='Test')
+        runs = list(cnf.get_runs())
+        runs = sorted(runs, key=lambda e: e.bench_cfg.name)
+
+        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex.execute()
+
+        try:
+            self.assertEqual("Bench1", runs[0].bench_cfg.name)
+            self.assertEqual(2, runs[0].get_number_of_data_points())
+            self.assertTrue(os.path.isfile(self._path + '/issue_59_cnt'))
+            with open(self._path + '/issue_59_cnt', 'r') as f:
+                content = f.read()
+            self.assertEqual("I\n", content)
+        finally:
+            os.remove(self._path + '/issue_59_cnt')

--- a/rebench/tests/features/issue_59_build_suite_test.py
+++ b/rebench/tests/features/issue_59_build_suite_test.py
@@ -39,7 +39,7 @@ class Issue59BuildSuite(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -56,7 +56,7 @@ class Issue59BuildSuite(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.bench_cfg.name)
 
-        ex = Executor(runs, False, False, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, build_log=cnf.build_log)
         ex.execute()
 
         try:

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -39,10 +39,10 @@ class PersistencyTest(ReBenchTestCase):
     def test_de_serialization(self):
         data_store = DataStore()
         vm        = VirtualMachine("MyVM", None, {'path': '', 'binary': ''},
-                                   None, [1], None)
+                                   None, [1], None, None)
         suite     = BenchmarkSuite("MySuite", vm, {'benchmarks': [],
                                                    'gauge_adapter': '',
-                                                   'command': ''})
+                                                   'command': ''}, None)
         bench_cfg = BenchmarkConfig("Test Bench [>", "Test Bench [>", None,
                                     suite, vm, None, 0, None, data_store)
 


### PR DESCRIPTION
This PR adds build support for benchmark suites. As we had it for VMs before, suites can now take a script to be executed before a benchmark is ran.
This address issue #59 partially.

This PR also makes sure that these scripts are executed only once.
This is based on the path/location they are executed in and the actual script.
If both match for another VM/suite, they are considered identical and only executed once, because they do not take any other parameters.
This addresses issue #70.

And, the last change is to introduce a command line flag, which suppresses any build operation.
With `-B`, we disable execution of any `build:` commands.
This addresses issue #69.