### PR TITLE
Support list of build commands

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -200,6 +200,9 @@ The number of times a run is executed within a virtual machine
 invocation. This needs to be supported by a benchmark harness and
 ReBench passes this value on to the harness or benchmark.
 
+The iterations setting can be used e.g. for the command as in the benchmark suite
+in the example below.
+
 Default: `1`
 
 Example:
@@ -207,6 +210,10 @@ Example:
 ```yaml
 runs:
   iterations: 42
+
+benchmark_suites:
+  ExampleSuite:
+    command: Harness -i=%(iterations)s
 ```
 
 ---
@@ -216,6 +223,9 @@ runs:
 Consider the first N iterations as warmup and ignore them in ReBench's summary
 statistics. Note ,they are still persisted in the data file.
 
+The warmup setting can be used e.g. for the command as in the benchmark suite
+in the example below.
+
 Default: `0`
 
 Example:
@@ -223,6 +233,10 @@ Example:
 ```yaml
 runs:
   warmup: 330
+ 
+benchmark_suites:
+  ExampleSuite:
+    command: Harness --warmup=%(warmup)s
 ```
 
 ---
@@ -527,14 +541,19 @@ in form of a sequence literal: `[small, large]`.
 
 Run configurations are generated from the cross product of all `input_sizes`,
 `cores`, and `variable_values` for a benchmark. 
+The specific input size can be used in the command as in the example below.
 
 Example:
 
 ```yaml
-- Benchmark2:
-    input_sizes:
-      - small
-      - large
+benchmark_suites:
+  ExampleSuite:
+    command: Harness --size=%(input)s
+    benchmarks:
+        - Benchmark2:
+            input_sizes:
+              - small
+              - large
 ```
 
 ---
@@ -548,12 +567,17 @@ any list of strings.
 
 Run configurations are generated from the cross product of all `input_sizes`,
 `cores`, and `variable_values` for a benchmark.
+The specific core setting can be used e.g. in the command as in the example below.
 
 Example:
 
 ```yaml
-- Benchmark2:
-    cores: [1, 3, 4, 19]
+benchmark_suites:
+  ExampleSuite:
+    command: Harness --cores=%(cores)s
+    benchmarks:
+        - Benchmark2:
+            cores: [1, 3, 4, 19]
 ```
 
 ---
@@ -565,15 +589,20 @@ It takes a list of strings, or arbitrary values really.
 
 Run configurations are generated from the cross product of all `input_sizes`,
 `cores`, and `variable_values` for a benchmark.
+The specific variable value can be used e.g. in the command as in the example below.
 
 Example:
 
 ```yaml
-- Benchmark2:
-    variable_values:
-      - Sequential
-      - Parallel
-      - Random
+benchmark_suites:
+  ExampleSuite:
+    command: Harness %(variable)s
+    benchmarks:
+        - Benchmark2:
+            variable_values:
+              - Sequential
+              - Parallel
+              - Random
 ```
 
 ---

--- a/docs/config.md
+++ b/docs/config.md
@@ -221,7 +221,7 @@ benchmark_suites:
 **warmup:**
 
 Consider the first N iterations as warmup and ignore them in ReBench's summary
-statistics. Note ,they are still persisted in the data file.
+statistics. Note, uithey are still persisted in the data file.
 
 The warmup setting can be used e.g. for the command as in the benchmark suite
 in the example below.

--- a/docs/config.md
+++ b/docs/config.md
@@ -387,17 +387,27 @@ benchmark_suites:
 
 **build:**
 
-The given string is executed by the system's shell and can be used to
-build a benchmark suite. It is executed once before any benchmarks of the suite
-are executed. If `location` is set, it is used as working directory.
-Otherwise, it is the current working directory of ReBench.
+A list of commands/strings to be executed by the system's shell.
+They are intended to set up the system for benchmarking,
+typically to build binaries, compiled archives, etc.
+
+Each command is executed once before any benchmark that depend on it
+is executed. If the `location` of the suite is set, it is used as
+working directory. Otherwise, it is the current working directory of ReBench.
+
+This is a list of commands to allow multiple suites/VMs to depend on the
+same command without duplicate execution.
+
+Though, location and command have to be identical (based on simple
+string comparisons).
 
 Example:
 
 ```yaml
 benchmark_suites:
   ExampleSuite:
-    build: ./build-suite.sh
+    build:
+      - ./build-suite.sh
 ```
 
 ---
