### PR TITLE
Improve error messages

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -25,7 +25,7 @@ from .model.exp_run_details import ExpRunDetails
 from .model.exp_variables import ExpVariables
 from .model.reporting import Reporting
 from .model.virtual_machine import VirtualMachine
-from .ui import UIError, DETAIL_INDENT, error, set_verbose_debug_mode
+from .ui import UIError, UI
 
 
 class _VMFilter(object):
@@ -131,19 +131,19 @@ def load_config(file_name):
                 validator.validate(raise_exception=True)
             except SchemaError as err:
                 raise UIError(
-                    "Validation of " + file_name + " failed." + DETAIL_INDENT +
-                    (DETAIL_INDENT.join(validator.validation_errors)), err)
+                    "Validation of " + file_name + " failed.\n{ind}" +
+                    "{ind}".join(validator.validation_errors) + "\n", err)
             return data
     except IOError as err:
         if err.errno == 2:
             assert err.strerror == "No such file or directory"
-            raise UIError("The requested config file (%s) could not be opened. %s."
+            raise UIError("The requested config file (%s) could not be opened. %s.\n"
                           % (file_name, err.strerror), err)
         else:
-            raise UIError(str(err), err)
+            raise UIError(str(err) + "\n", err)
     except yaml.YAMLError as err:
         raise UIError("Parsing of the config file "
-                      + file_name + " failed.\nError " + str(err), err)
+                      + file_name + " failed.\nError " + str(err) + "\n", err)
 
 
 class Configurator(object):
@@ -162,9 +162,10 @@ class Configurator(object):
             raw_config.get('reporting', {}), Reporting.empty(cli_reporter), cli_options)
 
         self._options = cli_options
+        self._ui = None
+        self._data_store = data_store
         self._process_cli_options()
 
-        self._data_store = data_store
         self._build_commands = dict()
 
         self._run_filter = _RunFilter(run_filter)
@@ -177,20 +178,27 @@ class Configurator(object):
         self._experiments = self._compile_experiments(experiments)
 
     @property
+    def ui(self):
+        return self._ui
+
+    @property
     def build_log(self):
         return self._build_log
 
     def _process_cli_options(self):
         if self._options is None:
+            self._ui = UI(False, False)
+            self._data_store.set_ui(self._ui)
             return
 
-        set_verbose_debug_mode(self._options.verbose, self._options.debug)
+        self._ui = UI(self._options.verbose, self._options.debug)
+        self._data_store.set_ui(self._ui)
 
         if self._options.use_nice and not can_set_niceness():
-            error("Error: Process niceness could not be set. "
-                  "To execute benchmarks with highest priority, "
-                  "you might need root/admin rights.")
-            error("Deactivated usage of nice command.")
+            self._ui.error("Error: Process niceness can not be set.\n"
+                           + "{ind}To execute benchmarks with highest priority,\n"
+                           + "{ind}you might need root/admin rights.\n"
+                           + "{ind}Deactivated usage of nice command.\n")
             self._options.use_nice = False
 
     @property

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -25,7 +25,7 @@ from .model.exp_run_details import ExpRunDetails
 from .model.exp_variables import ExpVariables
 from .model.reporting import Reporting
 from .model.virtual_machine import VirtualMachine
-from .ui import UIError, UI
+from .ui import UIError
 
 
 class _VMFilter(object):
@@ -148,7 +148,7 @@ def load_config(file_name):
 
 class Configurator(object):
 
-    def __init__(self, raw_config, data_store, cli_options=None, cli_reporter=None,
+    def __init__(self, raw_config, data_store, ui, cli_options=None, cli_reporter=None,
                  exp_name=None, data_file=None, build_log=None, run_filter=None):
         self._raw_config_for_debugging = raw_config  # kept around for debugging only
 
@@ -159,10 +159,10 @@ class Configurator(object):
         self._root_run_details = ExpRunDetails.compile(
             raw_config.get('runs', {}), ExpRunDetails.default())
         self._root_reporting = Reporting.compile(
-            raw_config.get('reporting', {}), Reporting.empty(cli_reporter), cli_options)
+            raw_config.get('reporting', {}), Reporting.empty(cli_reporter), cli_options, ui)
 
         self._options = cli_options
-        self._ui = None
+        self._ui = ui
         self._data_store = data_store
         self._process_cli_options()
 
@@ -187,12 +187,9 @@ class Configurator(object):
 
     def _process_cli_options(self):
         if self._options is None:
-            self._ui = UI(False, False)
-            self._data_store.set_ui(self._ui)
             return
 
-        self._ui = UI(self._options.verbose, self._options.debug)
-        self._data_store.set_ui(self._ui)
+        self._ui.init(self._options.verbose, self._options.debug)
 
         if self._options.use_nice and not can_set_niceness():
             self._ui.error("Error: Process niceness can not be set.\n"

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -418,9 +418,10 @@ class Executor(object):
             run_id.report_run_completed(stats, cmdline)
             if run_id.min_iteration_time and stats.mean < run_id.min_iteration_time:
                 warning(
-                    ("Warning: The mean (%.1f) is lower than min_iteration_time (%d)"
-                     "%sCmd: %s")
-                    % (stats.mean, run_id.min_iteration_time, DETAIL_INDENT, cmdline))
+                    ("Warning: Low mean run time for run %s."
+                     + DETAIL_INDENT + "The mean (%.1f) is lower than min_iteration_time (%d)"
+                     + DETAIL_INDENT + "Cmd: %s\n")
+                    % (run_id.as_simple_string(), stats.mean, run_id.min_iteration_time, cmdline))
 
         return terminate
 
@@ -461,14 +462,15 @@ class Executor(object):
         except OSError as err:
             run_id.fail_immediately()
             if err.errno == 2:
-                error(
-                    ("Failed executing a run." +
-                     DETAIL_INDENT + "It failed with: %s." +
-                     DETAIL_INDENT + "File: %s") % (err.strerror, err.filename))
+                msg = ("Failed executing run: %s"
+                       + DETAIL_INDENT + "It failed with: %s."
+                       + DETAIL_INDENT + "File name: %s") % (run_id.as_simple_string(),
+                                                             err.strerror, err.filename)
             else:
-                error(str(err))
-            error((DETAIL_INDENT + "Cmd: %s" +
-                   DETAIL_INDENT + "Cwd: %s") % (cmdline, run_id.location))
+                msg = str(err)
+            error((msg
+                   + DETAIL_INDENT + "Cmd: %s"
+                   + DETAIL_INDENT + "Cwd: %s\n") % (cmdline, run_id.location))
             return True
 
         if return_code != 0 and not self._include_faulty:

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -32,13 +32,11 @@ from select import select
 from threading import Thread, RLock
 from time import time
 
-from humanfriendly import Spinner
 from humanfriendly.compat import coerce_string
 
 from . import subprocess_with_timeout as subprocess_timeout
 from .interop.adapter import ExecutionDeliveredNoResults
 from .statistics import StatisticProperties, mean
