### PR TITLE
Add proper support for invocation/iteration

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -158,7 +158,9 @@ class Configurator(object):
         self._exp_name = exp_name or raw_config.get('standard_experiment', 'all')
 
         self._root_run_details = ExpRunDetails.compile(
-            raw_config.get('runs', {}), ExpRunDetails.default())
+            raw_config.get('runs', {}), ExpRunDetails.default(
+                cli_options.invocations if cli_options else 1,
+                cli_options.iterations if cli_options else 1))
         self._root_reporting = Reporting.compile(
             raw_config.get('reporting', {}), Reporting.empty(cli_reporter), cli_options, ui)
 

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -25,7 +25,7 @@ from .model.exp_run_details import ExpRunDetails
 from .model.exp_variables import ExpVariables
 from .model.reporting import Reporting
 from .model.virtual_machine import VirtualMachine
-from .ui import UIError
+from .ui import UIError, escape_braces
 
 
 class _VMFilter(object):
@@ -130,9 +130,10 @@ def load_config(file_name):
             try:
                 validator.validate(raise_exception=True)
             except SchemaError as err:
+                errors = [escape_braces(val_err) for val_err in validator.validation_errors]
                 raise UIError(
                     "Validation of " + file_name + " failed.\n{ind}" +
-                    "{ind}".join(validator.validation_errors) + "\n", err)
+                    "\n{ind}".join(errors) + "\n", err)
             return data
     except IOError as err:
         if err.errno == 2:

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -157,10 +157,16 @@ class Configurator(object):
         self._data_file = data_file or raw_config.get('standard_data_file', 'rebench.data')
         self._exp_name = exp_name or raw_config.get('standard_experiment', 'all')
 
+        # capture invocation and iteration settings and override when quick is selected
+        invocations = cli_options.invocations if cli_options else None
+        iterations = cli_options.iterations if cli_options else None
+        if cli_options and cli_options.quick:
+            invocations = 1
+            iterations = 1
+
         self._root_run_details = ExpRunDetails.compile(
             raw_config.get('runs', {}), ExpRunDetails.default(
-                cli_options.invocations if cli_options else 1,
-                cli_options.iterations if cli_options else 1))
+                invocations, iterations))
         self._root_reporting = Reporting.compile(
             raw_config.get('reporting', {}), Reporting.empty(cli_reporter), cli_options, ui)
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -456,7 +456,6 @@ class Executor(object):
     def _generate_data_point(self, cmdline, gauge_adapter, run_id,
                              termination_check):
         # execute the external program here
-        run_id.indicate_invocation_start()
 
         try:
             self._ui.debug_output_info("{ind}Starting run\n", run_id, cmdline)
@@ -506,7 +505,7 @@ class Executor(object):
 
     def _eval_output(self, output, run_id, gauge_adapter, cmdline):
         try:
-            data_points = gauge_adapter.parse_data(output, run_id)
+            data_points = gauge_adapter.parse_data(output, run_id, run_id.completed_invocations + 1)
 
             warmup = run_id.warmup_iterations
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -416,14 +416,12 @@ class Executor(object):
         if not terminate and self._do_builds:
             self._build_vm_and_suite(run_id)
 
-        stats = StatisticProperties(run_id.get_total_values())
-
         # now start the actual execution
         if not terminate:
             terminate = self._generate_data_point(cmdline, gauge_adapter,
                                                   run_id, termination_check)
-            stats = StatisticProperties(run_id.get_total_values())
 
+        stats = StatisticProperties(run_id.get_total_values())
         if terminate:
             run_id.report_run_completed(stats, cmdline)
             if (not run_id.is_failed() and run_id.min_iteration_time

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -430,7 +430,7 @@ class Executor(object):
                     and stats.mean < run_id.min_iteration_time):
                 self._ui.warning(
                     ("{ind}Warning: Low mean run time.\n"
-                     + "{ind}{ind}The mean (%.1f) is lower than min_iteration_time (%d)")
+                     + "{ind}{ind}The mean (%.1f) is lower than min_iteration_time (%d)\n")
                     % (stats.mean, run_id.min_iteration_time), run_id, cmdline)
 
         return terminate

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -541,13 +541,17 @@ class Executor(object):
             run_id.get_number_of_data_points())
 
     def execute(self):
-        self._scheduler.execute()
-        successful = True
-        for run in self._runs:
-            run.report_job_completed(self._runs)
-            if run.is_failed():
-                successful = False
-        return successful
+        try:
+            self._scheduler.execute()
+            successful = True
+            for run in self._runs:
+                run.report_job_completed(self._runs)
+                if run.is_failed():
+                    successful = False
+            return successful
+        finally:
+            for run in self._runs:
+                run.close_files()
 
     @property
     def runs(self):

