### PR TITLE
Improve user interface and output of ReBench

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ addons:
       - time
 
 install:
+  - pip install coveralls humanfriendly pylint
   - pip install .
-  - pip install coveralls
-  - pip install pylint
 
 # command to run tests
 script:

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -17,10 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import sys
 import logging
 import subprocess
-import traceback
 from os.path import dirname
 
 from .model.experiment import Experiment
@@ -28,7 +26,7 @@ from .model.exp_run_details import ExpRunDetails
 from .model.exp_variables import ExpVariables
 from .model.reporting import Reporting
 from .model.virtual_machine import VirtualMachine
-from .ui import UIError
+from .ui import UIError, DETAIL_INDENT
 
 
 class _VMFilter(object):
@@ -117,6 +115,7 @@ def load_config(file_name):
     """
     import yaml
     from pykwalify.core import Core
+    from pykwalify.errors import SchemaError
 
     # Disable most logging for pykwalify
     logging.getLogger('pykwalify').setLevel(logging.ERROR)
@@ -130,10 +129,9 @@ def load_config(file_name):
             try:
                 validator.validate(raise_exception=True)
             except SchemaError as err:
-                indent = "\n    "
                 raise UIError(
-                    "Validation of " + file_name + " failed." + indent +
-                    (indent.join(validator.validation_errors)), err)
+                    "Validation of " + file_name + " failed." + DETAIL_INDENT +
+                    (DETAIL_INDENT.join(validator.validation_errors)), err)
             return data
     except IOError as err:
         if err.errno == 2:

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -21,6 +21,8 @@ import logging
 import subprocess
 from os.path import dirname
 
+from humanfriendly.terminal import warning
+
 from .model.experiment import Experiment
 from .model.exp_run_details import ExpRunDetails
 from .model.exp_variables import ExpVariables
@@ -198,13 +200,12 @@ class Configurator(object):
             logging.basicConfig(level=logging.ERROR)
             logging.getLogger().setLevel(logging.ERROR)
 
-        if self._options.use_nice:
-            if not can_set_niceness():
-                logging.error("Process niceness cannot be set currently. "
-                              "To execute benchmarks with highest priority, "
-                              "you might need root/admin rights.")
-                logging.error("Deactivated usage of nice command.")
-                self._options.use_nice = False
+        if self._options.use_nice and not can_set_niceness():
+            warning("Error: Process niceness could not be set. "
+                    "To execute benchmarks with highest priority, "
+                    "you might need root/admin rights.")
+            warning("Deactivated usage of nice command.")
+            self._options.use_nice = False
 
     @property
     def use_nice(self):

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -120,7 +120,7 @@ def load_config(file_name):
     from pykwalify.errors import SchemaError
 
     # Disable most logging for pykwalify
-    logging.getLogger('pykwalify').setLevel(logging.ERROR)
+    logging.getLogger('pykwalify').addHandler(logging.NullHandler())
 
     try:
         with open(file_name, 'r') as conf_file:

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -118,6 +118,7 @@ def load_config(file_name):
 
     # Disable most logging for pykwalify
     import logging
+    logging.getLogger('pykwalify').setLevel(logging.CRITICAL)
     logging.getLogger('pykwalify').addHandler(logging.NullHandler())
 
     try:

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -17,7 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import logging
 import subprocess
 from os.path import dirname
 
@@ -26,7 +25,7 @@ from .model.exp_run_details import ExpRunDetails
 from .model.exp_variables import ExpVariables
 from .model.reporting import Reporting
 from .model.virtual_machine import VirtualMachine
-from .ui import UIError, DETAIL_INDENT, error
+from .ui import UIError, DETAIL_INDENT, error, set_verbose_debug_mode
 
 
 class _VMFilter(object):
@@ -118,6 +117,7 @@ def load_config(file_name):
     from pykwalify.errors import SchemaError
 
     # Disable most logging for pykwalify
+    import logging
     logging.getLogger('pykwalify').addHandler(logging.NullHandler())
 
     try:
@@ -183,18 +183,7 @@ class Configurator(object):
         if self._options is None:
             return
 
-        if self._options.debug:
-            if self._options.verbose:
-                logging.basicConfig(level=logging.NOTSET)
-                logging.getLogger().setLevel(logging.NOTSET)
-                logging.debug("Enabled verbose debug output.")
-            else:
-                logging.basicConfig(level=logging.DEBUG)
-                logging.getLogger().setLevel(logging.DEBUG)
-                logging.debug("Enabled debug output.")
-        else:
-            logging.basicConfig(level=logging.ERROR)
-            logging.getLogger().setLevel(logging.ERROR)
+        set_verbose_debug_mode(self._options.verbose, self._options.debug)
 
         if self._options.use_nice and not can_set_niceness():
             error("Error: Process niceness could not be set. "

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -160,12 +160,10 @@ class Configurator(object):
         self._root_run_details = ExpRunDetails.compile(
             raw_config.get('runs', {}), ExpRunDetails.default())
         self._root_reporting = Reporting.compile(
-            raw_config.get('reporting', {}), Reporting.empty(), cli_options)
+            raw_config.get('reporting', {}), Reporting.empty(cli_reporter), cli_options)
 
         self._options = cli_options
         self._process_cli_options()
-
-        self._cli_reporter = cli_reporter
 
         self._data_store = data_store
         self._build_commands = dict()

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -21,14 +21,12 @@ import logging
 import subprocess
 from os.path import dirname
 
-from humanfriendly.terminal import warning
-
 from .model.experiment import Experiment
 from .model.exp_run_details import ExpRunDetails
 from .model.exp_variables import ExpVariables
 from .model.reporting import Reporting
 from .model.virtual_machine import VirtualMachine
-from .ui import UIError, DETAIL_INDENT
+from .ui import UIError, DETAIL_INDENT, error
 
 
 class _VMFilter(object):
@@ -199,10 +197,10 @@ class Configurator(object):
             logging.getLogger().setLevel(logging.ERROR)
 
         if self._options.use_nice and not can_set_niceness():
-            warning("Error: Process niceness could not be set. "
-                    "To execute benchmarks with highest priority, "
-                    "you might need root/admin rights.")
-            warning("Deactivated usage of nice command.")
+            error("Error: Process niceness could not be set. "
+                  "To execute benchmarks with highest priority, "
+                  "you might need root/admin rights.")
+            error("Deactivated usage of nice command.")
             self._options.use_nice = False
 
     @property

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -34,8 +34,9 @@ from threading import Thread, RLock
 from humanfriendly.terminal import warning
 
 from . import subprocess_with_timeout as subprocess_timeout
-from .statistics  import StatisticProperties
 from .interop.adapter import ExecutionDeliveredNoResults
+from .statistics  import StatisticProperties
+from .ui import DETAIL_INDENT
 
 
 class FailedBuilding(Exception):
@@ -400,14 +401,14 @@ class Executor(object):
             run_id.fail_immediately()
             if err.errno == 2:
                 warning(
-                    ("Failed executing a run."
-                     "\n    It failed with: %s."
-                     "\n    File: %s") % (err.strerror, err.filename))
+                    ("Failed executing a run." +
+                     DETAIL_INDENT + "It failed with: %s." +
+                     DETAIL_INDENT + "File: %s") % (err.strerror, err.filename))
             else:
                 warning(str(err))
             warning(
-                ("\n    Cmd: %s"
-                 "\n    Cwd: %s") % (cmdline, run_id.location))
+                (DETAIL_INDENT + "Cmd: %s" +
+                 DETAIL_INDENT + "Cwd: %s") % (cmdline, run_id.location))
             return True
 
         if return_code != 0 and not self._include_faulty:

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -445,9 +445,10 @@ class Executor(object):
         run_id.indicate_invocation_start()
 
         try:
-            debug_output_info("Starting run" +
-                              DETAIL_INDENT + "Cmd: " + cmdline +
-                              DETAIL_INDENT + "Cwd: " + run_id.location)
+            msg = "Starting run" + DETAIL_INDENT + "Cmd: " + cmdline
+            if run_id.location:
+                msg += DETAIL_INDENT + "Cwd: " + run_id.location
+            debug_output_info(msg)
 
             (return_code, output, _) = subprocess_timeout.run(
                 cmdline, cwd=run_id.location, stdout=subprocess.PIPE,

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -465,8 +465,9 @@ class Executor(object):
             for data_point in data_points:
                 if warmup is not None and warmup > 0:
                     warmup -= 1
+                    run_id.add_data_point(data_point, True)
                 else:
-                    run_id.add_data_point(data_point)
+                    run_id.add_data_point(data_point, False)
                     # only log the last num_points_to_show results
                     if i >= num_points - num_points_to_show:
                         logging.debug("Run %s:%s result=%s" % (

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -32,12 +32,11 @@ import sys
 from threading import Thread, RLock
 
 from humanfriendly import Spinner
-from humanfriendly.terminal import warning
 
 from . import subprocess_with_timeout as subprocess_timeout
 from .interop.adapter import ExecutionDeliveredNoResults
 from .statistics import StatisticProperties, mean
-from .ui import DETAIL_INDENT
+from .ui import DETAIL_INDENT, error
 
 
 class FailedBuilding(Exception):
@@ -70,7 +69,7 @@ class RunScheduler(object):
     def _indicate_progress(self, completed_task, run):
         if not self._progress_spinner:
             return
-        
+
         totals = run.get_total_values()
         if completed_task:
             self._progress += 1
@@ -429,13 +428,13 @@ class Executor(object):
         except OSError as err:
             run_id.fail_immediately()
             if err.errno == 2:
-                warning(
+                error(
                     ("Failed executing a run." +
                      DETAIL_INDENT + "It failed with: %s." +
                      DETAIL_INDENT + "File: %s") % (err.strerror, err.filename))
             else:
-                warning(str(err))
-            warning(
+                error(str(err))
+            error(
                 (DETAIL_INDENT + "Cmd: %s" +
                  DETAIL_INDENT + "Cwd: %s") % (cmdline, run_id.location))
             return True

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -336,7 +336,7 @@ class Executor(object):
 
         proc = subprocess.Popen('/bin/sh', stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                cwd=path, verbose=self._debug)
+                                cwd=path)
         proc.stdin.write(str.encode(script))
         proc.stdin.close()
 
@@ -350,11 +350,15 @@ class Executor(object):
                         if file_no == proc.stdout.fileno():
                             read = self._read(proc.stdout)
                             if read:
+                                if self._debug:
+                                    sys.stdout.write(read)
                                 log_file.write(name + '|STD:')
                                 log_file.write(read)
                         elif file_no == proc.stderr.fileno():
                             read = self._read(proc.stderr)
                             if read:
+                                if self._debug:
+                                    sys.stderr.write(read)
                                 log_file.write(name + '|ERR:')
                                 log_file.write(read)
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -268,12 +268,12 @@ class ParallelScheduler(RunScheduler):
 class Executor(object):
 
     def __init__(self, runs, use_nice, do_builds, include_faulty=False,
-                 verbose=False, scheduler=BatchScheduler, build_log=None):
+                 debug=False, scheduler=BatchScheduler, build_log=None):
         self._runs = runs
         self._use_nice = use_nice
         self._do_builds = do_builds
         self._include_faulty = include_faulty
-        self._verbose = verbose
+        self._debug = debug
         self._scheduler = self._create_scheduler(scheduler)
         self._build_log = build_log
 
@@ -332,9 +332,13 @@ class Executor(object):
 
         script = build_command.command
 
+        debug_output_info("Starting build" +
+                          DETAIL_INDENT + "Cmd: " + script +
+                          DETAIL_INDENT + "Cwd: " + path)
+
         proc = subprocess.Popen('/bin/sh', stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                cwd=path)
+                                cwd=path, verbose=self._debug)
         proc.stdin.write(str.encode(script))
         proc.stdin.close()
 
@@ -438,9 +442,13 @@ class Executor(object):
         run_id.indicate_invocation_start()
 
         try:
+            debug_output_info("Starting run" +
+                              DETAIL_INDENT + "Cmd: " + cmdline +
+                              DETAIL_INDENT + "Cwd: " + run_id.location)
+
             (return_code, output, _) = subprocess_timeout.run(
                 cmdline, cwd=run_id.location, stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT, shell=True, verbose=self._verbose,
+                stderr=subprocess.STDOUT, shell=True, verbose=self._debug,
                 timeout=run_id.max_invocation_time)
             output = output.decode('utf-8')
         except OSError as err:

--- a/rebench/interop/test_adapter.py
+++ b/rebench/interop/test_adapter.py
@@ -34,7 +34,7 @@ class TestAdapter(GaugeAdapter):
 
     def parse_data(self, data, run_id):
         point = DataPoint(run_id)
-        point.add_measurement(Measurement(self.test_data[self.index], None,
+        point.add_measurement(Measurement(self.test_data[self.index], "ms",
                                           run_id))
         self.index = (self.index + 1) % len(self.test_data)
         return [point]

--- a/rebench/model/data_point.py
+++ b/rebench/model/data_point.py
@@ -41,3 +41,6 @@ class DataPoint(object):
 
     def get_total_value(self):
         return self._total.value if self._total else None
+
+    def get_total_unit(self):
+        return self._total.unit

--- a/rebench/model/measurement.py
+++ b/rebench/model/measurement.py
@@ -29,6 +29,7 @@ class Measurement(object):
         self._criterion = criterion
         self._value = value
         self._unit = unit
+        assert unit is not None
         self._timestamp = timestamp or datetime.now()
         self._line_number = line_number
         self._filename = filename

--- a/rebench/model/reporting.py
+++ b/rebench/model/reporting.py
@@ -34,8 +34,8 @@ class Reporting(object):
         return Reporting(codespeed, cli_reporter)
 
     @classmethod
-    def empty(cls):
-        return Reporting(None, None)
+    def empty(cls, cli_reporter):
+        return Reporting(None, cli_reporter)
 
     def __init__(self, codespeed_reporter, cli_reporter):
         self._codespeed_reporter = codespeed_reporter

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -156,8 +156,9 @@ class RunId(object):
     def loaded_data_point(self, data_point):
         self._data_points.append(data_point)
 
-    def add_data_point(self, data_point):
-        self._data_points.append(data_point)
+    def add_data_point(self, data_point, warmup):
+        if not warmup:
+            self._data_points.append(data_point)
         for persistence in self._persistence:
             persistence.persist_data_point(data_point)
 

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -17,7 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import logging
 import re
 
 from .benchmark import Benchmark
@@ -99,12 +98,6 @@ class RunId(object):
             return None
         return self._expand_vars(self._benchmark.suite.location)
 
-    def log(self):
-        msg = "Run Config: number of data points: %d" % self.get_number_of_data_points()
-        if self._benchmark.run_details.min_iteration_time:
-            msg += ", min_iteration_time: %dms" % self._benchmark.run_details.min_iteration_time
-        logging.debug(msg)
-
     def requires_warmup(self):
         return self._benchmark.run_details.warmup > 0
 
@@ -174,6 +167,11 @@ class RunId(object):
     def get_total_values(self):
         return [dp.get_total_value() for dp in self._data_points]
 
+    def get_total_unit(self):
+        if not self._data_points:
+            return None
+        return self._data_points[0].get_total_unit()
+
     def get_termination_check(self):
         if self._termination_check is None:
             self._termination_check = TerminationCheck(self._benchmark)
@@ -211,7 +209,7 @@ class RunId(object):
             msg = ("The configuration of %s contains improper Python format strings."
                    % self._benchmark.name)
             msg += DETAIL_INDENT + ("The command line configured is: %s" % string)
-            msg += DETAIL_INDENT + ("%s is not supported as key." % err.message)
+            msg += DETAIL_INDENT + ("%s is not supported as key." % err)
             msg += DETAIL_INDENT
             msg += "Only benchmark, input, variable, cores, and warmup are supported."
             raise UIError(msg, err)
@@ -250,7 +248,7 @@ class RunId(object):
 
         # figure out which format misses a conversion type
         msg += DETAIL_INDENT + ("The command line configured is: %s" % cmdline)
-        msg += DETAIL_INDENT + ("Error: %s" % err.message)
+        msg += DETAIL_INDENT + ("Error: %s" % err)
         without_conversion_type = re.findall(
             r"%\(.*?\)(?![diouxXeEfFgGcrs%])", cmdline)
         if without_conversion_type:

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -54,6 +54,14 @@ class RunId(object):
         return self._benchmark.run_details.max_invocation_time
 
     @property
+    def iterations(self):
+        return self._benchmark.run_details.iterations
+
+    @property
+    def invocations(self):
+        return self._benchmark.run_details.invocations
+
+    @property
     def execute_exclusively(self):
         return self._benchmark.run_details.execute_exclusively
 
@@ -203,7 +211,8 @@ class RunId(object):
                    % self._benchmark.name)
             msg += DETAIL_INDENT + ("The command line configured is: %s" % string)
             msg += DETAIL_INDENT + ("%s is not supported as key." % err.message)
-            msg += DETAIL_INDENT + "Only benchmark, input, variable, cores, and warmup are supported."
+            msg += DETAIL_INDENT
+            msg += "Only benchmark, input, variable, cores, and warmup are supported."
             raise UIError(msg, err)
 
     def cmdline(self):

--- a/rebench/model/termination_check.py
+++ b/rebench/model/termination_check.py
@@ -17,7 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import logging
+from ..ui import verbose_error_info
 
 
 class TerminationCheck(object):
@@ -53,15 +53,17 @@ class TerminationCheck(object):
 
     def should_terminate(self, number_of_data_points):
         if self._fail_immediately:
-            logging.info(
+            verbose_error_info(
                 "%s was marked to fail immediately" % self._benchmark.name)
         if self.fails_consecutively():
-            logging.error(("Three executions of %s have failed in a row, " +
-                           "benchmark is aborted") % self._benchmark.name)
+            verbose_error_info(
+                ("Three executions of %s have failed in a row, "
+                 "benchmark is aborted") % self._benchmark.name)
             return True
         elif self.has_too_many_failures(number_of_data_points):
-            logging.error("Many runs of %s are failing, benchmark is aborted."
-                          % self._benchmark.name)
+            verbose_error_info(
+                "Many runs of %s are failing, benchmark is aborted."
+                % self._benchmark.name)
             return True
         elif self._num_invocations >= self._benchmark.run_details.invocations:
             return True

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -20,9 +20,8 @@ schema;runs_type:
     warmup:
       type: int
       desc: |
-        Consider the first N iterations as warmup.
-        This is used by reporters, for instance to discard these
-        N measurements before calculating statistics.
+        Consider the first N iterations as warmup and ignore them in summary
+        statistics. Note they are still persistet in the data file.
 
     min_iteration_time:
       type: int

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -27,7 +27,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import logging
 import sys
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, SUPPRESS
@@ -38,7 +37,7 @@ from .persistence    import DataStore
 from .reporter       import CliReporter
 from .configurator   import Configurator, load_config
 from .configuration_error import ConfigurationError
-from .ui import UIError, error
+from .ui import UIError, error, debug_error_info, verbose_output_info
 
 
 class ReBench(object):
@@ -79,7 +78,7 @@ Argument:
                             default=False, help='Enable debug output')
         basics.add_argument('-v', '--verbose', action='store_true',
                             dest='verbose', default=False,
-                            help='Output more details in the report.')
+                            help='Output more details during execution.')
 
         execution = parser.add_argument_group(
             'Execution Options', 'Adapt how ReBench executes benchmarks')
@@ -193,7 +192,7 @@ Argument:
         return self.execute_experiment()
 
     def execute_experiment(self):
-        logging.debug("execute experiment: %s" % self._config.experiment_name)
+        verbose_output_info("Execute experiment: %s" % self._config.experiment_name)
 
         # first load old data if available
         if self._config.options.clean:
@@ -218,7 +217,7 @@ def main_func():
     try:
         return 0 if ReBench().run() else -1
     except KeyboardInterrupt:
-        logging.info("Aborted by user request")
+        debug_error_info("Aborted by user request")
         return -1
     except UIError as err:
         error(err.message)

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -208,7 +208,7 @@ Argument:
 
         executor = Executor(runs, self._config.use_nice, self._config.do_builds,
                             self._config.options.include_faulty,
-                            self._config.options.verbose,
+                            self._config.options.debug,
                             scheduler_class,
                             self._config.build_log)
         return executor.execute()

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -189,8 +189,8 @@ Argument:
                                         cli_reporter, exp_name, args.data_file,
                                         args.build_log, exp_filter)
         except ConfigurationError as exc:
-            logging.error(exc.message)
-            sys.exit(-1)
+            raise UIError(exc.message, exc)
+
         data_store.load_data()
         return self.execute_experiment()
 

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -29,7 +29,10 @@
 # IN THE SOFTWARE.
 import logging
 import sys
+
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, SUPPRESS
+
+from humanfriendly.terminal import warning
 
 from .executor       import Executor, BatchScheduler, RoundRobinScheduler, \
                             RandomScheduler
@@ -37,6 +40,7 @@ from .persistence    import DataStore
 from .reporter       import CliReporter
 from .configurator   import Configurator, load_config
 from .configuration_error import ConfigurationError
+from .ui import UIError
 
 
 class ReBench(object):
@@ -217,6 +221,9 @@ def main_func():
         return 0 if ReBench().run() else -1
     except KeyboardInterrupt:
         logging.info("Aborted by user request")
+        return -1
+    except UIError as err:
+        warning(err.message)
         return -1
 
 

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -32,15 +32,13 @@ import sys
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, SUPPRESS
 
-from humanfriendly.terminal import warning
-
 from .executor       import Executor, BatchScheduler, RoundRobinScheduler, \
                             RandomScheduler
 from .persistence    import DataStore
 from .reporter       import CliReporter
 from .configurator   import Configurator, load_config
 from .configuration_error import ConfigurationError
-from .ui import UIError
+from .ui import UIError, error
 
 
 class ReBench(object):
@@ -223,7 +221,7 @@ def main_func():
         logging.info("Aborted by user request")
         return -1
     except UIError as err:
-        warning(err.message)
+        error(err.message)
         return -1
 
 

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -26,6 +26,8 @@ import logging
 import json
 import re
 
+from .ui import warning_low_priority
+
 try:
     from http.client import HTTPException
     from urllib.request import urlopen
@@ -118,9 +120,6 @@ class CliReporter(TextReporter):
         self._runs_remaining = 0
         self._executes_verbose = executes_verbose
 
-        # TODO: re-add support, think, we need that based on the proper config, i.e., the run id
-#         self._min_iteration_time = configurator.statistics.min_iteration_time
-
     def run_failed(self, run_id, cmdline, return_code, output):
         # Additional information in debug mode
         result = "[%s] Run failed: %s\n" % (
@@ -155,14 +154,12 @@ class CliReporter(TextReporter):
         self._runs_completed += 1
         self._runs_remaining -= 1
 
-        if run_id.run_config.min_iteration_time:
-            if statistics.mean < run_id.run_config.min_iteration_time:
-                print(("WARNING: measured mean is lower than min_iteration_time (%s) "
-                       "\t mean: %.1f\trun id: %s")
-                      % (run_id.run_config.min_iteration_time,
-                         statistics.mean,
-                         run_id.as_simple_string()))
-                print("Cmd: %s" % cmdline)
+        if run_id.min_iteration_time and statistics.mean < run_id.min_iteration_time:
+            warning_low_priority(
+                ("WARNING: measured mean is lower than min_iteration_time (%s) "
+                 "\t mean: %.1f\trun id: %s")
+                % (run_id.min_iteration_time, statistics.mean, run_id.as_simple_string()))
+            warning_low_priority("Cmd: %s" % cmdline)
 
     def report_job_completed(self, run_ids):
         print("[%s] Job completed" % datetime.now())

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -19,7 +19,6 @@
 # THE SOFTWARE.
 from __future__ import with_statement
 
-from datetime import datetime
 from time import time
 import json
 import re
@@ -100,7 +99,7 @@ class CliReporter(TextReporter):
         self._runs_remaining = 0
         self._executes_verbose = executes_verbose
 
-    def run_failed(self, run_id, cmdline, return_code, output):
+    def run_failed(self, run_id, cmdline, return_code, cmd_output):
         pass
 
     def run_completed(self, run_id, statistics, cmdline):
@@ -224,12 +223,12 @@ class CodespeedReporter(Reporter):
                        DETAIL_INDENT + "projects: %s" +
                        DETAIL_INDENT + "benchmarks: %s" +
                        DETAIL_INDENT + "executables: %s") % (
-                    envs, projects, benchmarks, executables)
+                           envs, projects, benchmarks, executables)
 
                 error("Error: Reporting to Codespeed failed." +
                       DETAIL_INDENT + str(error) +
                       DETAIL_INDENT + "This is most likely caused by "
-                                      "either a wrong URL in the config file, or an " 
+                                      "either a wrong URL in the config file, or an "
                                       "environment not configured in Codespeed." +
                       DETAIL_INDENT + "URL: " + self._cfg.url +
                       DETAIL_INDENT + msg)

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -26,7 +26,7 @@ import logging
 import json
 import re
 
-from .ui import warning_low_priority
+from .ui import warning
 
 try:
     from http.client import HTTPException
@@ -155,11 +155,11 @@ class CliReporter(TextReporter):
         self._runs_remaining -= 1
 
         if run_id.min_iteration_time and statistics.mean < run_id.min_iteration_time:
-            warning_low_priority(
+            warning(
                 ("WARNING: measured mean is lower than min_iteration_time (%s) "
                  "\t mean: %.1f\trun id: %s")
                 % (run_id.min_iteration_time, statistics.mean, run_id.as_simple_string()))
-            warning_low_priority("Cmd: %s" % cmdline)
+            warning("Cmd: %s" % cmdline)
 
     def report_job_completed(self, run_ids):
         print("[%s] Job completed" % datetime.now())

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -137,8 +137,8 @@ class CliReporter(TextReporter):
 
         print("Cmd: %s\n" % cmdline)
 
-        if run_id.benchmark.suite.has_max_invocation_time():
-            logging.debug("max_invocation_time: %s" % run_id.benchmark.suite.max_invocation_time)
+        if run_id.max_invocation_time:
+            logging.debug("max_invocation_time: %s" % run_id.max_invocation_time)
         logging.debug("cwd: %s" % run_id.benchmark.suite.location)
 
         if not self._executes_verbose and output and output.strip():
@@ -173,16 +173,9 @@ class CliReporter(TextReporter):
     def start_run(self, run_id):
         if self._runs_completed > 0:
             current = time()
-            data_points_per_run = run_id.run_config.number_of_data_points
-            data_points_completed = (self._runs_completed *
-                                     data_points_per_run +
-                                     len(run_id.get_data_points()))
-            data_points_remaining = (self._runs_remaining *
-                                     data_points_per_run -
-                                     len(run_id.get_data_points()))
-            time_per_data_point = ((current - self._start_time) /
-                                   data_points_completed)
-            etl = time_per_data_point * data_points_remaining
+
+            time_per_invocation = ((current - self._start_time) / self._runs_completed)
+            etl = time_per_invocation * self._runs_remaining
             sec = etl % 60
             minute = (etl - sec) / 60 % 60
             hour = (etl - sec - minute) / 60 / 60

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -170,25 +170,6 @@ class CliReporter(TextReporter):
         self._num_runs = num_runs
         self._runs_remaining = num_runs
 
-    def start_run(self, run_id):
-        if self._runs_completed > 0:
-            current = time()
-
-            time_per_invocation = ((current - self._start_time) / self._runs_completed)
-            etl = time_per_invocation * self._runs_remaining
-            sec = etl % 60
-            minute = (etl - sec) / 60 % 60
-            hour = (etl - sec - minute) / 60 / 60
-            print(("Run %s \t runs left: %00d \t " +
-                   "time left: %02d:%02d:%02d") % (run_id.benchmark.name,
-                                                   self._runs_remaining,
-                                                   floor(hour), floor(minute),
-                                                   floor(sec)))
-        else:
-            self._start_time = time()
-            print("Run %s \t runs left: %d" % (run_id.benchmark.name,
-                                               self._runs_remaining))
-
     def _output_stats(self, output_list, run_id, statistics):
         if not statistics:
             return

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -17,12 +17,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from __future__ import with_statement, print_function
+from __future__ import with_statement
 
 from datetime import datetime
 from time import time
-from math import floor
-import logging
 import json
 import re
 
@@ -69,19 +67,6 @@ class Reporter(object):
 
 
 class TextReporter(Reporter):
-
-    def _configuration_details(self, run_id, statistics=None):
-        result = ["\t".join(run_id.as_str_list()), " = "]
-        self._output_stats(result, run_id, statistics)
-        return result
-
-    def _output_stats(self, output_list, _run_id, statistics):
-        if not statistics:
-            return
-
-        for field, value in statistics.__dict__.iteritems():
-            if not field.startswith('_'):
-                output_list.append("%s: %s " % (field, value))
 
     @staticmethod
     def _path_to_string(path):
@@ -131,48 +116,6 @@ class CliReporter(TextReporter):
     def set_total_number_of_runs(self, num_runs):
         self._num_runs = num_runs
         self._runs_remaining = num_runs
-
-    def _output_stats(self, output_list, run_id, statistics):
-        if not statistics:
-            return
-
-        if run_id.run_failed():
-            output_list.append("run failed.")
-            output_list.append("")
-            output_list.append("")
-            output_list.append("")
-        else:
-            output_list.append("mean:")
-            output_list.append(("%.1f" % statistics.mean).rjust(8))
-
-
-class FileReporter(TextReporter):
-    """ should be mainly a log file
-        data is the responsibility of the data_aggregator
-    """
-
-    def __init__(self, filename):
-        super(FileReporter, self).__init__()
-        self._file = open(filename, 'a+')
-
-    def run_failed(self, run_id, _cmdline, _return_code, _output):
-        result = "[%s] Run failed: %s\n" % (
-            datetime.now(),
-            " ".join(self._configuration_details(run_id)))
-        self._file.writelines(result)
-
-    def run_completed(self, run_id, statistics, cmdline):
-        result = "[%s] Run completed: %s\n" % (
-            datetime.now(),
-            " ".join(self._configuration_details(run_id, statistics)))
-        self._file.writelines(result)
-
-    def report_job_completed(self, run_ids):
-        self._file.write("[%s] Job completed\n" % datetime.now())
-        for line in self._generate_all_output(run_ids):
-            self._file.write(line + "\n")
-
-        self._file.close()
 
 
 class CodespeedReporter(Reporter):

--- a/rebench/tests/broken-schema.conf
+++ b/rebench/tests/broken-schema.conf
@@ -1,0 +1,40 @@
+# Config file for ReBench
+# Config format is YAML (see http://yaml.org/ for detailed spec)
+
+# this run definition will be chosen if no parameters are given to rebench.py
+standard_experiment: Test
+standard_data_file:  'tests/small.data'
+
+# general configuration for runs
+runs:
+    invocations:  10
+
+non_existing_attribute: foo bar
+
+benchmark_suites:
+    Suite:
+        gauge_adapter: TestVM
+        command: TestBenchMarks %(benchmark)s %(input)s %(variable)s
+        input_sizes: [2, 10]
+        variable_values:
+            - val1
+        benchmarks:
+            - Bench1
+            - Bench2
+
+virtual_machines:
+    TestRunner1:
+        path: tests
+        binary: test-vm1.py %(cores)s
+        cores: [1]
+    TestRunner2:
+        path: tests
+        binary: test-vm2.py
+
+experiments:
+    Test:
+        benchmark:
+            - Suite
+        executions:
+            - TestRunner1
+            - TestRunner2

--- a/rebench/tests/broken-yaml.conf
+++ b/rebench/tests/broken-yaml.conf
@@ -1,0 +1,42 @@
+# Config file for ReBench
+# Config format is YAML (see http://yaml.org/ for detailed spec)
+
+# this run definition will be chosen if no parameters are given to rebench.py
+standard_experiment: Test
+standard_data_file:  'tests/small.data'
+
+# general configuration for runs
+runs:
+    invocations:  10
+
+non_existing_attribute: foo bar
+
+- fsdfsd
+
+benchmark_suites:
+    Suite:
+        gauge_adapter: TestVM
+        command: TestBenchMarks %(benchmark)s %(input)s %(variable)s
+        input_sizes: [2, 10]
+        variable_values:
+            - val1
+        benchmarks:
+            - Bench1
+            - Bench2
+
+virtual_machines:
+    TestRunner1:
+        path: tests
+        binary: test-vm1.py %(cores)s
+        cores: [1]
+    TestRunner2:
+        path: tests
+        binary: test-vm2.py
+
+experiments:
+    Test:
+        benchmark:
+            - Suite
+        executions:
+            - TestRunner1
+            - TestRunner2

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -18,7 +18,6 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 import unittest
-import logging
 
 from ..configurator           import Configurator, load_config
 from ..persistence            import DataStore
@@ -26,14 +25,6 @@ from .rebench_test_case import ReBenchTestCase
 
 
 class ConfiguratorTest(ReBenchTestCase):
-
-    def setUp(self):
-        super(ConfiguratorTest, self).setUp()
-        self._logging_error = logging.error
-
-    def tearDown(self):
-        super(ConfiguratorTest, self).tearDown()
-        logging.error = self._logging_error  # restore normal logging
 
     def test_experiment_name_from_cli(self):
         cnf = Configurator(load_config(self._path + '/test.conf'),

--- a/rebench/tests/rebench_test_case.py
+++ b/rebench/tests/rebench_test_case.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+import logging
 import os
 from os.path  import dirname, realpath
 
@@ -32,6 +33,8 @@ class ReBenchTestCase(TestCase):
         os.chdir(self._path)
 
     def setUp(self):
+        logging.getLogger('pykwalify').addHandler(logging.NullHandler())
+
         self._set_path(__file__)
         self._tmp_file = mkstemp()[1]  # just use the file name
 

--- a/rebench/tests/ui_test.py
+++ b/rebench/tests/ui_test.py
@@ -1,0 +1,25 @@
+from pykwalify.errors import SchemaError
+from yaml import YAMLError
+
+from ..configurator import load_config
+from ..ui import UIError
+
+from .rebench_test_case import ReBenchTestCase
+
+
+class UITest(ReBenchTestCase):
+
+    def test_missing_file(self):
+        with self.assertRaises(UIError) as err:
+            load_config("--file-that-does-not-exist")
+        self.assertIsInstance(err.exception.source_exception, IOError)
+
+    def test_config_not_validating(self):
+        with self.assertRaises(UIError) as err:
+            load_config(self._path + '/broken-schema.conf')
+        self.assertIsInstance(err.exception.source_exception, SchemaError)
+
+    def test_config_not_proper_yaml(self):
+        with self.assertRaises(UIError) as err:
+            load_config(self._path + '/broken-yaml.conf')
+        self.assertIsInstance(err.exception.source_exception, YAMLError)

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -32,7 +32,7 @@ _debug_output = False
 
 
 def set_verbose_debug_mode(verbose, debug):
-    global _verbose_output, _debug_output
+    global _verbose_output, _debug_output  # pylint: disable=global-statement
     _verbose_output = verbose
     _debug_output = debug
 

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -20,16 +20,60 @@
 import sys
 
 from humanfriendly.compat import coerce_string
-from humanfriendly.terminal import terminal_supports_colors, ansi_wrap, auto_encode
+from humanfriendly.terminal import terminal_supports_colors, ansi_wrap,\
+    auto_encode, warning as hf_warning, output as hf_output
 
 DETAIL_INDENT = "\n    "
+DETAIL_INDENT_WON = "    "
 
 
-def warning_low_priority(text, *args, **kw):
+_verbose_output = False
+_debug_output = False
+
+
+def set_verbose_debug_mode(verbose, debug):
+    global _verbose_output, _debug_output
+    _verbose_output = verbose
+    _debug_output = debug
+
+
+def output(text, *args, **kw):
+    hf_output(text, *args, **kw)
+
+
+def warning(text, *args, **kw):
     text = coerce_string(text)
     if terminal_supports_colors(sys.stderr):
         text = ansi_wrap(text, color='magenta')
     auto_encode(sys.stderr, text + '\n', *args, **kw)
+
+
+def error(text, *args, **kw):
+    return hf_warning(text, *args, **kw)
+
+
+def verbose_output_info(text, *args, **kw):
+    if _verbose_output:
+        text = coerce_string(text)
+        auto_encode(sys.stdout, text + '\n', *args, **kw)
+
+
+def verbose_error_info(text, *args, **kw):
+    if _verbose_output:
+        text = coerce_string(text)
+        auto_encode(sys.stderr, text + '\n', *args, **kw)
+
+
+def debug_output_info(text, *args, **kw):
+    if _debug_output:
+        text = coerce_string(text)
+        auto_encode(sys.stdout, text + '\n', *args, **kw)
+
+
+def debug_error_info(text, *args, **kw):
+    if _debug_output:
+        text = coerce_string(text)
+        auto_encode(sys.stderr, text + '\n', *args, **kw)
 
 
 class UIError(Exception):

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -17,9 +17,19 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+import sys
 
+from humanfriendly.compat import coerce_string
+from humanfriendly.terminal import terminal_supports_colors, ansi_wrap, auto_encode
 
 DETAIL_INDENT = "\n    "
+
+
+def warning_low_priority(text, *args, **kw):
+    text = coerce_string(text)
+    if terminal_supports_colors(sys.stderr):
+        text = ansi_wrap(text, color='magenta')
+    auto_encode(sys.stderr, text + '\n', *args, **kw)
 
 
 class UIError(Exception):

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2018 Stefan Marr <http://www.stefan-marr.de/>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+
+class UIError(Exception):
+
+    def __init__(self, message, exception):
+        super(UIError, self).__init__()
+        self._message = message
+        self._exception = exception
+
+    @property
+    def message(self):
+        return self._message
+
+    @property
+    def source_exception(self):
+        return self._exception

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -19,6 +19,9 @@
 # IN THE SOFTWARE.
 
 
+DETAIL_INDENT = "\n    "
+
+
 class UIError(Exception):
 
     def __init__(self, message, exception):

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,7 +34,8 @@ setup(name='ReBench',
       packages=find_packages(exclude=['*.tests']),
       install_requires=[
           'PyYAML>=3.12',
-          'pykwalify>=1.6.1'
+          'pykwalify>=1.6.1',
+          'humanfriendly>=4.12'
       ],
       entry_points = {
           'console_scripts' : ['rebench = rebench:main_func']


### PR DESCRIPTION
Revamp the command line output of ReBench.

From now on, all output is generated immediately from the code.
We do no longer use reporters for the user interface, they are now meant solely for reporting to external systems, for instance to Codespeed.
We now use the humanfriendly module to have colored output and formatted result tables.

This PR also changes the semantics for the `warmup` setting to not discard any data.
This means, the data file will include all data, and the warmup setting only disregards the warmup runs for reporting, and statistics.