-from .ui import DETAIL_INDENT, error, verbose_output_info, warning, debug_output_info
 
 
 class FailedBuilding(Exception):
@@ -51,20 +49,20 @@ class FailedBuilding(Exception):
 
 class RunScheduler(object):
 
-    def __init__(self, executor):
+    def __init__(self, executor, ui):
         self._executor = executor
+        self._ui = ui
         self._runs_completed = 0
-        self._progress_spinner = None
         self._start_time = time()
         self._total_num_runs = 0
 
     @staticmethod
-    def _filter_out_completed_runs(runs):
-        return [run for run in runs if not run.is_completed()]
+    def _filter_out_completed_runs(runs, ui):
+        return [run for run in runs if not run.is_completed(ui)]
 
     @staticmethod
-    def number_of_uncompleted_runs(runs):
-        return len(RunScheduler._filter_out_completed_runs(runs))
+    def number_of_uncompleted_runs(runs, ui):
+        return len(RunScheduler._filter_out_completed_runs(runs, ui))
 
     def _process_remaining_runs(self, runs):
         """Abstract, to be implemented"""
@@ -83,7 +81,7 @@ class RunScheduler(object):
         return floor(hour), floor(minute), floor(sec)
 
     def _indicate_progress(self, completed_task, run):
-        if not self._progress_spinner:
+        if not self._ui.spinner_initialized():
             return
 
         totals = run.get_total_values()
@@ -99,17 +97,16 @@ class RunScheduler(object):
 
         label = "Running Benchmarks: %70s\tmean: %10.1f\ttime left: %02d:%02d:%02d" \
                 % (run.as_simple_string(), art_mean, hour, minute, sec)
-        self._progress_spinner.step(self._runs_completed, label)
+        self._ui.step_spinner(self._runs_completed, label)
 
     def execute(self):
         self._total_num_runs = len(self._executor.runs)
-        runs = self._filter_out_completed_runs(self._executor.runs)
+        runs = self._filter_out_completed_runs(self._executor.runs, self._ui)
         completed_runs = self._total_num_runs - len(runs)
         self._runs_completed = completed_runs
 
-        with Spinner(label="Running Benchmarks", total=self._total_num_runs) as spinner:
-            self._progress_spinner = spinner
-            spinner.step(completed_runs)
+        with self._ui.init_spinner(self._total_num_runs):
+            self._ui.step_spinner(completed_runs)
             self._process_remaining_runs(runs)
 
 
@@ -188,8 +185,8 @@ class BenchmarkThreadExceptions(Exception):
 
 class ParallelScheduler(RunScheduler):
 
-    def __init__(self, executor, seq_scheduler_class):
-        RunScheduler.__init__(self, executor)
+    def __init__(self, executor, seq_scheduler_class, ui):
+        RunScheduler.__init__(self, executor, ui)
         self._seq_scheduler_class = seq_scheduler_class
         self._lock = RLock()
         self._num_worker_threads = self._number_of_threads()
@@ -215,7 +212,7 @@ class ParallelScheduler(RunScheduler):
     def _process_sequential_runs(self, runs):
         seq_runs, par_runs = self._split_runs(runs)
 
-        scheduler = self._seq_scheduler_class(self._executor)
+        scheduler = self._seq_scheduler_class(self._executor, self._ui)
         scheduler._process_remaining_runs(seq_runs)
 
         return par_runs
@@ -250,7 +247,7 @@ class ParallelScheduler(RunScheduler):
         return per_thread
 
     def get_local_scheduler(self):
-        return self._seq_scheduler_class(self._executor)
+        return self._seq_scheduler_class(self._executor, self._ui)
 
     def acquire_work(self):
         with self._lock:
@@ -267,17 +264,18 @@ class ParallelScheduler(RunScheduler):
 
 class Executor(object):
 
