### PR TITLE
Fix setup.py, pylint 2.0, and codespeed reporting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -127,7 +127,8 @@ disable=parameter-unpacking,
         no-self-use,
         protected-access,
         no-else-return,
-        duplicate-code
+        duplicate-code,
+        useless-object-inheritance
         
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/rebench/__init__.py
+++ b/rebench/__init__.py
@@ -1,3 +1,1 @@
-from .rebench import ReBench, main_func
-
-__version__ = ReBench().version
+__version__ = "0.10.1"

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -31,6 +31,7 @@ import sys
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, SUPPRESS
 
+from . import __version__ as rebench_version
 from .executor       import Executor, BatchScheduler, RoundRobinScheduler, \
                             RandomScheduler
 from .persistence    import DataStore
@@ -43,7 +44,7 @@ from .ui import UIError, UI
 class ReBench(object):
 
     def __init__(self):
-        self.version = "0.10.1"
+        self.version = rebench_version
         self.options = None
         self._config = None
         self._ui = UI()

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -147,6 +147,9 @@ class CodespeedReporter(Reporter):
             self._send_and_empty_cache()
 
     def _send_and_empty_cache(self):
+        if not self._cache:
+            return
+
         if len(self._cache) == 1:
             run_id = list(self._cache.keys())[0]
         else:
@@ -187,7 +190,7 @@ class CodespeedReporter(Reporter):
         else:
             result['result_value'] = -1
 
-        result['executable'] = self._cfg.executable or run_id.benchmark.vm.name
+        result['executable'] = self._cfg.executable or run_id.benchmark.suite.vm.name
 
         if run_id.benchmark.codespeed_name:
             name = run_id.benchmark.codespeed_name
@@ -234,12 +237,13 @@ class CodespeedReporter(Reporter):
                        + "{ind}{ind}executables: %s\n") % (
                            envs, projects, benchmarks, executables)
 
-                error("{ind}Error: Reporting to Codespeed failed.\n"
-                      + "{ind}{ind}" + str(error) + "\n"
-                      + "{ind}{ind}This is most likely caused by either a wrong URL in the\n"
-                      + "{ind}{ind}config file, or an environment not configured in Codespeed.\n"
-                      + "{ind}{ind}URL: " + self._cfg.url + "\n"
-                      + "{ind}{ind}" + msg + "\n", run_id)
+                self._ui.error(
+                    "{ind}Error: Reporting to Codespeed failed.\n"
+                    + "{ind}{ind}" + str(error) + "\n"
+                    + "{ind}{ind}This is most likely caused by either a wrong URL in the\n"
+                    + "{ind}{ind}config file, or an environment not configured in Codespeed.\n"
+                    + "{ind}{ind}URL: " + self._cfg.url + "\n"
+                    + "{ind}{ind}" + msg + "\n", run_id)
 
     def _prepare_result(self, run_id):
         stats = StatisticProperties(run_id.get_total_values())

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -223,10 +223,10 @@ class CodespeedReporter(Reporter):
                 self._ui.verbose_error_info("Sent %d results to Codespeed, response was: %s\n"
                                             % (len(results), response))
             except (IOError, HTTPException) as error:
