### PR TITLE
Remove remaining traces of CSV statistic reporting

### DIFF
--- a/rebench/model/reporting.py
+++ b/rebench/model/reporting.py
@@ -24,10 +24,6 @@ from ..reporter import CodespeedReporter
 class Reporting(object):
 
     def __init__(self, raw_config, cli_reporter, options):
-        self._csv_file = raw_config.get('csv_file', None)
-        self._csv_locale = raw_config.get('csv_locale', None)
-        self._csv_raw = raw_config.get('csv_raw', None)
-
         if "codespeed" in raw_config and options.use_codespeed:
             self._codespeed = CodespeedReporting(raw_config, options)
         else:
@@ -35,23 +31,8 @@ class Reporting(object):
 
         self._cli_reporter = cli_reporter
 
-    @property
-    def csv_file(self):
-        return self._csv_file
-
-    @property
-    def csv_locale(self):
-        return self._csv_locale
-
-    @property
-    def csv_raw(self):
-        return self._csv_raw
-
-    def combined(self, raw_config):
+    def combined(self, _raw_config):
         rep = Reporting({}, self._cli_reporter, None)
-        rep._csv_file = raw_config.get('csv_file', self._csv_file)
-        rep._csv_locale = raw_config.get('csv_locale', self._csv_locale)
-        rep._csv_raw = raw_config.get('csv_raw', self._csv_raw)
 
         rep._codespeed = self._codespeed
         return rep

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -20,18 +20,6 @@ schema;runs_type:
 schema;reporting_type:
   type: map
   mapping:
-    csv_file:
-      type: str
-      desc: Statistics are written to a CSV file
-    csv_locale:
-      type: str
-      desc: |
-        The local influences separators.
-        Setting it might make work with Excel easier.
-    csv_raw:
-      type: str
-      desc: |
-        Raw data file. TODO: what was this again? probable needs to be removed.
     codespeed:
       type: map
       desc: Send results to Codespeed for continuous performance tracking.

--- a/rebench/tests/codespeed.conf
+++ b/rebench/tests/codespeed.conf
@@ -11,10 +11,8 @@ reporting:
     # results can also be reported to a codespeed instance
     # see: https://github.com/tobami/codespeed
     codespeed:
-        url: http://localhost:1/ # not supposed to work 
+        url: http://localhost:1/ # not supposed to work
         # other details like commitid are required to be given as parameters
-    csv_file: test.csv
-    csv_locale: de_DE.UTF-8
 
 runs:
     number_of_data_points: 10
@@ -43,7 +41,7 @@ virtual_machines:
         path: tests
         binary: test-vm1.py %(cores)s
         cores: [1, 4]
-        
+
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:
     Test:

--- a/rebench/tests/small.conf
+++ b/rebench/tests/small.conf
@@ -5,11 +5,6 @@
 standard_experiment: Test
 standard_data_file:  'tests/small.data'
 
-reporting:
-    csv_file:   tests/small.csv
-    csv_locale: de_DE.UTF-8
-    csv_raw:    tests/small.data.csv
-
 # general configuration for runs
 runs:
     number_of_data_points:  10

--- a/rebench/tests/test.conf
+++ b/rebench/tests/test.conf
@@ -1,22 +1,18 @@
 # Config file for ReBench
 # Config format is YAML (see http://yaml.org/ for detailed spec)
 
-# this experiment is chosen if no parameter is given to rebench.py
+# this experiment is chosen if no parameter is given to rebench
 standard_experiment: Test
 standard_data_file:  'tests/test.data'
 
-# reporting should enable the configuration of the format of the out put
-# REM: not implement yet (STEFAN: 2011-01-19)
-reporting:
+# reporting should enable the configuration of the format of the output
+# reporting:
     # results can also be reported to a codespeed instance
     # see: https://github.com/tobami/codespeed
     # codespeed:
     #     url: http://localhost:8000/result/add-multiple/
     #     project: test
     #     # other details like commitid are required to be given as parameters
-    csv_file: test.csv
-    csv_locale: de_DE.UTF-8
-    csv_raw:  tests/test.data.csv
 
 # general configuration for runs
 runs:
@@ -28,7 +24,7 @@ runs:
     # parallel executed benchmarks
     # Note: this is a strictly global setting
     parallel_interference_factor: 2.5
- 
+
 # settings for quick runs, useful for fast feedback during experiments
 quick_runs:
     number_of_data_points: 3
@@ -106,12 +102,10 @@ experiments:
             - TestSuite2
         number_of_data_points: 1
         data_file: TestTest.data.data
-        reporting:
-            csv_file: TestTest.data.data.csv
         executions:
             # List of VMs and Benchmarks/Benchmark Suites to be run on them
             # benchmarks define here will override the ones defined for the whole run
-            
+
             #the following example is equivalent to the global run definition,
             #but needs to be tested...
             - TestRunner1:


### PR DESCRIPTION
The outdated code was removed already in #79.
This change also removes the schema and config examples.