### PR TITLE
Show spinner-like output also for non-interactive terminals

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,6 +95,25 @@ We can override this setting with the following parameters:
 -q, --quick      Execute quickly. Identical with --iterations=1 --invocations=1
 ```
 
+#### Niceness
+
+It is highly recommended to run benchmarks on an idle machine with all
+unnecessary services disabled.
+However, even if the machine is idle, it can happen that other processes
+might desire processing time, which can lead to noise in the measurements.
+To prevent such effects, it is recommended to run benchmarks with the highest
+possible priority. On Linux systems, this is typically achieved with
+the `nice` command and a niceness setting of `-20` (i.e., the process behaves
+very not-nice).
+
+Typically, this requires admin/root rights.
+On Ubuntu, one can however allow a user to set negative niceness values
+by adding the following line in `/etc/security/limits.conf`:
+
+```text
+user_executing_benchmarks    -       nice            -20
+```
+
 #### Discarding Data, Rerunning Experiments
 
 ReBench's normal execution mode will assume that it should accumulate all data

--- a/rebench/model/termination_check.py
+++ b/rebench/model/termination_check.py
@@ -49,13 +49,13 @@ class TerminationCheck(object):
 
     def should_terminate(self, number_of_data_points):
         if self._fail_immediately:
-            self._ui.verbose_error_info("{ind}Marked to fail immediately.\n", self._run_id)
+            self._ui.warning("{ind}Marked to fail immediately.\n", self._run_id)
         if self.fails_consecutively():
-            self._ui.verbose_error_info(
+            self._ui.warning(
                 "{ind}Three executions have failed in a row, benchmark is aborted.\n", self._run_id)
             return True
         elif self.has_too_many_failures(number_of_data_points):
-            self._ui.verbose_error_info(
+            self._ui.warning(
                 "{ind}Many runs are failing, benchmark is aborted.\n", self._run_id)
             return True
         elif self._run_id.completed_invocations >= self._run_id.invocations:


### PR DESCRIPTION
Simply print line with progress, and do not erase.

Also make sure we use stdout as for all other output.