--- a/rebench/interop/adapter.py
+++ b/rebench/interop/adapter.py
@@ -38,7 +38,7 @@ class GaugeAdapter(object):
     def acquire_command(self, command):
         return command
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, invocation):
         raise NotImplementedError()
 
     def check_for_error(self, line):

--- a/rebench/interop/jmh_adapter.py
+++ b/rebench/interop/jmh_adapter.py
@@ -33,7 +33,8 @@ class JMHAdapter(GaugeAdapter):
     re_result_line = re.compile(r"^Iteration\s+(\d+):\s+(\d+(?:\.\d+)?)\s+(.+)")
     re_bench = re.compile(r"^# Benchmark: (.+)")
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, invocation):
+        iteration = 1
         data_points = []
 
         for line in data.split("\n"):
@@ -60,8 +61,10 @@ class JMHAdapter(GaugeAdapter):
                 criterion = "total"
 
                 point = DataPoint(run_id)
-                point.add_measurement(Measurement(value, unit, run_id, criterion))
+                point.add_measurement(Measurement(invocation, iteration,
+                                                  value, unit, run_id, criterion))
                 data_points.append(point)
+                iteration += 1
 
         if not data_points:
             raise OutputNotParseable(data)

--- a/rebench/interop/multivariate_adapter.py
+++ b/rebench/interop/multivariate_adapter.py
@@ -37,7 +37,8 @@ class MultivariateAdapter(GaugeAdapter):
         super(MultivariateAdapter, self).__init__(include_faulty)
         self._other_error_definitions = [re.compile("FAILED")]
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, invocation):
+        iteration = 1
         data_points = []
         current = DataPoint(run_id)
 
@@ -63,7 +64,8 @@ class MultivariateAdapter(GaugeAdapter):
                 else:
                     value = float(value_thing)
 
-                measure = Measurement(value, unit if unit is not None else 'ms',
+                measure = Measurement(invocation, iteration, value,
+                                      unit if unit is not None else 'ms',
                                       run_id, variable)
                 current.add_measurement(measure)
 
@@ -71,6 +73,7 @@ class MultivariateAdapter(GaugeAdapter):
                     # compatibility for TestVMPerformance
                     data_points.append(current)
                     current = DataPoint(run_id)
+                    iteration += 1
 
         if not data_points:
             raise OutputNotParseable(data)

--- a/rebench/interop/plain_seconds_log_adapter.py
+++ b/rebench/interop/plain_seconds_log_adapter.py
@@ -41,7 +41,8 @@ class PlainSecondsLogAdapter(GaugeAdapter):
                                          self.re_NPB_invalid, self.re_incorrect,
                                          self.re_err]
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, invocation):
+        iteration = 1
         data_points = []
         current = DataPoint(run_id)
 
@@ -52,11 +53,12 @@ class PlainSecondsLogAdapter(GaugeAdapter):
 
             try:
                 time = float(line) * 1000
-                measure = Measurement(time, 'ms', run_id, 'total')
+                measure = Measurement(invocation, iteration, time, 'ms', run_id, 'total')
                 current.add_measurement(measure)
 
                 data_points.append(current)
                 current = DataPoint(run_id)
+                iteration += 1
             except ValueError:
                 pass  # ignore that line
 

--- a/rebench/interop/rebench_log_adapter.py
+++ b/rebench/interop/rebench_log_adapter.py
@@ -45,7 +45,8 @@ class RebenchLogAdapter(GaugeAdapter):
         self._other_error_definitions = [self.re_NPB_partial_invalid,
                                          self.re_NPB_invalid, self.re_incorrect]
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, invocation):
+        iteration = 1
         data_points = []
         current = DataPoint(run_id)
 
@@ -62,7 +63,7 @@ class RebenchLogAdapter(GaugeAdapter):
                     time /= 1000
                 criterion = (match.group(2) or 'total').strip()
 
-                measure = Measurement(time, 'ms', run_id, criterion)
+                measure = Measurement(invocation, iteration, time, 'ms', run_id, criterion)
 
             else:
                 match = self.re_extra_criterion_log_line.match(line)
@@ -71,7 +72,7 @@ class RebenchLogAdapter(GaugeAdapter):
                     criterion = match.group(2)
                     unit = match.group(4)
 
-                    measure = Measurement(value, unit, run_id, criterion)
+                    measure = Measurement(invocation, iteration, value, unit, run_id, criterion)
 
             if measure:
                 current.add_measurement(measure)
@@ -79,6 +80,7 @@ class RebenchLogAdapter(GaugeAdapter):
                 if measure.is_total():
                     data_points.append(current)
                     current = DataPoint(run_id)
+                    iteration += 1
 
         if not data_points:
             raise OutputNotParseable(data)

