### PR TITLE
Fix some issues with spinner and sort result table

### DIFF
--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -98,6 +98,11 @@ class RunScheduler(object):
                 % (run.as_simple_string(), art_mean, hour, minute, sec)
         self._ui.step_spinner(self._runs_completed, label)
 
+    def indicate_build(self, run_id):
+        run_id_names = run_id.as_str_list()
+        self._ui.step_spinner(
+            self._runs_completed, "Run build for %s %s" % (run_id_names[1], run_id_names[2]))
+
     def execute(self):
         self._total_num_runs = len(self._executor.runs)
         runs = self._filter_out_completed_runs(self._executor.runs, self._ui)
@@ -335,6 +340,7 @@ class Executor(object):
 
         script = build_command.command
 
+        self._scheduler.indicate_build(run_id)
         self._ui.debug_output_info("Start build\n", None, script, path)
 
         def _keep_alive(seconds):

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -20,6 +20,7 @@
 from __future__ import with_statement
 
 from time import time
+from operator import itemgetter
 import json
 import re
 
@@ -88,7 +89,7 @@ class TextReporter(Reporter):
                 out.append(int(round(stats.mean, 0)))
             rows.append(out)
 
-        return rows
+        return sorted(rows, key=itemgetter(2, 1, 3, 4, 5, 6, 7))
 
 
 class CliReporter(TextReporter):

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -59,6 +59,7 @@ class UI(object):
     def step_spinner(self, completed_runs, label=None):
         assert self._progress_spinner
         self._progress_spinner.step(completed_runs, label)
+        self._progress_spinner.stream.flush()
         self._need_to_erase_spinner = self._progress_spinner.interactive
 
     def _prepare_details(self, run_id, cmd, cwd):
@@ -109,6 +110,7 @@ class UI(object):
     def output(self, text, *args, **kw):
         self._erase_spinner()
         auto_encode(sys.stdout, coerce_string(text) + '\n', *args, **kw)
+        sys.stdout.flush()
 
     def _output(self, text, color, *args, **kw):
         self._erase_spinner()
@@ -117,6 +119,7 @@ class UI(object):
         if terminal_supports_colors(sys.stdout):
             text = ansi_wrap(text, color=color)
         auto_encode(sys.stdout, text, ind=_DETAIL_INDENT, *args, **kw)
+        sys.stdout.flush()
 
     def warning(self, text, run_id=None, cmd=None, cwd=None, **kw):
         self._output_detail_header(run_id, cmd, cwd)

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -59,7 +59,7 @@ class UI(object):
     def step_spinner(self, completed_runs, label=None):
         assert self._progress_spinner
         self._progress_spinner.step(completed_runs, label)
-        self._need_to_erase_spinner = True
+        self._need_to_erase_spinner = self._progress_spinner.interactive
 
     def _prepare_details(self, run_id, cmd, cwd):
         if not run_id and not cmd:
@@ -100,15 +100,18 @@ class UI(object):
         if text:
             self._output(text, None)
 
-    @staticmethod
-    def output(text, *args, **kw):
-        auto_encode(sys.stdout, coerce_string(text) + '\n', *args, **kw)
-
-    def _output(self, text, color, *args, **kw):
+    def _erase_spinner(self):
         if self._need_to_erase_spinner:
             if self._progress_spinner and self._progress_spinner.interactive:
                 sys.stdout.write(erase_line_code)
             self._need_to_erase_spinner = False
+
+    def output(self, text, *args, **kw):
+        self._erase_spinner()
+        auto_encode(sys.stdout, coerce_string(text) + '\n', *args, **kw)
+
+    def _output(self, text, color, *args, **kw):
+        self._erase_spinner()
 
         text = coerce_string(text)
         if terminal_supports_colors(sys.stdout):

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -21,11 +21,12 @@ import sys
 
 from os import getcwd
 
-from humanfriendly import erase_line_code, Spinner
+from humanfriendly import Spinner
 from humanfriendly.compat import coerce_string
 from humanfriendly.terminal import terminal_supports_colors, ansi_wrap, auto_encode
 
 _DETAIL_INDENT = "    "
+_ERASE_LINE = '\r\x1b[2K'
 
 
 def escape_braces(string):
@@ -104,7 +105,7 @@ class UI(object):
     def _erase_spinner(self):
         if self._need_to_erase_spinner:
             if self._progress_spinner and self._progress_spinner.interactive:
-                sys.stdout.write(erase_line_code)
+                sys.stdout.write(_ERASE_LINE)
             self._need_to_erase_spinner = False
 
     def output(self, text, *args, **kw):


### PR DESCRIPTION
The spinner does not get deleted reliably.
One issue is that it can wrap over multiple lines, and we only delete the last line.
This is still the case.

But even clearing the last line was not reliable. This is now fixed.

This change also flushes output and makes sure `ui.output()` is not ignored.

And finally, the result table is sorted now.