@@ -638,19 +648,28 @@ virtual_machines:
 
 **build:**
 
-The given string is executed by the system's shell and can be used to
-build a VM. It is executed once before any benchmarks are executed with
-the VM. If `path` is set, it is used as working directory. Otherwise,
-it is the current working directory of ReBench.
+A list of commands/strings to be executed by the system's shell.
+They are intended to set up the system for benchmarking,
+typically to build binaries, compiled archives, etc.
+
+Each command is executed once before the VM is executed.
+If the `path` of the VM is set, it is used as
+working directory. Otherwise, it is the current working directory of ReBench.
+
+This is a list of commands to allow multiple suites/VMs to depend on the
+same command without duplicate execution.
+
+Though, location and command have to be identical (based on simple
+string comparisons).
 
 Example:
 
 ```yaml
 virtual_machines:
   MyBin1:
-    build: |
-      make clobber
-      make
+    build:
+      - make clobber
+      - make
 ```
 
 ---

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -28,7 +28,6 @@ import pkgutil
 import random
 import subprocess
 import sys
-from select import select
 from threading import Thread, RLock
 from time import time
 
@@ -338,74 +337,47 @@ class Executor(object):
 
         self._ui.debug_output_info("Start build\n", None, script, path)
 
-        proc = subprocess.Popen('/bin/sh', stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                cwd=path)
-        proc.stdin.write(str.encode(script))
-        proc.stdin.close()
+        def _keep_alive(seconds):
+            self._ui.warning(
+                "Keep alive. current job runs since %dmin" % (seconds / 60), run_id, script, path)
+
+        return_code, stdout_result, stderr_result = subprocess_timeout.run(
+            '/bin/sh', path, False, True,
+            stdin_input=str.encode(script),
+            keep_alive_output=_keep_alive)
+
+        stdout_result = coerce_string(stdout_result.decode('utf-8'))
+        stderr_result = coerce_string(stderr_result.decode('utf-8'))
 
         if self._build_log:
-            output = self.process_output(name, proc)
+            self.process_output(name, stdout_result, stderr_result)
 
-        if proc.returncode != 0:
+        if return_code != 0:
             build_command.mark_failed()
             run_id.fail_immediately()
             run_id.report_run_failed(
-                script, proc.returncode, "Build of " + name + " failed.")
+                script, return_code, "Build of " + name + " failed.")
             self._ui.error("{ind}Build of " + name + " failed.\n", None, script, path)