--- a/rebench/interop/savina_log_adapter.py
+++ b/rebench/interop/savina_log_adapter.py
@@ -30,17 +30,19 @@ class SavinaLogAdapter(GaugeAdapter):
     re_log_line = re.compile(
         r"^([\w\.]+)\s+Iteration-(?:\d+):\s+([0-9]+\.[0-9]+) ms")
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, invocation):
+        iteration = 1
         data_points = []
 
         for line in data.split("\n"):
             match = self.re_log_line.match(line)
             if match:
                 time = float(match.group(2))
-                measure = Measurement(time, 'ms', run_id, 'total')
+                measure = Measurement(invocation, iteration, time, 'ms', run_id, 'total')
                 current = DataPoint(run_id)
                 current.add_measurement(measure)
                 data_points.append(current)
+                iteration += 1
 
         if not data_points:
             raise OutputNotParseable(data)

--- a/rebench/interop/test_adapter.py
+++ b/rebench/interop/test_adapter.py
@@ -32,9 +32,9 @@ class TestAdapter(GaugeAdapter):
                  45875, 45871, 45869, 45870, 45874]
     index = 0
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, _invocation):
         point = DataPoint(run_id)
-        point.add_measurement(Measurement(self.test_data[self.index], "ms",
+        point.add_measurement(Measurement(1, 1, self.test_data[self.index], "ms",
                                           run_id))
         self.index = (self.index + 1) % len(self.test_data)
         return [point]

--- a/rebench/interop/test_vm_adapter.py
+++ b/rebench/interop/test_vm_adapter.py
@@ -35,7 +35,8 @@ class TestVMAdapter(GaugeAdapter):
         super(TestVMAdapter, self).__init__(include_faulty)
         self._other_error_definitions = [re.compile("FAILED")]
 
-    def parse_data(self, data, run_id):
+    def parse_data(self, data, run_id, invocation):
+        iteration = 1
         data_points = []
         current = DataPoint(run_id)
 
@@ -46,13 +47,15 @@ class TestVMAdapter(GaugeAdapter):
 
             match = TestVMAdapter.re_time.match(line)
             if match:
-                measure = Measurement(float(match.group(2)), 'ms', run_id,
+                measure = Measurement(invocation, iteration,
+                                      float(match.group(2)), 'ms', run_id,
                                       match.group(1))
                 current.add_measurement(measure)
 
                 if measure.is_total():
                     data_points.append(current)
                     current = DataPoint(run_id)
+                    iteration += 1
 
         if not data_points:
             raise OutputNotParseable(data)

--- a/rebench/model/data_point.py
+++ b/rebench/model/data_point.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from ..ui import UIError
 
 
 class DataPoint(object):
@@ -24,11 +25,23 @@ class DataPoint(object):
         self._run_id = run_id
         self._measurements = []
         self._total = None
+        self._invocation = -1
+
+    @property
+    def invocation(self):
+        return self._invocation
 
     def number_of_measurements(self):
         return len(self._measurements)
 
     def add_measurement(self, measurement):
+        if self._invocation == -1:
+            self._invocation = measurement.invocation
+        elif self._invocation != measurement.invocation:
+            raise UIError("A data point is expected to represent a single invocation " +
+                          "but we got invocation " + str(measurement.invocation) +
+                          " and " + str(self._invocation) + "\n", None)
+
         self._measurements.append(measurement)
         if measurement.is_total():
             if self._total is not None:

--- a/rebench/model/exp_run_details.py
+++ b/rebench/model/exp_run_details.py
@@ -39,18 +39,21 @@ class ExpRunDetails(object):
                                                       defaults.execute_exclusively))
 
         return ExpRunDetails(invocations, iterations, warmup, min_iteration_time,
-                             max_invocation_time, parallel_interference_factor, execute_exclusively)
+                             max_invocation_time, parallel_interference_factor, execute_exclusively,
+                             defaults.invocations_override, defaults.iterations_override)
 
     @classmethod
     def empty(cls):
-        return ExpRunDetails(None, None, None, None, None, None, None)
+        return ExpRunDetails(None, None, None, None, None, None, None, None, None)
 
     @classmethod
-    def default(cls):
-        return ExpRunDetails(1, 1, None, 50, -1, None, True)
+    def default(cls, invocations_override, iterations_override):
+        return ExpRunDetails(1, 1, None, 50, -1, None, True,
+                             invocations_override, iterations_override)
 
     def __init__(self, invocations, iterations, warmup, min_iteration_time,
-                 max_invocation_time, parallel_interference_factor, execute_exclusively):
+                 max_invocation_time, parallel_interference_factor, execute_exclusively,
+                 invocations_override, iterations_override):
         self._invocations = invocations
         self._iterations = iterations
         self._warmup = warmup
@@ -60,6 +63,9 @@ class ExpRunDetails(object):
         self._parallel_interference_factor = parallel_interference_factor
         self._execute_exclusively = execute_exclusively
 
+        self._invocations_override = invocations_override
+        self._iterations_override = iterations_override
+
     @property
     def invocations(self):
         return self._invocations