-                envs = list(set([i['environment'] for i in results]))
-                projects = list(set([i['project'] for i in results]))
-                benchmarks = list(set([i['benchmark'] for i in results]))
-                executables = list(set([i['executable'] for i in results]))
+                envs = list({i['environment'] for i in results})
+                projects = list({i['project'] for i in results})
+                benchmarks = list({i['benchmark'] for i in results})
+                executables = list({i['executable'] for i in results})
                 msg = ("{ind}Data\n"
                        + "{ind}{ind}environments: %s\n"
                        + "{ind}{ind}projects: %s\n"

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -22,7 +22,7 @@ import subprocess
 import os
 
 from .rebench_test_case import ReBenchTestCase
-from ..                  import ReBench
+from ..rebench           import ReBench
 from ..executor          import Executor
 from ..configurator      import Configurator, load_config
 from ..model.measurement import Measurement

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -120,7 +120,7 @@ class ExecutorTest(ReBenchTestCase):
     def test_execution_with_quick_set(self):
         self._set_path(__file__)
         option_parser = ReBench().shell_options()
-        cmd_config = option_parser.parse_args(['-q', 'persistency.conf'])
+        cmd_config = option_parser.parse_args(['-S', '-q', 'persistency.conf'])
         self.assertTrue(cmd_config.quick)
 
         cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
@@ -137,7 +137,7 @@ class ExecutorTest(ReBenchTestCase):
     def test_execution_with_invocation_and_iteration_set(self):
         self._set_path(__file__)
         option_parser = ReBench().shell_options()
-        cmd_config = option_parser.parse_args(['-in=2', '-it=2', 'persistency.conf'])
+        cmd_config = option_parser.parse_args(['-S', '-in=2', '-it=2', 'persistency.conf'])
         self.assertEqual(2, cmd_config.invocations)
         self.assertEqual(2, cmd_config.iterations)
 

--- a/rebench/tests/persistency.conf
+++ b/rebench/tests/persistency.conf
@@ -5,6 +5,9 @@
 default_experiment: Test
 default_data_file:  'persistency.data'
 
+reporting:
+  codespeed:
+    url: example.org
 
 benchmark_suites:
     TestSuite:

--- a/rebench/tests/reporter_test.py
+++ b/rebench/tests/reporter_test.py
@@ -1,0 +1,61 @@
+from .rebench_test_case import ReBenchTestCase
+
+from ..configurator import Configurator, load_config
+from ..executor import Executor
+from ..persistence import DataStore
+from ..rebench import ReBench
+from ..reporter import CodespeedReporter
+
+try:
+    from http.client import HTTPException
+except ImportError:
+    from httplib import HTTPException
+
+
+class ReporterTest(ReBenchTestCase):
+
+    def _run_benchmarks_and_do_reporting(self):
+        option_parser = ReBench().shell_options()
+        cmd_config = option_parser.parse_args([
+            '--commit-id=id', '--environment=test', '--project=test', 'persistency.conf'])
+        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
+                           self._ui, cmd_config, data_file=self._tmp_file)
+
+        self._runs = cnf.get_runs()  # pylint: disable=attribute-defined-outside-init
+
+        ex = Executor(self._runs, False, False, self._ui)
+        ex.execute()
+        reporter = cnf.reporting.codespeed_reporter
+        reporter.report_job_completed(self._runs)
+
+    def test_send_to_codespeed(self):
+        sent_results = [False]
+
+        def _send_to_codespeed(_reporter, _results, run_id):
+            self.assertIn(run_id, self._runs)
+            sent_results[0] = True
+
+        original_send_to = CodespeedReporter._send_to_codespeed
+        CodespeedReporter._send_to_codespeed = _send_to_codespeed
+
+        try:
+            self._run_benchmarks_and_do_reporting()
+            self.assertTrue(sent_results[0])
+        finally:
+            CodespeedReporter._send_to_codespeed = original_send_to
+
+    def test_send_to_codespeed_with_error(self):
+        sent_results = [False]
+
+        def _send_payload(_reporter, _payload):
+            sent_results[0] = True
+            raise HTTPException()
+
+        old_send_payload = CodespeedReporter._send_payload
+        CodespeedReporter._send_payload = _send_payload
+
+        try:
+            self._run_benchmarks_and_do_reporting()
+            self.assertTrue(sent_results[0])
+        finally:
+            CodespeedReporter._send_payload = old_send_payload

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,10 @@
 # IN THE SOFTWARE.
 
 from setuptools import setup, find_packages
-from rebench import ReBench
-
-rebench = ReBench()
+from rebench import __version__ as rebench_version
 
 setup(name='ReBench',
-      version=rebench.version,
+      version=rebench_version,
       description='Execute and document benchmarks reproducibly.',
       author='Stefan Marr',
       author_email='rebench@stefan-marr.de',
@@ -38,7 +36,7 @@ setup(name='ReBench',
           'humanfriendly>=4.12'
       ],
       entry_points = {
-          'console_scripts' : ['rebench = rebench:main_func']
+          'console_scripts' : ['rebench = rebench.rebench:main_func']
       },
       tests_require = ['scipy>=0.8.0'],
       test_suite = 'rebench.tests',


### PR DESCRIPTION
This PR fixes issues a number of issues.

`setup.py` used to import the main module, which leads to the setup depending on the packages we want to install.

And, the codespeed reporting didn't have tests, which caused it to break. This PR adds basic tests and fixes the issues.