-            if output and output.strip():
-                lines = output.split('\n')
-                self._ui.error("{ind}Output:\n\n{ind}{ind}"
+            if stdout_result and stdout_result.strip():
+                lines = stdout_result.split('\n')
+                self._ui.error("{ind}stdout:\n\n{ind}{ind}"
+                               + "\n{ind}{ind}".join(lines) + "\n")
+            if stderr_result and stderr_result.strip():
+                lines = stderr_result.split('\n')
+                self._ui.error("{ind}stderr:\n\n{ind}{ind}"
                                + "\n{ind}{ind}".join(lines) + "\n")
             raise FailedBuilding(name, build_command)
         else:
             build_command.mark_succeeded()
 
-    def process_output(self, name, proc):
-        output = ""
+    def process_output(self, name, stdout_result, stderr_result):
         with open_with_enc(self._build_log, 'a', encoding='utf8') as log_file:
-            while True:
-                reads = [proc.stdout.fileno(), proc.stderr.fileno()]
-                ret = select(reads, [], [])
-
-                for file_no in ret[0]:
-                    if file_no == proc.stdout.fileno():
-                        read = self._read(proc.stdout)
-                        if read:
-                            if self._debug:
-                                sys.stdout.write(read)
-                            log_file.write(name + '|STD:')
-                            log_file.write(read)
-                            output += read
-                    elif file_no == proc.stderr.fileno():
-                        read = self._read(proc.stderr)
-                        if read:
-                            if self._debug:
-                                sys.stderr.write(read)
-                            log_file.write(name + '|ERR:')
-                            log_file.write(read)
-                            output += read
-
-                if proc.poll() is not None:
-                    break
-            # read rest of pipes
-            while True:
-                read = self._read(proc.stdout)
-                if read == "":
-                    break
+            if stdout_result:
                 log_file.write(name + '|STD:')
-                log_file.write(read)
-                output += read
-            while True:
-                read = self._read(proc.stderr)
-                if not read:
-                    break
+                log_file.write(stdout_result)
+            if stderr_result:
                 log_file.write(name + '|ERR:')
-                log_file.write(read)
-                output += read
-
-            log_file.write('\n')
-        return output
+                log_file.write(stderr_result)
 
     def execute_run(self, run_id):
         termination_check = run_id.get_termination_check(self._ui)
@@ -463,10 +435,15 @@ class Executor(object):
         try:
             self._ui.debug_output_info("{ind}Starting run\n", run_id, cmdline)
 
+            def _keep_alive(seconds):
+                self._ui.warning(
+                    "Keep alive. current job runs since %dmin" % (seconds / 60), run_id, cmdline)
+
             (return_code, output, _) = subprocess_timeout.run(
                 cmdline, cwd=run_id.location, stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT, shell=True, verbose=self._debug,
-                timeout=run_id.max_invocation_time)
+                timeout=run_id.max_invocation_time,
+                keep_alive_output=_keep_alive)
             output = output.decode('utf-8')
         except OSError as err:
             run_id.fail_immediately()

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -310,19 +310,24 @@ class Executor(object):
     def _build_vm_and_suite(self, run_id):
         name = "VM:" + run_id.benchmark.suite.vm.name
         build = run_id.benchmark.suite.vm.build
-        self._process_build(build, name, run_id)
+        self._process_builds(build, name, run_id)
 
         name = "S:" + run_id.benchmark.suite.name
         build = run_id.benchmark.suite.build
-        self._process_build(build, name, run_id)
+        self._process_builds(build, name, run_id)
 
-    def _process_build(self, build, name, run_id):
-        if not build or build.is_built:
+    def _process_builds(self, builds, name, run_id):
+        if not builds:
             return
-        if build.is_failed_build:
-            run_id.fail_immediately()
-            raise FailedBuilding(name, build)
-        self._execute_build_cmd(build, name, run_id)
+
+        for build in builds:
+            if build.is_built:
+                continue
+
+            if build.is_failed_build:
+                run_id.fail_immediately()
+                raise FailedBuilding(name, build)
+            self._execute_build_cmd(build, name, run_id)
 
     def _execute_build_cmd(self, build_command, name, run_id):
         path = build_command.location

--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -17,6 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+import os
+
 from .build_cmd import BuildCommand
 from .exp_run_details import ExpRunDetails
 from .exp_variables import ExpVariables
@@ -29,9 +31,10 @@ class BenchmarkSuite(object):
         gauge_adapter = suite.get('gauge_adapter')
         command = suite.get('command')
 
-        # TODO: should the location be made absolute as the vm._path??
         location = suite.get('location', vm.path)
-        build = BuildCommand.create(suite.get('build'), build_commands, location)
+        if location:
+            location = os.path.abspath(location)
+        build = BuildCommand.create_commands(suite.get('build'), build_commands, location)
         benchmarks_config = suite.get('benchmarks')
 
         description = suite.get('description')

--- a/rebench/model/build_cmd.py
+++ b/rebench/model/build_cmd.py
@@ -22,9 +22,15 @@
 class BuildCommand(object):
 
     @classmethod
-    def create(cls, cmd, build_commands, location):
-        if not cmd:
+    def create_commands(cls, commands, build_commands, location):
+        if not commands:
             return None
+
+        return [BuildCommand.create(cmd, build_commands, location) for cmd in commands]
+
+    @classmethod
+    def create(cls, cmd, build_commands, location):
+        assert cmd
 
         build_command = BuildCommand(cmd, location)
         if build_command in build_commands:

--- a/rebench/model/virtual_machine.py
+++ b/rebench/model/virtual_machine.py
@@ -34,7 +34,7 @@ class VirtualMachine(object):
         binary = vm.get('binary')
         args = vm.get('args')
 