@@ -67,6 +73,14 @@ class ExpRunDetails(object):
     @property
     def iterations(self):
         return self._iterations
+
+    @property
+    def invocations_override(self):
+        return self._invocations_override
+
+    @property
+    def iterations_override(self):
+        return self._iterations_override
 
     @property
     def warmup(self):

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -54,11 +54,17 @@ class RunId(object):
 
     @property
     def iterations(self):
-        return self._benchmark.run_details.iterations
+        run_details = self._benchmark.run_details
+        if run_details.iterations_override is not None:
+            return run_details.iterations_override
+        return run_details.iterations
 
     @property
     def invocations(self):
-        return self._benchmark.run_details.invocations
+        run_details = self._benchmark.run_details
+        if run_details.invocations_override is not None:
+            return run_details.invocations_override
+        return run_details.invocations
 
     @property
     def execute_exclusively(self):
@@ -197,9 +203,10 @@ class RunId(object):
     def _expand_vars(self, string):
         try:
             return string % {'benchmark': self._benchmark.command,
-                             'input': self._input_size,
-                             'variable': self._var_value,
                              'cores': self._cores,
+                             'input': self._input_size,
+                             'iterations': self.iterations,
+                             'variable': self._var_value,
                              'warmup': self._benchmark.run_details.warmup}
         except ValueError as err:
             self._report_format_issue_and_exit(string, err)

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -155,6 +155,10 @@ class RunId(object):
     def add_persistence(self, persistence):
         self._persistence.add(persistence)
 
+    def close_files(self):
+        for persistence in self._persistence:
+            persistence.close()
+
     def loaded_data_point(self, data_point):
         self._max_invocation = max(self._max_invocation, data_point.invocation)
         self._data_points.append(data_point)

--- a/rebench/model/termination_check.py
+++ b/rebench/model/termination_check.py
@@ -23,16 +23,12 @@ class TerminationCheck(object):
     def __init__(self, run_id, ui):
         self._run_id = run_id
         self._ui = ui
-        self._num_invocations = 0
         self._consecutive_erroneous_executions = 0
         self._failed_execution_count = 0
         self._fail_immediately = False
 
     def fail_immediately(self):
         self._fail_immediately = True
-
-    def indicate_invocation_start(self):
-        self._num_invocations += 1
 
     def indicate_failed_execution(self):
         self._consecutive_erroneous_executions += 1
@@ -62,7 +58,7 @@ class TerminationCheck(object):
             self._ui.verbose_error_info(
                 "{ind}Many runs are failing, benchmark is aborted.\n", self._run_id)
             return True
-        elif self._num_invocations >= self._run_id.benchmark.run_details.invocations:
+        elif self._run_id.completed_invocations >= self._run_id.benchmark.run_details.invocations:
             return True
         else:
             return False

--- a/rebench/model/termination_check.py
+++ b/rebench/model/termination_check.py
@@ -58,7 +58,7 @@ class TerminationCheck(object):
             self._ui.verbose_error_info(
                 "{ind}Many runs are failing, benchmark is aborted.\n", self._run_id)
             return True
-        elif self._run_id.completed_invocations >= self._run_id.benchmark.run_details.invocations:
+        elif self._run_id.completed_invocations >= self._run_id.invocations:
             return True
         else:
             return False

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -238,3 +238,8 @@ class _DataPointPersistence(object):
     def _open_file_to_add_new_data(self):
         if not self._file:
             self._file = open(self._data_filename, 'a+')
