### PR TITLE
Add rebench-schema.yml to package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
       - time
 
 install:
-  - pip install coveralls humanfriendly pylint
+  - pip install coveralls pylint
   - pip install .
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 # command to run tests
 script:
  - nosetests --with-coverage --cover-package=rebench
+ - (cd rebench && rebench -N ../rebench.conf vm:TestRunner2)
  - pylint rebench
 
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(name='ReBench',
       author_email='rebench@stefan-marr.de',
       url='https://github.com/smarr/ReBench',
       packages=find_packages(exclude=['*.tests']),
+      package_data={'rebench': ['rebench-schema.yml']},
       install_requires=[
           'PyYAML>=3.12',
           'pykwalify>=1.6.1',


### PR DESCRIPTION
This adds the missing `rebench-schema.yml`, and adds a direct ReBench run as test to the Travis setup.

Issue identified by @charig: https://github.com/smarr/ReBench/pull/89#issuecomment-405649414

@charig This should fix the issue. Thanks for the report.