-        build = BuildCommand.create(vm.get('build'), build_commands, path)
+        build = BuildCommand.create_commands(vm.get('build'), build_commands, path)
 
         description = vm.get('description')
         desc = vm.get('desc')

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -119,6 +119,24 @@ schema;benchmark_type_map:
             This is useful to have a name different from the one relevant
             at the suite level.
 
+schema;build_type:
+  desc: |
+    A list of commands/strings to be executed by the system's shell.
+    They are intended to set up the system for benchmarking,
+    typically to build binaries, compiled archieves, etc.
+    Each command is executed once before any benchmark or VM that depend on it
+    is executed. If the `location` or `path` of a suite/VM is set, it is used as
+    working directory. Otherwise, it is the current working directory of ReBench.
+
+    This is a list of commands to allow multiple suites/VMs to depend on the
+    same command without duplicate execution.
+
+    Though, location and command have to be identical (based on simple
+    string comparisons).
+  type: seq
+  sequence:
+    - type: str
+
 schema;benchmark_suite_type:
   type: map
   mapping:
@@ -147,12 +165,7 @@ schema;benchmark_suite_type:
         The path to the benchmark harness. Execution use this location as
         working directory. It overrides the location/path of a VM.
     build:
-      desc: |
-        The given string is executed by the system's shell and can be used to
-        build a benchmark suite. It is executed once before any benchmarks are
-        executed. If `location` is set, it is used as working directory.
-        Otherwise, it is the current working directory of ReBench.
-      type: str
+      include: build_type
     benchmarks:
       type: seq
       required: yes
@@ -194,12 +207,7 @@ schema;vm_type:
     description:
       type: str
     build:
-      desc: |
-        The given string is executed by the system's shell and can be used to
-        build a VM. It is executed once before any benchmarks are executed with
-        the VM. If `path` is set, it is used as working directory. Otherwise,
-        it is the current working directory of ReBench.
-      type: str
+      include: build_type
 
 schema;exp_suite_type:
   desc: A list of suites

--- a/rebench/tests/features/issue_58.conf
+++ b/rebench/tests/features/issue_58.conf
@@ -16,26 +16,30 @@ virtual_machines:
     BashA:
         binary: ./vm_58a.sh
         args: foo bar 1
-        build: ./issue_58_buildvm_a.sh
+        build:
+          - ./issue_58_buildvm_a.sh
     BashAA:
         binary: ./vm_58a.sh
         args: foo bar 1
-        build: ./issue_58_buildvm_a.sh
+        build:
+          - ./issue_58_buildvm_a.sh
     BashB:
         binary: ./vm_58b.sh
         args: foo bar 2
-        build: |
-          echo "#!/bin/bash" >  vm_58b.sh
-          echo "echo \$@"    >> vm_58b.sh
-          echo error 1>&2
-          echo standard
-          chmod +x vm_58b.sh
+        build:
+          - |
+            echo "#!/bin/bash" >  vm_58b.sh
+            echo "echo \$@"    >> vm_58b.sh
+            echo error 1>&2
+            echo standard
+            chmod +x vm_58b.sh
     BashC:
         binary: ./vm_58a.sh
         args: foo bar 3
-        build: |
-           ./issue_58_buildvm_a.sh
-           exit 1
+        build:
+          - |
+            ./issue_58_buildvm_a.sh
+            exit 1
 
 experiments:
     Test:

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -83,7 +83,7 @@ class Issue58BuildVM(ReBenchTestCase):
         log = self._read_log()
 
         self.assertEqual(
-            "VM:BashA|STD:standard\nVM:BashA|ERR:error\n\n", log)
+            "VM:BashA|STD:standard\nVM:BashA|ERR:error\n", log)
 
     def test_broken_build_prevents_experiments(self):
         self._cleanup_log()
@@ -107,7 +107,7 @@ class Issue58BuildVM(ReBenchTestCase):
         log = self._read_log()
 
         self.assertEqual(
-            "VM:BashC|STD:standard\nVM:BashC|ERR:error\n\n", log)
+            "VM:BashC|STD:standard\nVM:BashC|ERR:error\n", log)
 
     def test_build_is_run_only_once_for_same_command(self):
         self._cleanup_log()