+
+    def close(self):
+        if self._file:
+            self._file.close()
+            self._file = None

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -188,7 +188,7 @@ class _DataPointPersistence(object):
                 msg = str(err)
                 if not errors:
                     self._ui.debug_error_info("Failed loading data from data file: "
-                                              + data_file + "\n")
+                                              + self._data_filename + "\n")
                 if msg not in errors:
                     # Configuration is not available, skip data point
                     self._ui.debug_error_info("{ind}" + msg + "\n")

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -88,9 +88,16 @@ Argument:
         execution = parser.add_argument_group(
             'Execution Options', 'Adapt how ReBench executes benchmarks')
         execution.add_argument(
+            '-in', '--invocations', action='store', dest='invocations',
+            help='The number of times a VM is started to execute a run.',
+            default=None)
+        execution.add_argument(
+            '-it', '--iterations', action='store', dest='iterations',
+            help='The number of times a benchmark is to be executed within a VM invocation.',
+            default=None)
+        execution.add_argument(
             '-q', '--quick', action='store_true', dest='quick',
-            help='Do a quick benchmark run instead of a full, '
-                 'statistical rigorous experiment.',
+            help='Execute quickly. Identical with --iterations=1 --invocations=1',
             default=False)
         execution.add_argument(
             '-N', '--without-nice', action='store_false', dest='use_nice',

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -90,11 +90,11 @@ Argument:
         execution.add_argument(
             '-in', '--invocations', action='store', dest='invocations',
             help='The number of times a VM is started to execute a run.',
-            default=None)
+            default=None, type=int)
         execution.add_argument(
             '-it', '--iterations', action='store', dest='iterations',
             help='The number of times a benchmark is to be executed within a VM invocation.',
-            default=None)
+            default=None, type=int)
         execution.add_argument(
             '-q', '--quick', action='store_true', dest='quick',
             help='Execute quickly. Identical with --iterations=1 --invocations=1',

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -225,7 +225,7 @@ def main_func():
         rebench = ReBench()
         return 0 if rebench.run() else -1
     except KeyboardInterrupt:
-        rebench.ui.debug_error_info("Aborted by user request")
+        rebench.ui.debug_error_info("Aborted by user request\n")
         return -1
     except UIError as err:
         rebench.ui.error(err.message)

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -197,7 +197,6 @@ Argument:
             self._config = Configurator(config, data_store, self._ui, args,
                                         cli_reporter, exp_name, args.data_file,
                                         args.build_log, exp_filter)
-            #TODO how to set ui on codespeed reporter?
         except ConfigurationError as exc:
             raise UIError(exc.message + "\n", exc)
 

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -81,10 +81,11 @@ class TextReporter(Reporter):
         for run_id in run_ids:
             stats = StatisticProperties(run_id.get_total_values())
             out = run_id.as_str_list()
+            out.append(stats.num_samples)
             if stats.num_samples == 0:
                 out.append("Failed")
             else:
-                out.append(stats.mean)
+                out.append(int(round(stats.mean, 0)))
             rows.append(out)
 
         return rows
@@ -112,7 +113,7 @@ class CliReporter(TextReporter):
     def report_job_completed(self, run_ids):
         self._ui.output("\n\n" + format_pretty_table(
             self._generate_all_output(run_ids),
-            ['Benchmark', 'VM', 'Suite', 'Extra', 'Core', 'Size', 'Var', 'Mean'],
+            ['Benchmark', 'VM', 'Suite', 'Extra', 'Core', 'Size', 'Var', '#Samples', 'Mean (ms)'],
             vertical_bar=' '))
 
     def set_total_number_of_runs(self, num_runs):

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -117,6 +117,23 @@ class ExecutorTest(ReBenchTestCase):
                            'all', data_file=self._tmp_file)
         self._basic_execution(cnf)
 
+    def test_execution_with_quick_set(self):
+        self._set_path(__file__)
+        option_parser = ReBench().shell_options()
+        cmd_config = option_parser.parse_args(['-q', 'persistency.conf'])
+        self.assertTrue(cmd_config.quick)
+
+        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
+                           self._ui, cmd_config, data_file=self._tmp_file)
+        runs = cnf.get_runs()
+        self.assertEqual(1, len(runs))
+
+        ex = Executor(runs, False, False, self._ui)
+        ex.execute()
+        run = list(runs)[0]
+
+        self.assertEqual(1, run.get_number_of_data_points())
+
     def test_shell_options_without_filters(self):
         option_parser = ReBench().shell_options()
         args = option_parser.parse_args(['-d', '-v', 'some.conf'])

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -134,6 +134,24 @@ class ExecutorTest(ReBenchTestCase):
 
         self.assertEqual(1, run.get_number_of_data_points())
 
+    def test_execution_with_invocation_and_iteration_set(self):
+        self._set_path(__file__)
+        option_parser = ReBench().shell_options()
+        cmd_config = option_parser.parse_args(['-in=2', '-it=2', 'persistency.conf'])
+        self.assertEqual(2, cmd_config.invocations)
+        self.assertEqual(2, cmd_config.iterations)
+
+        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
+                           self._ui, cmd_config, data_file=self._tmp_file)
+        runs = cnf.get_runs()
+        self.assertEqual(1, len(runs))
+
+        ex = Executor(runs, False, False, self._ui)
+        ex.execute()
+        run = list(runs)[0]
+
+        self.assertEqual(2, run.get_number_of_data_points())
+
     def test_shell_options_without_filters(self):
         option_parser = ReBench().shell_options()
         args = option_parser.parse_args(['-d', '-v', 'some.conf'])

--- a/rebench/tests/features/issue_32_jmh_support_test.py
+++ b/rebench/tests/features/issue_32_jmh_support_test.py
@@ -35,7 +35,7 @@ class Issue32JMHSupport(TestCase):
 
     def test_parsing(self):
         adapter = JMHAdapter(False)
-        data_points = adapter.parse_data(self._data, None)
+        data_points = adapter.parse_data(self._data, None, 1)
 
         self.assertEqual(4 * 20, len(data_points))
 