-    def __init__(self, runs, use_nice, do_builds, include_faulty=False,
+    def __init__(self, runs, use_nice, do_builds, ui, include_faulty=False,
                  debug=False, scheduler=BatchScheduler, build_log=None):
         self._runs = runs
         self._use_nice = use_nice
         self._do_builds = do_builds
+        self._ui = ui
         self._include_faulty = include_faulty
         self._debug = debug
         self._scheduler = self._create_scheduler(scheduler)
         self._build_log = build_log
 
-        num_runs = RunScheduler.number_of_uncompleted_runs(runs)
+        num_runs = RunScheduler.number_of_uncompleted_runs(runs, ui)
         for run in runs:
             run.set_total_number_of_runs(num_runs)
 
@@ -289,9 +287,9 @@ class Executor(object):
                 if not run.execute_exclusively:
                     i += 1
             if i > 1:
-                return ParallelScheduler(self, scheduler)
+                return ParallelScheduler(self, scheduler, self._ui)
 
-        return scheduler(self)
+        return scheduler(self, self._ui)
 
     def _construct_cmdline(self, run_id, gauge_adapter):
         cmdline = ""
@@ -333,9 +331,7 @@ class Executor(object):
 
         script = build_command.command
 
-        debug_output_info("Starting build" +
-                          DETAIL_INDENT + "Cmd: " + script +
-                          DETAIL_INDENT + "Cwd: " + path)
+        self._ui.debug_output_info("Start build\n", None, script, path)
 
         proc = subprocess.Popen('/bin/sh', stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -393,7 +389,7 @@ class Executor(object):
             build_command.mark_succeeded()
 
     def execute_run(self, run_id):
-        termination_check = run_id.get_termination_check()
+        termination_check = run_id.get_termination_check(self._ui)
 
         run_id.report_start_run()
 
@@ -417,11 +413,10 @@ class Executor(object):
         if terminate:
             run_id.report_run_completed(stats, cmdline)
             if run_id.min_iteration_time and stats.mean < run_id.min_iteration_time:
-                warning(
-                    ("Warning: Low mean run time for run %s."
-                     + DETAIL_INDENT + "The mean (%.1f) is lower than min_iteration_time (%d)"
-                     + DETAIL_INDENT + "Cmd: %s\n")
-                    % (run_id.as_simple_string(), stats.mean, run_id.min_iteration_time, cmdline))
+                self._ui.warning(
+                    ("{ind}Warning: Low mean run time.\n"
+                     + "{ind}{ind}The mean (%.1f) is lower than min_iteration_time (%d)")
+                    % (stats.mean, run_id.min_iteration_time), run_id, cmdline)
 
         return terminate
 
@@ -449,10 +444,7 @@ class Executor(object):
         run_id.indicate_invocation_start()
 
         try:
-            msg = "Starting run" + DETAIL_INDENT + "Cmd: " + cmdline
-            if run_id.location:
-                msg += DETAIL_INDENT + "Cwd: " + run_id.location
-            debug_output_info(msg)
+            self._ui.debug_output_info("{ind}Starting run\n", run_id, cmdline)
 
             (return_code, output, _) = subprocess_timeout.run(
                 cmdline, cwd=run_id.location, stdout=subprocess.PIPE,
@@ -462,37 +454,36 @@ class Executor(object):
         except OSError as err:
             run_id.fail_immediately()
             if err.errno == 2:
-                msg = ("Failed executing run: %s"
-                       + DETAIL_INDENT + "It failed with: %s."
-                       + DETAIL_INDENT + "File name: %s") % (run_id.as_simple_string(),
-                                                             err.strerror, err.filename)
+                msg = ("{ind}Failed executing run\n"
+                       + "{ind}{ind}It failed with: %s.\n"
+                       + "{ind}{ind}File name: %s\n") % (err.strerror, err.filename)
             else:
                 msg = str(err)
-            error((msg
-                   + DETAIL_INDENT + "Cmd: %s"
-                   + DETAIL_INDENT + "Cwd: %s\n") % (cmdline, run_id.location))
+            self._ui.error(msg, run_id, cmdline)
             return True
 
         if return_code != 0 and not self._include_faulty:
             run_id.indicate_failed_execution()
             run_id.report_run_failed(cmdline, return_code, output)
             if return_code == 126:
-                error(("Error: Could not execute %s. A likely cause is that "
-                       "the file is not marked as executable. Return code: %d")
-                      % (run_id.benchmark.vm.name, return_code))
+                msg = ("{ind}Error: Could not execute %s.\n"
+                       + "{ind}{ind}The file may not be marked as executable.\n"
+                       + "{ind}Return code: %d\n") % (
+                           run_id.benchmark.vm.name, return_code)
             elif return_code == -9:
-                error("Run timed out. Return code: %d" % return_code)
-                error(DETAIL_INDENT + "max_invocation_time: %s" % run_id.max_invocation_time)
+                msg = ("{ind}Run timed out.\n"
+                       + "{ind}{ind}Return code: %d\n"
+                       + "{ind}{ind}max_invocation_time: %s\n") % (
+                           return_code, run_id.max_invocation_time)
             else:
-                error("Run failed. Return code: %d" % return_code)
+                msg = "{ind}Run failed. Return code: %d\n" % return_code
 
-            error((DETAIL_INDENT + "Cmd: %s" +
-                   DETAIL_INDENT + "Cwd: %s") % (cmdline, run_id.location))
+            self._ui.error(msg, run_id, cmdline)
 
             if output and output.strip():
                 lines = output.split('\n')
-                error(DETAIL_INDENT + "Output: ")
-                error(DETAIL_INDENT + DETAIL_INDENT.join(lines) + "\n\n")
+                self._ui.error("{ind}Output:\n\n{ind}{ind}"
+                               + "\n{ind}{ind}".join(lines) + "\n")
         else:
             self._eval_output(output, run_id, gauge_adapter, cmdline)
 
@@ -507,11 +498,10 @@ class Executor(object):
             num_points_to_show = 20
             num_points = len(data_points)
 
-            msg = "\nCompleted invocation of " + run_id.as_simple_string()
-            msg += DETAIL_INDENT + "Cmd: " + cmdline
+            msg = "{ind}Completed invocation\n"
 
             if num_points > num_points_to_show:
-                msg += DETAIL_INDENT + "Recorded %d data points, show last 20..." % num_points
+                msg += "{ind}{ind}Recorded %d data points, show last 20...\n" % num_points
             i = 0
             for data_point in data_points:
                 if warmup is not None and warmup > 0:
@@ -521,12 +511,12 @@ class Executor(object):
                     run_id.add_data_point(data_point, False)
                     # only log the last num_points_to_show results
                     if i >= num_points - num_points_to_show:
-                        msg += DETAIL_INDENT + "%4d\t%s%s" % (
+                        msg += "{ind}{ind}%4d\t%s%s\n" % (
                             i + 1, data_point.get_total_value(), data_point.get_total_unit())
                 i += 1
 
             run_id.indicate_successful_execution()
-            verbose_output_info(msg)
+            self._ui.verbose_output_info(msg, run_id, cmdline)
         except ExecutionDeliveredNoResults:
             run_id.indicate_failed_execution()
             run_id.report_run_failed(cmdline, 0, output)

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -34,7 +34,7 @@ class Experiment(object):
         data_file = exp.get('data_file') or configurator.data_file
 
         reporting = Reporting.compile(exp.get('reporting', {}), configurator.reporting,
-                                      configurator.options)
+                                      configurator.options, configurator.ui)
 
         run_details = ExpRunDetails.compile(exp, configurator.run_details)
         variables = ExpVariables.compile(exp, ExpVariables.empty())

--- a/rebench/model/reporting.py
+++ b/rebench/model/reporting.py
@@ -24,9 +24,9 @@ from ..reporter import CodespeedReporter
 class Reporting(object):
 
     @classmethod
-    def compile(cls, reporting, root_reporting, options):
+    def compile(cls, reporting, root_reporting, options, ui):
         if "codespeed" in reporting and options and options.use_codespeed:
-            codespeed = CodespeedReporting(reporting, options).get_reporter()
+            codespeed = CodespeedReporting(reporting, options, ui).get_reporter()
         else:
             codespeed = root_reporting.codespeed_reporter
 
@@ -60,7 +60,7 @@ class Reporting(object):
 
 class CodespeedReporting(object):
 
-    def __init__(self, raw_config, options):
+    def __init__(self, raw_config, options, ui):
         codespeed = raw_config.get("codespeed", {})
 
         if options.commit_id is None:
@@ -93,7 +93,7 @@ class CodespeedReporting(object):
         self._branch = options.branch
         self._executable = options.executable
 
-        self._reporter = CodespeedReporter(self)
+        self._reporter = CodespeedReporter(self, ui)
 
     @property
     def report_incrementally(self):

--- a/rebench/model/termination_check.py
+++ b/rebench/model/termination_check.py
@@ -17,12 +17,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-from ..ui import verbose_error_info
 
 
 class TerminationCheck(object):
-    def __init__(self, benchmark):
-        self._benchmark = benchmark
+    def __init__(self, run_id, ui):
+        self._run_id = run_id
+        self._ui = ui
         self._num_invocations = 0
         self._consecutive_erroneous_executions = 0
         self._failed_execution_count = 0
@@ -53,19 +53,16 @@ class TerminationCheck(object):
 
     def should_terminate(self, number_of_data_points):
         if self._fail_immediately:
-            verbose_error_info(
-                "%s was marked to fail immediately" % self._benchmark.name)
+            self._ui.verbose_error_info("{ind}Marked to fail immediately.\n", self._run_id)
         if self.fails_consecutively():
-            verbose_error_info(
-                ("Three executions of %s have failed in a row, "
-                 "benchmark is aborted") % self._benchmark.name)
+            self._ui.verbose_error_info(
+                "{ind}Three executions have failed in a row, benchmark is aborted.\n", self._run_id)
             return True
         elif self.has_too_many_failures(number_of_data_points):
-            verbose_error_info(
-                "Many runs of %s are failing, benchmark is aborted."
-                % self._benchmark.name)
+            self._ui.verbose_error_info(
+                "{ind}Many runs are failing, benchmark is aborted.\n", self._run_id)
             return True
-        elif self._num_invocations >= self._benchmark.run_details.invocations:
+        elif self._num_invocations >= self._run_id.benchmark.run_details.invocations:
             return True
         else:
             return False

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -31,16 +31,11 @@ from .model.run_id      import RunId
 
 class DataStore(object):
 
-    def __init__(self):
+    def __init__(self, ui):
         self._files = {}
         self._run_ids = {}
         self._bench_cfgs = {}
-        self._ui = None
-
-    def set_ui(self, ui):
         self._ui = ui
-        for persistence in list(self._files.values()):
-            persistence.set_ui(ui)
 
     def load_data(self):
         for persistence in list(self._files.values()):
@@ -138,9 +133,6 @@ class _DataPointPersistence(object):
             self._discard_old_data()
         self._insert_shebang_line()
         self._lock = Lock()
-
-    def set_ui(self, ui):
-        self._ui = ui
 
     def _discard_old_data(self):
         self._truncate_file(self._data_filename)

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -27,7 +27,6 @@ import time
 from .model.data_point  import DataPoint
 from .model.measurement import Measurement
 from .model.run_id      import RunId
-from .ui import debug_error_info, DETAIL_INDENT, error, DETAIL_INDENT_WON
 
 
 class DataStore(object):
@@ -36,6 +35,12 @@ class DataStore(object):
         self._files = {}
         self._run_ids = {}
         self._bench_cfgs = {}
+        self._ui = None
+
+    def set_ui(self, ui):
+        self._ui = ui
+        for persistence in list(self._files.values()):
+            persistence.set_ui(ui)
 
     def load_data(self):
         for persistence in list(self._files.values()):
@@ -44,7 +49,8 @@ class DataStore(object):
     def get(self, filename, discard_old_data):
         if filename not in self._files:
             self._files[filename] = _DataPointPersistence(filename, self,
-                                                          discard_old_data)
+                                                          discard_old_data,
+                                                          self._ui)
         return self._files[filename]
 
     def create_run_id(self, benchmark, cores, input_size, var_value):
@@ -97,15 +103,15 @@ class DataStore(object):
         return by_file
 
     @classmethod
-    def discard_data_of_runs(cls, runs):
+    def discard_data_of_runs(cls, runs, ui):
         by_file = cls.get_by_file(runs)
         for filename, measures in by_file.items():
             try:
                 with open(filename, 'r') as data_file:
                     lines = data_file.readlines()
             except IOError:
-                debug_error_info(
-                    "Tried to discard old data, but file does not seem to exist: %s" % filename)
+                ui.debug_error_info(
+                    "Tried to discard old data, but file does not seem to exist: %s\n" % filename)
                 continue
 
             for measure in measures:
@@ -119,8 +125,9 @@ class DataStore(object):
 
 class _DataPointPersistence(object):
 
-    def __init__(self, data_filename, data_store, discard_old_data):
+    def __init__(self, data_filename, data_store, discard_old_data, ui):
         self._data_store = data_store
+        self._ui = ui
         if not data_filename:
             raise ValueError("DataPointPersistence expects a filename " +
                              "for data_filename, but got: %s" % data_filename)
@@ -131,6 +138,9 @@ class _DataPointPersistence(object):
             self._discard_old_data()
         self._insert_shebang_line()
         self._lock = Lock()
+
+    def set_ui(self, ui):
+        self._ui = ui
 
     def _discard_old_data(self):
         self._truncate_file(self._data_filename)
@@ -148,8 +158,8 @@ class _DataPointPersistence(object):
             with open(self._data_filename, 'r') as data_file:
                 self._process_lines(data_file)
         except IOError:
-            debug_error_info("No data loaded, since %s does not exist."
-                             % self._data_filename)
+            self._ui.debug_error_info("No data loaded, since %s does not exist.\n"
+                                      % self._data_filename)
 
     def _process_lines(self, data_file):
         """
@@ -185,10 +195,11 @@ class _DataPointPersistence(object):
             except ValueError as err:
                 msg = str(err)
                 if not errors:
-                    debug_error_info("Failed loading data from data file: " + data_file)
+                    self._ui.debug_error_info("Failed loading data from data file: "
+                                              + data_file + "\n")
                 if msg not in errors:
                     # Configuration is not available, skip data point
-                    debug_error_info(DETAIL_INDENT_WON + msg)
+                    self._ui.debug_error_info("{ind}" + msg + "\n")
                     errors.add(msg)
             line_number += 1
 
@@ -222,8 +233,8 @@ class _DataPointPersistence(object):
                 shutil.copyfileobj(open(renamed_file, 'r'), data_file)
             os.remove(renamed_file)
         except Exception as err:  # pylint: disable=broad-except
-            error("Error: While inserting a shebang line into the data file.%s%s"
-                  % (DETAIL_INDENT, err))
+            self._ui.error(
+                "Error: While inserting a shebang line into the data file.\n{ind}%s\n" % err)
 
     _SEP = "\t"  # separator between serialized parts of a measurement
 

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -37,7 +37,7 @@ from .persistence    import DataStore
 from .reporter       import CliReporter
 from .configurator   import Configurator, load_config
 from .configuration_error import ConfigurationError
-from .ui import UIError, error, debug_error_info, verbose_output_info
+from .ui import UIError, UI
 
 
 class ReBench(object):
@@ -46,6 +46,11 @@ class ReBench(object):
         self.version = "0.10.1"
         self.options = None
         self._config = None
+        self._ui = None
+
+    @property
+    def ui(self):
+        return self._ui
 
     def shell_options(self):
         usage = """%(prog)s [options] <config> [exp_name] [vm:$]* [s:$]*
@@ -185,14 +190,16 @@ Argument:
             self._config = Configurator(config, data_store, args,
                                         cli_reporter, exp_name, args.data_file,
                                         args.build_log, exp_filter)
+            self._ui = self._config.ui
+            cli_reporter.set_ui(self._ui)
         except ConfigurationError as exc:
-            raise UIError(exc.message, exc)
+            raise UIError(exc.message + "\n", exc)
 
         data_store.load_data()
         return self.execute_experiment()
 
     def execute_experiment(self):
-        verbose_output_info("Execute experiment: %s" % self._config.experiment_name)
+        self._ui.verbose_output_info("Execute experiment: " + self._config.experiment_name + "\n")
 
         # first load old data if available
         if self._config.options.clean:
@@ -203,9 +210,10 @@ Argument:
                            'random':      RandomScheduler}.get(self._config.options.scheduler)
         runs = self._config.get_runs()
         if self._config.options.do_rerun:
-            DataStore.discard_data_of_runs(runs)
+            DataStore.discard_data_of_runs(runs, self._ui)
 
         executor = Executor(runs, self._config.use_nice, self._config.do_builds,
+                            self._ui,
                             self._config.options.include_faulty,
                             self._config.options.debug,
                             scheduler_class,
@@ -215,12 +223,15 @@ Argument:
 
 def main_func():
     try:
-        return 0 if ReBench().run() else -1
+        rebench = ReBench()
+        return 0 if rebench.run() else -1
     except KeyboardInterrupt:
-        debug_error_info("Aborted by user request")
+        ui = rebench.ui or UI(False, False)
+        ui.debug_error_info("Aborted by user request")
         return -1
     except UIError as err:
-        error(err.message)
+        ui = rebench.ui or UI(False, False)
+        ui.error(err.message)
         return -1
 
 

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -93,19 +93,14 @@ class TextReporter(Reporter):
 class CliReporter(TextReporter):
     """ Reports to standard out using the logging framework """
 
-    def __init__(self, executes_verbose):
+    def __init__(self, executes_verbose, ui):
         super(CliReporter, self).__init__()
         self._num_runs = None
-        self._ui = None
+        self._ui = ui
         self._runs_completed = 0
         self._start_time = None
         self._runs_remaining = 0
         self._executes_verbose = executes_verbose
-
-    def set_ui(self, ui):
-        assert ui
-        assert not self._ui
-        self._ui = ui
 
     def run_failed(self, run_id, cmdline, return_code, cmd_output):
         pass
@@ -131,13 +126,14 @@ class CodespeedReporter(Reporter):
     to the configured Codespeed instance.
     """
 
-    def __init__(self, cfg):
+    def __init__(self, cfg, ui):
         super(CodespeedReporter, self).__init__()
         self._cfg = cfg
         self._incremental_report = self._cfg.report_incrementally
         self._cache_for_seconds = 30
         self._cache = {}
         self._last_send = time()
+        self._ui = ui
 
     def run_completed(self, run_id, statistics, cmdline):
         if not self._incremental_report:

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -81,7 +81,10 @@ class TextReporter(Reporter):
         for run_id in run_ids:
             stats = StatisticProperties(run_id.get_total_values())
             out = run_id.as_str_list()
-            out.append(stats.mean)
+            if stats.num_samples == 0:
+                out.append("Failed")
+            else:
+                out.append(stats.mean)
             rows.append(out)
 
         return rows

--- a/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
+++ b/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
@@ -20,7 +20,6 @@
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
-from ...ui                     import TestDummyUI
 
 from ..rebench_test_case import ReBenchTestCase
 
@@ -32,12 +31,12 @@ class Issue27InvalidRunNotHandled(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_execution_should_recognize_invalid_run_and_continue_normally(self):
-        cnf = Configurator(load_config(self._path + '/issue_27.conf'), DataStore(),
-                           data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_27.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
 
-        ex = Executor([runs[0]], False, False, TestDummyUI())
+        ex = Executor([runs[0]], False, False, self._ui)
         ex.execute()
 
         self.assertEqual(runs[0].get_number_of_data_points(), 0)

--- a/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
+++ b/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
@@ -20,6 +20,7 @@
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
+from ...ui                     import TestDummyUI
 
 from ..rebench_test_case import ReBenchTestCase
 
@@ -36,7 +37,7 @@ class Issue27InvalidRunNotHandled(ReBenchTestCase):
         runs = list(cnf.get_runs())
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
 
-        ex = Executor([runs[0]], False, False)
+        ex = Executor([runs[0]], False, False, TestDummyUI())
         ex.execute()
 
         self.assertEqual(runs[0].get_number_of_data_points(), 0)

--- a/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
+++ b/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
@@ -25,6 +25,7 @@ from ...model.run_id           import RunId
 from ...model.exp_run_details  import ExpRunDetails
 from ...model.virtual_machine  import VirtualMachine
 from ...persistence            import DataStore
+from ...ui                     import TestDummyUI
 
 
 class Issue4RunEquality(unittest.TestCase):
@@ -39,7 +40,7 @@ class Issue4RunEquality(unittest.TestCase):
         suite = BenchmarkSuite("MySuite", vm, '', '%(benchmark)s %(cores)s %(input)s',
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite, None,
-                              '3', ExpRunDetails.empty(), None, DataStore())
+                              '3', ExpRunDetails.empty(), None, DataStore(TestDummyUI()))
         return RunId(benchmark, 1, 2, None)
 
     @staticmethod
@@ -49,7 +50,7 @@ class Issue4RunEquality(unittest.TestCase):
         suite = BenchmarkSuite('MySuite', vm, '', '%(benchmark)s %(cores)s 2 3',
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite,
-                              None, None, ExpRunDetails.empty(), None, DataStore())
+                              None, None, ExpRunDetails.empty(), None, DataStore(TestDummyUI()))
         return RunId(benchmark, 1, None, None)
 
     def test_hardcoded_equals_template_constructed(self):

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -28,26 +28,29 @@ class ConfiguratorTest(ReBenchTestCase):
 
     def test_experiment_name_from_cli(self):
         cnf = Configurator(load_config(self._path + '/test.conf'),
-                           DataStore(), None, 'Test')
+                           DataStore(self._ui), self._ui, None, 'Test')
 
         self.assertEqual('Test', cnf.experiment_name)
 
     def test_experiment_name_from_config_file(self):
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(), None)
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
+                           self._ui, None)
         self.assertEqual('Test', cnf.experiment_name)
 
     def test_number_of_experiments_smallconf(self):
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(), None)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                           self._ui, None)
         self.assertEqual(1, len(cnf.get_experiments()))
 
     @unittest.skip
     def test_number_of_experiments_testconf(self):
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(),
-                           None, None, 'all')
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
+                           self._ui, None, None, 'all')
         self.assertEqual(6, len(cnf.get_experiments()))
 
     def test_get_experiment(self):
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(), None)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                           self._ui, None)
         exp = cnf.get_experiment('Test')
         self.assertIsNotNone(exp)
         return exp
@@ -60,39 +63,39 @@ class ConfiguratorTest(ReBenchTestCase):
     # Support for running a selected experiment
     def test_only_running_test_runner2(self):
         filter_args = ['vm:TestRunner2']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(),
-                           run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
 
     def test_only_running_bench1(self):
         filter_args = ['s:Suite:Bench1']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(),
-                           run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
 
     def test_only_running_non_existing_stuff(self):
         filter_args = ['s:non-existing', 'vm:non-existing']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(),
-                           run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(0, len(runs))
 
     def test_only_running_bench1_and_test_runner2(self):
         filter_args = ['s:Suite:Bench1', 'vm:TestRunner2']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(),
-                           run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(2, len(runs))
 
     def test_only_running_bench1_or_bench2_and_test_runner2(self):
         filter_args = ['s:Suite:Bench1', 's:Suite:Bench2', 'vm:TestRunner2']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(),
-                           run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -42,7 +42,8 @@ class ExecutorTest(ReBenchTestCase):
         subprocess.Popen = Popen_override
         options = ReBench().shell_options().parse_args(['dummy'])
 
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(), options,
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
+                           self._ui, options,
                            None, 'Test', data_file=self._tmp_file)
 
         ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
@@ -65,7 +66,7 @@ class ExecutorTest(ReBenchTestCase):
         with self.assertRaises(UIError) as err:
             options = ReBench().shell_options().parse_args(['dummy'])
             cnf = Configurator(load_config(self._path + '/test.conf'),
-                               DataStore(), options,
+                               DataStore(self._ui), self._ui, options,
                                None, 'TestBrokenCommandFormat',
                                data_file=self._tmp_file)
             ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
@@ -76,7 +77,7 @@ class ExecutorTest(ReBenchTestCase):
         with self.assertRaises(UIError) as err:
             options = ReBench().shell_options().parse_args(['dummy'])
             cnf = Configurator(load_config(self._path + '/test.conf'),
-                               DataStore(), options,
+                               DataStore(self._ui), self._ui, options,
                                None, 'TestBrokenCommandFormat2',
                                data_file=self._tmp_file)
             ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
@@ -101,13 +102,13 @@ class ExecutorTest(ReBenchTestCase):
 
     def test_basic_execution(self):
         cnf = Configurator(load_config(self._path + '/small.conf'),
-                           DataStore(), None,
+                           DataStore(self._ui), self._ui, None,
                            data_file=self._tmp_file)
         self._basic_execution(cnf)
 
     def test_basic_execution_with_magic_all(self):
         cnf = Configurator(load_config(self._path + '/small.conf'),
-                           DataStore(), None, None,
+                           DataStore(self._ui), self._ui, None, None,
                            'all', data_file=self._tmp_file)
         self._basic_execution(cnf)
 

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -27,7 +27,7 @@ from ..executor          import Executor
 from ..configurator      import Configurator, load_config
 from ..model.measurement import Measurement
 from ..persistence       import DataStore
-from ..ui import UIError
+from ..ui import UIError, TestDummyUI
 
 
 class ExecutorTest(ReBenchTestCase):
@@ -45,7 +45,7 @@ class ExecutorTest(ReBenchTestCase):
         cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(), options,
                            None, 'Test', data_file=self._tmp_file)
 
-        ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
+        ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
         ex.execute()
 
 # TODO: should test more details
@@ -68,7 +68,7 @@ class ExecutorTest(ReBenchTestCase):
                                DataStore(), options,
                                None, 'TestBrokenCommandFormat',
                                data_file=self._tmp_file)
-            ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
+            ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
             ex.execute()
         self.assertIsInstance(err.exception.source_exception, ValueError)
 
@@ -79,14 +79,14 @@ class ExecutorTest(ReBenchTestCase):
                                DataStore(), options,
                                None, 'TestBrokenCommandFormat2',
                                data_file=self._tmp_file)
-            ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
+            ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
             ex.execute()
             self.assertIsInstance(err.exception.source_exception, TypeError)
 
     def _basic_execution(self, cnf):
         runs = cnf.get_runs()
         self.assertEqual(8, len(runs))
-        ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds)
+        ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
         ex.execute()
         for run in runs:
             data_points = run.get_data_points()

--- a/rebench/tests/features/issue_15_warm_up_support_test.py
+++ b/rebench/tests/features/issue_15_warm_up_support_test.py
@@ -20,6 +20,7 @@
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
+from ...ui                     import TestDummyUI
 
 from ..rebench_test_case import ReBenchTestCase
 
@@ -52,7 +53,7 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
         self.assertEqual(runs[0].warmup_iterations, 13)
 
-        ex = Executor([runs[0]], False, False)
+        ex = Executor([runs[0]], False, False, TestDummyUI())
         ex.execute()
 
         self.assertEqual(runs[0].get_number_of_data_points(), 10)

--- a/rebench/tests/features/issue_15_warm_up_support_test.py
+++ b/rebench/tests/features/issue_15_warm_up_support_test.py
@@ -38,8 +38,8 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_run_id_indicates_warm_up_iterations_required(self):
-        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(),
-                           data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         self.assertGreaterEqual(len(runs), 1)
 
@@ -47,8 +47,8 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         self.assertGreater(runs[0].warmup_iterations, 0)
 
     def test_warm_up_results_should_be_ignored(self):
-        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(),
-                           data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
         self.assertEqual(runs[0].warmup_iterations, 13)

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -20,6 +20,7 @@
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
+from ...ui                     import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -38,7 +39,7 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
         cnf = Configurator(load_config(self._path + '/issue_16.conf'), DataStore(),
                            exp_name=exp_name,
                            data_file=self._tmp_file)
-        ex = Executor(cnf.get_runs(), False, False)
+        ex = Executor(cnf.get_runs(), False, False, TestDummyUI())
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -20,7 +20,6 @@
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
-from ...ui                     import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -36,10 +35,10 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def _records_data_points(self, exp_name, num_data_points):
-        cnf = Configurator(load_config(self._path + '/issue_16.conf'), DataStore(),
-                           exp_name=exp_name,
+        cnf = Configurator(load_config(self._path + '/issue_16.conf'), DataStore(self._ui),
+                           self._ui, exp_name=exp_name,
                            data_file=self._tmp_file)
-        ex = Executor(cnf.get_runs(), False, False, TestDummyUI())
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_19_one_data_point_test.py
+++ b/rebench/tests/features/issue_19_one_data_point_test.py
@@ -23,6 +23,7 @@ from ...configurator     import Configurator, load_config
 from ...executor         import Executor, RoundRobinScheduler
 from ...persistence      import DataStore
 from ...reporter         import Reporter
+from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -85,7 +86,7 @@ class OneMeasurementAtATime(Issue19OneDataPointAtATime):
         for run in cnf.get_runs():
             run.add_reporter(reporter)
 
-        ex = Executor(cnf.get_runs(), False, False, False, False,
+        ex = Executor(cnf.get_runs(), False, False, TestDummyUI(), False, False,
                       RoundRobinScheduler)
         ex.execute()
 

--- a/rebench/tests/features/issue_19_one_data_point_test.py
+++ b/rebench/tests/features/issue_19_one_data_point_test.py
@@ -23,7 +23,6 @@ from ...configurator     import Configurator, load_config
 from ...executor         import Executor, RoundRobinScheduler
 from ...persistence      import DataStore
 from ...reporter         import Reporter
-from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -80,13 +79,13 @@ class OneMeasurementAtATime(Issue19OneDataPointAtATime):
         self._run_count[run_id] = self._run_count.get(run_id, 0) + 1
 
     def test_one_measurement_at_a_time_and_correct_number_of_data_points(self):
-        cnf = Configurator(load_config(self._path + '/issue_19.conf'), DataStore(),
-                           data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_19.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file)
         reporter = TestReporter(self)
         for run in cnf.get_runs():
             run.add_reporter(reporter)
 
-        ex = Executor(cnf.get_runs(), False, False, TestDummyUI(), False, False,
+        ex = Executor(cnf.get_runs(), False, False, self._ui, False, False,
                       RoundRobinScheduler)
         ex.execute()
 

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
+from ...ui                     import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -38,7 +39,7 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         cnf = Configurator(load_config(self._path + '/issue_31.conf'), DataStore(),
                            exp_name=exp_name,
                            data_file=self._tmp_file)
-        ex = Executor(cnf.get_runs(), False, False)
+        ex = Executor(cnf.get_runs(), False, False, TestDummyUI())
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
-from ...ui                     import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -36,10 +35,10 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def _records_data_points(self, exp_name, num_data_points):
-        cnf = Configurator(load_config(self._path + '/issue_31.conf'), DataStore(),
-                           exp_name=exp_name,
+        cnf = Configurator(load_config(self._path + '/issue_31.conf'), DataStore(self._ui),
+                           self._ui, exp_name=exp_name,
                            data_file=self._tmp_file)
-        ex = Executor(cnf.get_runs(), False, False, TestDummyUI())
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_34_accept_faulty_runs_test.py
+++ b/rebench/tests/features/issue_34_accept_faulty_runs_test.py
@@ -21,6 +21,7 @@ from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...rebench          import ReBench
 from ...persistence      import DataStore
+from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -36,7 +37,7 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, False, False)
+        ex = Executor(runs, False, False, TestDummyUI(), False)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].benchmark.name)
@@ -62,7 +63,7 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, False, True)
+        ex = Executor(runs, False, False, TestDummyUI(), True)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].benchmark.name)

--- a/rebench/tests/features/issue_34_accept_faulty_runs_test.py
+++ b/rebench/tests/features/issue_34_accept_faulty_runs_test.py
@@ -21,7 +21,6 @@ from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...rebench          import ReBench
 from ...persistence      import DataStore
-from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -32,12 +31,12 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_faulty_runs_rejected_without_switch(self):
-        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(),
-                           data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, False, TestDummyUI(), False)
+        ex = Executor(runs, False, False, self._ui, False)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].benchmark.name)
@@ -58,12 +57,12 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         self.assertFalse(options.include_faulty)
 
     def test_faulty_runs_accepted_with_switch(self):
-        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(),
-                           data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, False, TestDummyUI(), True)
+        ex = Executor(runs, False, False, self._ui, True)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].benchmark.name)

--- a/rebench/tests/features/issue_57_binary_on_path_test.py
+++ b/rebench/tests/features/issue_57_binary_on_path_test.py
@@ -20,6 +20,7 @@
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
+from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -36,7 +37,7 @@ class Issue57BinaryOnPath(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, False, False)
+        ex = Executor(runs, False, False, TestDummyUI(), False)
         ex.execute()
 
         self.assertEqual("Bench1", runs[0].benchmark.name)

--- a/rebench/tests/features/issue_57_binary_on_path_test.py
+++ b/rebench/tests/features/issue_57_binary_on_path_test.py
@@ -20,7 +20,6 @@
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
-from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -31,13 +30,13 @@ class Issue57BinaryOnPath(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_sleep_gives_results(self):
-        store = DataStore()
+        store = DataStore(self._ui)
         cnf = Configurator(load_config(self._path + '/issue_57.conf'), store,
-                           data_file=self._tmp_file)
+                           self._ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, False, TestDummyUI(), False)
+        ex = Executor(runs, False, False, self._ui, False)
         ex.execute()
 
         self.assertEqual("Bench1", runs[0].benchmark.name)

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -23,6 +23,7 @@ import os
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
+from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -47,7 +48,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -65,7 +66,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -94,7 +95,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -117,7 +118,7 @@ class Issue58BuildVM(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
         ex.execute()
 
         os.remove(self._path + '/vm_58a.sh')

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -23,7 +23,6 @@ import os
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
-from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -43,12 +42,12 @@ class Issue58BuildVM(ReBenchTestCase):
 
     def test_build_vm_simple_cmd(self):
         self._cleanup_log()
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(),
-                           data_file=self._tmp_file, exp_name='A')
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file, exp_name='A')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
+        ex = Executor(runs, False, True, self._ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -61,12 +60,12 @@ class Issue58BuildVM(ReBenchTestCase):
     def test_build_vm_cmd_list(self):
         self._cleanup_log()
 
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(),
-                           data_file=self._tmp_file, exp_name='B')
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file, exp_name='B')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
+        ex = Executor(runs, False, True, self._ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -89,13 +88,13 @@ class Issue58BuildVM(ReBenchTestCase):
     def test_broken_build_prevents_experiments(self):
         self._cleanup_log()
 
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(),
-                           data_file=self._tmp_file,
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file,
                            exp_name='C')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
+        ex = Executor(runs, False, True, self._ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -112,13 +111,13 @@ class Issue58BuildVM(ReBenchTestCase):
 
     def test_build_is_run_only_once_for_same_command(self):
         self._cleanup_log()
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(),
-                           data_file=self._tmp_file,
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file,
                            exp_name='AandAA')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
+        ex = Executor(runs, False, True, self._ui, build_log=cnf.build_log)
         ex.execute()
 
         os.remove(self._path + '/vm_58a.sh')

--- a/rebench/tests/features/issue_59_build_suite_test.py
+++ b/rebench/tests/features/issue_59_build_suite_test.py
@@ -23,7 +23,6 @@ import os
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
-from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -34,12 +33,12 @@ class Issue59BuildSuite(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_build_suite1(self):
-        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(),
-                           data_file=self._tmp_file, exp_name='A')
+        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file, exp_name='A')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
+        ex = Executor(runs, False, True, self._ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -50,12 +49,12 @@ class Issue59BuildSuite(ReBenchTestCase):
             os.remove(self._path + '/issue_59_cnt')
 
     def test_build_suite_same_command_executed_once_only(self):
-        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(),
-                           data_file=self._tmp_file, exp_name='Test')
+        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file, exp_name='Test')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
+        ex = Executor(runs, False, True, self._ui, build_log=cnf.build_log)
         ex.execute()
 
         try:

--- a/rebench/tests/features/issue_59_build_suite_test.py
+++ b/rebench/tests/features/issue_59_build_suite_test.py
@@ -23,6 +23,7 @@ import os
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
+from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -38,7 +39,7 @@ class Issue59BuildSuite(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -54,7 +55,7 @@ class Issue59BuildSuite(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
         ex.execute()
 
         try:

--- a/rebench/tests/features/issue_81_unicode_test.py
+++ b/rebench/tests/features/issue_81_unicode_test.py
@@ -25,6 +25,7 @@ from codecs import open as open_with_enc
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
+from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -42,7 +43,7 @@ class Issue81UnicodeSuite(ReBenchTestCase):
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, build_log=cnf.build_log)
+        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
         ex.execute()
 
         self.assertEqual("Bench1", runs[0].benchmark.name)

--- a/rebench/tests/features/issue_81_unicode_test.py
+++ b/rebench/tests/features/issue_81_unicode_test.py
@@ -25,7 +25,6 @@ from codecs import open as open_with_enc
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
-from ...ui               import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -38,12 +37,12 @@ class Issue81UnicodeSuite(ReBenchTestCase):
             os.remove(self._path + '/build.log')
 
     def test_building(self):
-        cnf = Configurator(load_config(self._path + '/issue_81.conf'), DataStore(),
-                           data_file=self._tmp_file, exp_name='Test')
+        cnf = Configurator(load_config(self._path + '/issue_81.conf'), DataStore(self._ui),
+                           self._ui, data_file=self._tmp_file, exp_name='Test')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, True, TestDummyUI(), build_log=cnf.build_log)
+        ex = Executor(runs, False, True, self._ui, build_log=cnf.build_log)
         ex.execute()
 
         self.assertEqual("Bench1", runs[0].benchmark.name)

--- a/rebench/tests/model/runs_config_test.py
+++ b/rebench/tests/model/runs_config_test.py
@@ -20,7 +20,6 @@
 from ...model.termination_check import TerminationCheck
 from ...configurator import Configurator, load_config
 from ...persistence  import DataStore
-from ...ui import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -28,13 +27,14 @@ class RunsConfigTestCase(ReBenchTestCase):
 
     def setUp(self):
         super(RunsConfigTestCase, self).setUp()
-        self._cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(), None,
+        self._cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
+                                 self._ui, None,
                                  data_file=self._tmp_file)
         runs = self._cnf.get_runs()
         self._run = list(runs)[0]
 
     def test_termination_check_basic(self):
-        check = TerminationCheck(self._run, TestDummyUI())
+        check = TerminationCheck(self._run, self._ui)
         self.assertFalse(check.should_terminate(0))
 
         # start 9 times, but expect to be done only after 10
@@ -46,13 +46,13 @@ class RunsConfigTestCase(ReBenchTestCase):
         self.assertTrue(check.should_terminate(0))
 
     def test_terminate_not_determine_by_number_of_data_points(self):
-        check = TerminationCheck(self._run, TestDummyUI())
+        check = TerminationCheck(self._run, self._ui)
         self.assertFalse(check.should_terminate(0))
         self.assertFalse(check.should_terminate(10))
         self.assertFalse(check.should_terminate(10000))
 
     def test_consecutive_fails(self):
-        check = TerminationCheck(self._run, TestDummyUI())
+        check = TerminationCheck(self._run, self._ui)
         self.assertFalse(check.should_terminate(0))
 
         for _ in range(0, 2):
@@ -63,7 +63,7 @@ class RunsConfigTestCase(ReBenchTestCase):
         self.assertTrue(check.should_terminate(0))
 
     def test_too_many_fails(self):
-        check = TerminationCheck(self._run, TestDummyUI())
+        check = TerminationCheck(self._run, self._ui)
         self.assertFalse(check.should_terminate(0))
 
         for _ in range(0, 6):

--- a/rebench/tests/model/runs_config_test.py
+++ b/rebench/tests/model/runs_config_test.py
@@ -20,6 +20,7 @@
 from ...model.termination_check import TerminationCheck
 from ...configurator import Configurator, load_config
 from ...persistence  import DataStore
+from ...ui import TestDummyUI
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -33,7 +34,7 @@ class RunsConfigTestCase(ReBenchTestCase):
         self._run = list(runs)[0]
 
     def test_termination_check_basic(self):
-        check = TerminationCheck(self._run.benchmark)
+        check = TerminationCheck(self._run, TestDummyUI())
         self.assertFalse(check.should_terminate(0))
 
         # start 9 times, but expect to be done only after 10
@@ -45,13 +46,13 @@ class RunsConfigTestCase(ReBenchTestCase):
         self.assertTrue(check.should_terminate(0))
 
     def test_terminate_not_determine_by_number_of_data_points(self):
-        check = TerminationCheck(self._run.benchmark)
+        check = TerminationCheck(self._run, TestDummyUI())
         self.assertFalse(check.should_terminate(0))
         self.assertFalse(check.should_terminate(10))
         self.assertFalse(check.should_terminate(10000))
 
     def test_consecutive_fails(self):
-        check = TerminationCheck(self._run.benchmark)
+        check = TerminationCheck(self._run, TestDummyUI())
         self.assertFalse(check.should_terminate(0))
 
         for _ in range(0, 2):
@@ -62,7 +63,7 @@ class RunsConfigTestCase(ReBenchTestCase):
         self.assertTrue(check.should_terminate(0))
 
     def test_too_many_fails(self):
-        check = TerminationCheck(self._run.benchmark)
+        check = TerminationCheck(self._run, TestDummyUI())
         self.assertFalse(check.should_terminate(0))
 
         for _ in range(0, 6):

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -34,7 +34,7 @@ from ..model.virtual_machine  import VirtualMachine
 class PersistencyTest(ReBenchTestCase):
 
     def test_de_serialization(self):
-        data_store = DataStore()
+        data_store = DataStore(self._ui)
         vm = VirtualMachine("MyVM", '', '',
                             None, None, None, None, None)
         suite = BenchmarkSuite("MySuite", vm, '', '', None, None,

--- a/rebench/tests/rebench_test_case.py
+++ b/rebench/tests/rebench_test_case.py
@@ -24,6 +24,7 @@ from os.path  import dirname, realpath
 import sys
 from unittest import TestCase
 from tempfile import mkstemp
+from ..ui  import TestDummyUI
 
 
 class ReBenchTestCase(TestCase):
@@ -31,6 +32,7 @@ class ReBenchTestCase(TestCase):
     def _set_path(self, path):
         self._path = dirname(realpath(path))
         os.chdir(self._path)
+        self._ui = TestDummyUI()
 
     def setUp(self):
         logging.getLogger('pykwalify').addHandler(logging.NullHandler())

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -28,15 +28,19 @@ _DETAIL_INDENT = "    "
 
 class UI(object):
 
-    def __init__(self, verbose, debug):
-        self._verbose = verbose
-        self._debug = debug
+    def __init__(self):
+        self._verbose = True
+        self._debug = True
 
         self._prev_run_id = None
         self._prev_cmd = None
         self._prev_cwd = None
         self._progress_spinner = None
         self._need_to_erase_spinner = False
+
+    def init(self, verbose, debug):
+        self._verbose = verbose
+        self._debug = debug
 
     def spinner_initialized(self):
         return self._progress_spinner is not None
@@ -147,6 +151,9 @@ class UIError(Exception):
 
 
 class TestDummyUI(object):
+
+    def init(self, _verbose, _debug):
+        pass
 
     def spinner_initialized(self):
         pass


### PR DESCRIPTION
- restructure UI to avoid redundant output, by being able to know what has been printed last
- interact with spinner, to avoid over-writing output
- failing runs indicate run id, command
- low mean errors indicate run id, command