@@ -125,4 +125,4 @@ class Issue58BuildVM(ReBenchTestCase):
         log = self._read_log()
 
         self.assertEqual(
-            "VM:BashA|STD:standard\nVM:BashA|ERR:error\n\n", log)
+            "VM:BashA|STD:standard\nVM:BashA|ERR:error\n", log)

--- a/rebench/tests/features/issue_59.conf
+++ b/rebench/tests/features/issue_59.conf
@@ -8,14 +8,16 @@ runs:
 
 benchmark_suites:
     Suite1:
-        build: ./issue_59_build_suite.sh
+        build:
+          - ./issue_59_build_suite.sh
         location: .
         gauge_adapter: Time
         command: " "
         benchmarks:
           - Bench1
     Suite2:
-        build: ./issue_59_build_suite.sh
+        build:
+          - ./issue_59_build_suite.sh
         location: .
         gauge_adapter: Time
         command: " "

--- a/rebench/tests/features/issue_81.conf
+++ b/rebench/tests/features/issue_81.conf
@@ -9,7 +9,8 @@ runs:
 
 benchmark_suites:
     Suite1:
-        build: ./issue_81_build_suite.sh
+        build:
+          - ./issue_81_build_suite.sh
         location: .
         gauge_adapter: Time
         command: " "
@@ -18,7 +19,8 @@ benchmark_suites:
 
 virtual_machines:
     VM1:
-        build: ./issue_81_build_vm.sh
+        build:
+          - ./issue_81_build_vm.sh
         binary: echo foo
 
 experiments:

--- a/rebench/tests/features/issue_81_unicode_test.py
+++ b/rebench/tests/features/issue_81_unicode_test.py
@@ -58,11 +58,11 @@ class Issue81UnicodeSuite(ReBenchTestCase):
         except NameError:
             unicode_char = chr(22234)
 
-        self.assertGreater(log.find("VM:VM1|ERR:" + unicode_char), -1)
-        self.assertGreater(log.find("VM:VM1|STD:" + unicode_char), -1)
+        self.assertGreaterEqual(15, log.find(unicode_char))  # VM:VM1|STD:
+        self.assertGreaterEqual(log.find(unicode_char, 16), 38)  # VM:VM1|ERR:
 
-        self.assertGreater(log.find("S:Suite1|ERR:" + unicode_char), -1)
-        self.assertGreater(log.find("S:Suite1|STD:" + unicode_char), -1)
+        self.assertGreaterEqual(log.find(unicode_char, 42), 63)  # S:Suite1|STD:
+        self.assertGreaterEqual(log.find(unicode_char, 70), 88)  # S:Suite1|ERR:
 
         if os.path.exists(self._path + '/build.log'):
             os.remove(self._path + '/build.log')

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -98,7 +98,7 @@ class UI(object):
     def _output_detail_header(self, run_id, cmd, cwd):
         text = self._prepare_details(run_id, cmd, cwd)
         if text:
-            self._output(text, 'black')
+            self._output(text, None)
 
     @staticmethod
     def output(text, *args, **kw):
@@ -126,7 +126,7 @@ class UI(object):
     def verbose_output_info(self, text, run_id=None, cmd=None, cwd=None, **kw):
         if self._verbose:
             self._output_detail_header(run_id, cmd, cwd)
-            self._output(text, 'black', faint=True, **kw)
+            self._output(text, None, faint=True, **kw)
 
     def verbose_error_info(self, text, run_id=None, cmd=None, cwd=None, **kw):
         if self._verbose:
@@ -136,7 +136,7 @@ class UI(object):
     def debug_output_info(self, text, run_id=None, cmd=None, cwd=None, **kw):
         if self._debug:
             self._output_detail_header(run_id, cmd, cwd)
-            self._output(text, 'black', faint=True, **kw)
+            self._output(text, None, faint=True, **kw)
 
     def debug_error_info(self, text, run_id=None, cmd=None, cwd=None, **kw):
         if self._debug:


### PR DESCRIPTION
This PR addresses the remaining points of #59.

- adds keep alive output for build commands
- supports lists of commands

It also cleans up the code for building by using the `subprocess_with_timeout` module as for the benchmark execution.

This PR also fixes some issues in the documentation and fixes the color of normal output. Thanks @charig and @spilot for the corresponding feedback.