--- a/rebench/tests/interop/plain_seconds_log_adapter_test.py
+++ b/rebench/tests/interop/plain_seconds_log_adapter_test.py
@@ -35,7 +35,7 @@ class PlainSecondsAdapterTest(TestCase):
 50
 1"""
         adapter = PlainSecondsLogAdapter(False)
-        data = adapter.parse_data(data, None)
+        data = adapter.parse_data(data, None, 2)
         self.assertEqual(3, len(data))
 
         self.assertEqual(1, len(data[0].get_measurements()))
@@ -49,4 +49,4 @@ class PlainSecondsAdapterTest(TestCase):
 
     def test_parse_no_data(self):
         adapter = PlainSecondsLogAdapter(False)
-        self.assertRaises(OutputNotParseable, adapter.parse_data, "", None)
+        self.assertRaises(OutputNotParseable, adapter.parse_data, "", None, 1)

--- a/rebench/tests/interop/rebench_log_adapter_test.py
+++ b/rebench/tests/interop/rebench_log_adapter_test.py
@@ -38,32 +38,32 @@ class RebenchAdapterTest(TestCase):
 
     def test_simple_name(self):
         adapter = RebenchLogAdapter(True)
-        data = adapter.parse_data("Dispatch: iterations=1 runtime: 557ms", None)
+        data = adapter.parse_data("Dispatch: iterations=1 runtime: 557ms", None, 1)
         self._assert_basics(data, 557, 'ms', 'total', True)
 
     def test_doted_name(self):
         adapter = RebenchLogAdapter(True)
         data = adapter.parse_data(
-            "LanguageFeatures.Dispatch: iterations=1 runtime: 309557us", None)
+            "LanguageFeatures.Dispatch: iterations=1 runtime: 309557us", None, 1)
         self._assert_basics(data, 309.557, 'ms', 'total', True)
 
     def test_doted_and_ms(self):
         adapter = RebenchLogAdapter(True)
         data = adapter.parse_data(
-            "LanguageFeatures.Dispatch: iterations=1 runtime: 557ms", None)
+            "LanguageFeatures.Dispatch: iterations=1 runtime: 557ms", None, 1)
         self._assert_basics(data, 557, 'ms', 'total', True)
 
     def test_high_iter_count(self):
         adapter = RebenchLogAdapter(True)
         data = adapter.parse_data(
-            "LanguageFeatures.Dispatch: iterations=2342 runtime: 557ms", None)
+            "LanguageFeatures.Dispatch: iterations=2342 runtime: 557ms", None, 1)
         self._assert_basics(data, 557, 'ms', 'total', True)
 
     def test_total_explicit(self):
         adapter = RebenchLogAdapter(True)
         data = adapter.parse_data(
             "LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms",
-            None)
+            None, 1)
         self._assert_basics(data, 557, 'ms', 'total', True)
 
     def test_alloc_criterion(self):
@@ -71,7 +71,7 @@ class RebenchAdapterTest(TestCase):
         data = adapter.parse_data(
             """LanguageFeatures.Dispatch alloc: iterations=2342 runtime: 222ms
 LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms""",
-            None)
+            None, 3)
         self._assert_two_measures(data, 222, 'ms', 'alloc', 557, 'ms')
 
     def test_foobar_criterion(self):
@@ -79,7 +79,7 @@ LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms""",
         data = adapter.parse_data(
             """LanguageFeatures.Dispatch foobar: iterations=2342 runtime: 550ms
 LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms""",
-            None)
+            None, 5)
         self._assert_two_measures(data, 550, 'ms', 'foobar', 557, 'ms')
 
     def test_foobar_criterion_no_doted_name(self):
@@ -87,21 +87,21 @@ LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms""",
         data = adapter.parse_data(
             """Dispatch foobar: iterations=2342 runtime: 550ms
 LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms""",
-            None)
+            None, 7)
         self._assert_two_measures(data, 550, 'ms', 'foobar', 557, 'ms')
 
     def test_some_prefix_before_data(self):
         adapter = RebenchLogAdapter(True)
         data = adapter.parse_data(
             "some prefix: Dispatch: iterations=2342 runtime: 557ms",
-            None)
+            None, 11)
         self._assert_basics(data, 557, 'ms', 'total', True)
 
     def test_path_as_name(self):
         adapter = RebenchLogAdapter(True)
         data = adapter.parse_data(
             "core-lib/Benchmarks/Join/FibSeq.ns: iterations=1 runtime: 129us",
-            None)
+            None, 12)
         self._assert_basics(data, 0.129, 'ms', 'total', True)
 
     def test_other_data(self):
@@ -111,7 +111,7 @@ Savina.Chameneos: external data: 40byte
 Savina.Chameneos: iterations=1 runtime: 64208us
 Savina.Chameneos: trace size:    3903414byte
 Savina.Chameneos: external data: 40byte
-Savina.Chameneos: iterations=1 runtime: 48581us""", None)
+Savina.Chameneos: iterations=1 runtime: 48581us""", None, 13)
 
         self.assertEqual(2, len(data))
         point = data[0]

--- a/rebench/tests/interop/time_adapter_test.py
+++ b/rebench/tests/interop/time_adapter_test.py
@@ -35,7 +35,7 @@ class TimeAdapterTest(TestCase):
 user         5.00
 sys          1.00"""
         adapter = TimeAdapter(False)
-        data = adapter.parse_data(data, None)
+        data = adapter.parse_data(data, None, 1)
         self.assertEqual(1, len(data))
 
         measurements = data[0].get_measurements()
@@ -44,7 +44,7 @@ sys          1.00"""
 
     def test_parse_no_data(self):
         adapter = TimeAdapter(False)
-        self.assertRaises(OutputNotParseable, adapter.parse_data, "", None)
+        self.assertRaises(OutputNotParseable, adapter.parse_data, "", None, 1)
 
     def test_manual_adapter(self):
         adapter = TimeManualAdapter(False)

--- a/rebench/tests/model/runs_config_test.py
+++ b/rebench/tests/model/runs_config_test.py
@@ -17,6 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from ...model.data_point import DataPoint
+from ...model.measurement import Measurement
 from ...model.termination_check import TerminationCheck
 from ...configurator import Configurator, load_config
 from ...persistence  import DataStore
@@ -38,11 +40,15 @@ class RunsConfigTestCase(ReBenchTestCase):
         self.assertFalse(check.should_terminate(0))
 
         # start 9 times, but expect to be done only after 10
-        for _ in range(0, 9):
-            check.indicate_invocation_start()
+        for i in range(1, 10):
+            dp = DataPoint(self._run)
+            dp.add_measurement(Measurement(i, 1, 0, 'ms', self._run))
+            self._run.loaded_data_point(dp)
         self.assertFalse(check.should_terminate(0))
 
-        check.indicate_invocation_start()
+        dp = DataPoint(self._run)
+        dp.add_measurement(Measurement(10, 1, 0, 'ms', self._run))
+        self._run.loaded_data_point(dp)
         self.assertTrue(check.should_terminate(0))
 
     def test_terminate_not_determine_by_number_of_data_points(self):

--- a/rebench/tests/persistency.conf
+++ b/rebench/tests/persistency.conf
@@ -1,0 +1,29 @@
+# Config file for ReBench
+# Config format is YAML (see http://yaml.org/ for detailed spec)
+
+# this run definition will be chosen if no parameters are given to rebench.py
+standard_experiment: Test
+standard_data_file:  'persistency.data'
+
+
+benchmark_suites:
+    TestSuite:
+        invocations:  10
+        min_iteration_time: 1
+        gauge_adapter: Time
+        command: 1 FooBar %(benchmark)s 2 3 4
+        benchmarks:
+            - TestBench
+
+virtual_machines:
+    TestVM:
+        path: .
+        binary: test-vm1.py
+        cores: [1]
+
+experiments:
+    Test:
+        suites:
+            - TestSuite
+        executions:
+            - TestVM

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -40,7 +40,8 @@ class PersistencyTest(ReBenchTestCase):
         suite = BenchmarkSuite("MySuite", vm, '', '', None, None,
                                None, None, None, None)
         benchmark = Benchmark("Test Bench [>", "Test Bench [>", None,
-                              suite, None, None, ExpRunDetails.default(), None, data_store)
+                              suite, None, None, ExpRunDetails.default(None, None),
+                              None, data_store)
 
         run_id = RunId(benchmark, 1000, 44, 'sdf sdf sdf sdfsf')
         timestamp = datetime.now().replace(microsecond=0)

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -17,12 +17,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-from datetime import datetime
-
 from .rebench_test_case import ReBenchTestCase
 
 from ..persistence  import DataStore
 
+from ..configurator import Configurator, load_config
+from ..executor import Executor
 from ..model.benchmark import Benchmark
 from ..model.benchmark_suite import BenchmarkSuite
 from ..model.exp_run_details import ExpRunDetails
@@ -44,9 +44,7 @@ class PersistencyTest(ReBenchTestCase):
                               None, data_store)
 
         run_id = RunId(benchmark, 1000, 44, 'sdf sdf sdf sdfsf')
-        timestamp = datetime.now().replace(microsecond=0)
-        measurement = Measurement(2222.2222, 'ms', run_id, 'foobar crit',
-                                  timestamp)
+        measurement = Measurement(43, 45, 2222.2222, 'ms', run_id, 'foobar crit')
 
         serialized = measurement.as_str_list()
         deserialized = Measurement.from_str_list(data_store, serialized)
@@ -54,6 +52,43 @@ class PersistencyTest(ReBenchTestCase):
         self.assertEqual(deserialized.criterion, measurement.criterion)
         self.assertEqual(deserialized.value, measurement.value)
         self.assertEqual(deserialized.unit, measurement.unit)
-        self.assertAlmostEqual(deserialized.timestamp, measurement.timestamp)
+        self.assertEqual(deserialized.invocation, measurement.invocation)
+        self.assertEqual(deserialized.iteration, measurement.iteration)
 
         self.assertEqual(deserialized.run_id, measurement.run_id)
+
+    def _assert_runs(self, cnf, num_runs, num_dps, num_invocations):
+        runs = cnf.get_runs()
+        self.assertEqual(num_runs, len(runs))
+        run = list(runs)[0]
+
+        self.assertEqual(num_dps, run.get_number_of_data_points())
+        self.assertEqual(num_invocations, run.completed_invocations)
+
+    def test_iteration_invocation_semantics(self):
+        ## Executes first time
+        ds = DataStore(self._ui)
+        cnf = Configurator(load_config(self._path + '/persistency.conf'),
+                           ds, self._ui, data_file=self._tmp_file)
+        ds.load_data()
+
+        self._assert_runs(cnf, 1, 0, 0)
+
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
+        ex.execute()
+
+        self._assert_runs(cnf, 1, 10, 10)
+
+        ## Execute a second time, should not add any data points,
+        ## because goal is already reached
+        ds2 = DataStore(self._ui)
+        cnf2 = Configurator(load_config(self._path + '/persistency.conf'),
+                            ds2, self._ui, data_file=self._tmp_file)
+        ds2.load_data()
+
+        self._assert_runs(cnf2, 1, 10, 10)
+
+        ex2 = Executor(cnf2.get_runs(), False, False, self._ui)
+        ex2.execute()
+
+        self._assert_runs(cnf2, 1, 10, 10)

--- a/rebench/tests/rebench_test_case.py
+++ b/rebench/tests/rebench_test_case.py
@@ -32,7 +32,6 @@ class ReBenchTestCase(TestCase):
     def _set_path(self, path):
         self._path = dirname(realpath(path))
         os.chdir(self._path)
-        self._ui = TestDummyUI()
 
     def setUp(self):
         logging.getLogger('pykwalify').addHandler(logging.NullHandler())
@@ -41,6 +40,7 @@ class ReBenchTestCase(TestCase):
         self._tmp_file = mkstemp()[1]  # just use the file name
 
         self._sys_exit = sys.exit  # make sure that we restore sys.exit
+        self._ui = TestDummyUI()
 
     def tearDown(self):
         os.remove(self._tmp_file)

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -126,7 +126,7 @@ class UI(object):
     def verbose_error_info(self, text, run_id=None, cmd=None, cwd=None, **kw):
         if self._verbose:
             self._output_detail_header(run_id, cmd, cwd)
-            self._output(text, 'error', faint=True, **kw)
+            self._output(text, 'red', faint=True, **kw)
 
     def debug_output_info(self, text, run_id=None, cmd=None, cwd=None, **kw):
         if self._debug:
@@ -136,7 +136,7 @@ class UI(object):
     def debug_error_info(self, text, run_id=None, cmd=None, cwd=None, **kw):
         if self._debug:
             self._output_detail_header(run_id, cmd, cwd)
-            self._output(text, 'error', faint=True, **kw)
+            self._output(text, 'red', faint=True, **kw)
 
 
 class UIError(Exception):

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -26,6 +26,11 @@ from humanfriendly.terminal import terminal_supports_colors, ansi_wrap, auto_enc
 _DETAIL_INDENT = "    "
 
 
+def escape_braces(string):
+    string = coerce_string(string)
+    return string.replace('{', '{{').replace('}', '}}')
+
+
 class UI(object):
 
     def __init__(self):

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -19,6 +19,8 @@
 # IN THE SOFTWARE.
 import sys
 
+from os import getcwd
+
 from humanfriendly import erase_line_code, Spinner
 from humanfriendly.compat import coerce_string
 from humanfriendly.terminal import terminal_supports_colors, ansi_wrap, auto_encode
@@ -82,8 +84,10 @@ class UI(object):
         assert text
         if cwd:
             text += _DETAIL_INDENT + "cwd: " + cwd + "\n"
-        elif run_id:
+        elif run_id and run_id.location:
             text += _DETAIL_INDENT + "cwd: " + run_id.location + "\n"
+        else:
+            text += _DETAIL_INDENT + "cwd: " + getcwd() + "\n"
 
         self._prev_run_id = run_id
         self._prev_cmd = cmd


### PR DESCRIPTION
This adds full support for the invocation/iteration concepts.

- add the corresponding command-line argument support
- adapt the quick option `-q`

It fixes also a number of issues seen during debugging

- some error/reporting issues
- fix `Popen_override` used in testing
- ensure data files are closed properly

This addresses the remaining issues of #68.