### PR TITLE
Reduce memory usage and calculate statistics online/incrementally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ language: python
 matrix:
   include:
     - python: "2.7"
-      virtualenv:
-        system_site_packages: true
-      addons:
-        apt:
-          packages:
-            - python-scipy
-
     - python: "3.6"
     # PyPy versions
     - python: pypy

--- a/rebench/model/data_point.py
+++ b/rebench/model/data_point.py
@@ -28,6 +28,10 @@ class DataPoint(object):
         self._invocation = -1
 
     @property
+    def run_id(self):
+        return self._run_id
+
+    @property
     def invocation(self):
         return self._invocation
 

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -21,6 +21,7 @@ import re
 
 from .benchmark import Benchmark
 from .termination_check import TerminationCheck
+from ..statistics import StatisticProperties
 from ..ui import UIError
 
 
@@ -35,6 +36,8 @@ class RunId(object):
         self._reporters = set()
         self._persistence = set()
         self._data_points = []
+        self._statistics = StatisticProperties()
+        self._total_unit = None
 
         self._termination_check = None
         self._cmdline = None
@@ -136,9 +139,9 @@ class RunId(object):
         for reporter in self._reporters:
             reporter.run_failed(self, cmdline, return_code, output)
 
-    def report_run_completed(self, statistics, cmdline):
+    def report_run_completed(self, cmdline):
         for reporter in self._reporters:
-            reporter.run_completed(self, statistics, cmdline)
+            reporter.run_completed(self, self._statistics, cmdline)
 
     def report_job_completed(self, run_ids):
         for reporter in self._reporters:
@@ -152,6 +155,9 @@ class RunId(object):
         for reporter in self._reporters:
             reporter.start_run(self)
 
+    def is_persisted_by(self, persistence):
+        return persistence in self._persistence
+
     def add_persistence(self, persistence):
         self._persistence.add(persistence)
 
@@ -159,20 +165,33 @@ class RunId(object):
         for persistence in self._persistence:
             persistence.close()
 
-    def loaded_data_point(self, data_point):
+    def _new_data_point(self, data_point):
         self._max_invocation = max(self._max_invocation, data_point.invocation)
+        if self._total_unit is None:
+            self._total_unit = data_point.get_total_unit()
+
+    def loaded_data_point(self, data_point):
+        self._new_data_point(data_point)
         self._data_points.append(data_point)
+        self._statistics.add_sample(data_point.get_total_value())
 
     def add_data_point(self, data_point, warmup):
-        self._max_invocation = max(self._max_invocation, data_point.invocation)
+        self._new_data_point(data_point)
 
         if not warmup:
             self._data_points.append(data_point)
+            self._statistics.add_sample(data_point.get_total_value())
         for persistence in self._persistence:
             persistence.persist_data_point(data_point)
 
     def get_number_of_data_points(self):
-        return len(self._data_points)
+        return self._statistics.num_samples
+
+    def get_mean_of_totals(self):
+        return self._statistics.mean
+
+    def get_statistics(self):
+        return self._statistics
 
     def get_data_points(self):
         return self._data_points
@@ -181,13 +200,8 @@ class RunId(object):
         self._data_points = []
         self._max_invocation = 0
 
-    def get_total_values(self):
-        return [dp.get_total_value() for dp in self._data_points]
-
     def get_total_unit(self):
-        if not self._data_points:
-            return None
-        return self._data_points[0].get_total_unit()
+        return self._total_unit
 
     def get_termination_check(self, ui):
         if self._termination_check is None:

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -35,7 +35,6 @@ class RunId(object):
 
         self._reporters = set()
         self._persistence = set()
-        self._data_points = []
         self._statistics = StatisticProperties()
         self._total_unit = None
 
@@ -172,14 +171,12 @@ class RunId(object):
 
     def loaded_data_point(self, data_point):
         self._new_data_point(data_point)
-        self._data_points.append(data_point)
         self._statistics.add_sample(data_point.get_total_value())
 
     def add_data_point(self, data_point, warmup):
         self._new_data_point(data_point)
 
         if not warmup:
-            self._data_points.append(data_point)
             self._statistics.add_sample(data_point.get_total_value())
         for persistence in self._persistence:
             persistence.persist_data_point(data_point)
@@ -192,13 +189,6 @@ class RunId(object):
 
     def get_statistics(self):
         return self._statistics
-
-    def get_data_points(self):
-        return self._data_points
-
-    def discard_data_points(self):
-        self._data_points = []
-        self._max_invocation = 0
 
     def get_total_unit(self):
         return self._total_unit
@@ -216,7 +206,7 @@ class RunId(object):
     def run_failed(self):
         return (self._termination_check.fails_consecutively() or
                 self._termination_check.has_too_many_failures(
-                    len(self._data_points)))
+                    len(self.get_number_of_data_points())))
 
     def __hash__(self):
         return hash(self.cmdline())

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -240,18 +240,22 @@ class RunId(object):
     def cmdline(self):
         if self._cmdline:
             return self._cmdline
+        return self._construct_cmdline()
 
+    def _construct_cmdline(self):
         cmdline = ""
         if self._benchmark.suite.executor.path:
-            cmdline = "%s/" % (self._benchmark.suite.executor.path, )
+            cmdline = self._benchmark.suite.executor.path + "/"
 
-        cmdline += "%s %s" % (self._benchmark.suite.executor.executable,
-                              self._benchmark.suite.executor.args or '')
+        cmdline += self._benchmark.suite.executor.executable
 
-        cmdline += self._benchmark.suite.command
+        if self._benchmark.suite.executor.args:
+            cmdline += " " + str(self._benchmark.suite.executor.args)
 
-        if self._benchmark.extra_args is not None:
-            cmdline += " %s" % self._benchmark.extra_args
+        cmdline += " " + self._benchmark.suite.command
+
+        if self._benchmark.extra_args:
+            cmdline += " " + str(self._benchmark.extra_args)
 
         cmdline = self._expand_vars(cmdline)
 

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -206,7 +206,7 @@ class RunId(object):
     def run_failed(self):
         return (self._termination_check.fails_consecutively() or
                 self._termination_check.has_too_many_failures(
-                    len(self.get_number_of_data_points())))
+                    self.get_number_of_data_points()))
 
     def __hash__(self):
         return hash(self.cmdline())

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -203,22 +203,16 @@ Argument:
         except ConfigurationError as exc:
             raise UIError(exc.message + "\n", exc)
 
-        data_store.load_data()
-        return self.execute_experiment()
+        runs = self._config.get_runs()
+        data_store.load_data(runs, self._config.options.do_rerun)
+        return self.execute_experiment(runs)
 
-    def execute_experiment(self):
+    def execute_experiment(self, runs):
         self._ui.verbose_output_info("Execute experiment: " + self._config.experiment_name + "\n")
-
-        # first load old data if available
-        if self._config.options.clean:
-            pass
 
         scheduler_class = {'batch':       BatchScheduler,
                            'round-robin': RoundRobinScheduler,
                            'random':      RandomScheduler}.get(self._config.options.scheduler)
-        runs = self._config.get_runs()
-        if self._config.options.do_rerun:
-            DataStore.discard_data_of_runs(runs, self._ui)
 
         executor = Executor(runs, self._config.use_nice, self._config.do_builds,
                             self._ui,

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -36,8 +36,6 @@ except ImportError:
     from urllib import urlencode # pylint: disable=ungrouped-imports
     from urllib2 import urlopen
 
-from .statistics import StatisticProperties
-
 
 class Reporter(object):
 
@@ -80,13 +78,14 @@ class TextReporter(Reporter):
         rows = []
 
         for run_id in run_ids:
-            stats = StatisticProperties(run_id.get_total_values())
+            mean = run_id.get_mean_of_totals()
+            num_samples = run_id.get_number_of_data_points()
             out = run_id.as_str_list()
-            out.append(stats.num_samples)
-            if stats.num_samples == 0:
+            out.append(num_samples)
+            if num_samples == 0:
                 out.append("Failed")
             else:
-                out.append(int(round(stats.mean, 0)))
+                out.append(int(round(mean, 0)))
             rows.append(out)
 
         return sorted(rows, key=itemgetter(2, 1, 3, 4, 5, 6, 7))
@@ -248,8 +247,7 @@ class CodespeedReporter(Reporter):
                     + "{ind}{ind}" + msg + "\n", run_id)
 
     def _prepare_result(self, run_id):
-        stats = StatisticProperties(run_id.get_total_values())
-        return self._format_for_codespeed(run_id, stats)
+        return self._format_for_codespeed(run_id, run_id.get_statistics())
 
     def report_job_completed(self, run_ids):
         if self._incremental_report:

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -21,6 +21,7 @@ import unittest
 import subprocess
 import os
 
+from .persistence import TestPersistence
 from .rebench_test_case import ReBenchTestCase
 from ..rebench           import ReBench
 from ..executor          import Executor
@@ -79,10 +80,16 @@ class ExecutorTest(ReBenchTestCase):
     def _basic_execution(self, cnf):
         runs = cnf.get_runs()
         self.assertEqual(8, len(runs))
-        ex = Executor(cnf.get_runs(), cnf.use_nice, cnf.do_builds, TestDummyUI())
+
+        runs = cnf.get_runs()
+        persistence = TestPersistence()
+        for run in runs:
+            run.add_persistence(persistence)
+
+        ex = Executor(runs, cnf.use_nice, cnf.do_builds, TestDummyUI())
         ex.execute()
         for run in runs:
-            data_points = run.get_data_points()
+            data_points = persistence.get_data_points(run)
             self.assertEqual(10, len(data_points))
             for data_point in data_points:
                 measurements = data_point.get_measurements()

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -54,19 +54,6 @@ class ExecutorTest(ReBenchTestCase):
         finally:
             subprocess.Popen = old_popen
 
-# TODO: should test more details
-#        (mean, sdev, (interval, interval_percentage),
-#                (interval_t, interval_percentage_t)) = ex.result['test-executor']['test-bench']
-#
-#        self.assertEqual(31, len(ex.benchmark_data['test-executor']['test-bench']))
-#        self.assertAlmostEqual(45870.4193548, mean)
-#        self.assertAlmostEqual(2.93778711485, sdev)
-#
-#        (i_low, i_high) = interval
-#        self.assertAlmostEqual(45869.385195243565, i_low)
-#        self.assertAlmostEqual(45871.453514433859, i_high)
-#        self.assertAlmostEqual(0.00450904792104, interval_percentage)
-
     def test_broken_command_format_with_ValueError(self):
         with self.assertRaises(UIError) as err:
             options = ReBench().shell_options().parse_args(['dummy'])

--- a/rebench/tests/features/issue_15_warm_up_support_test.py
+++ b/rebench/tests/features/issue_15_warm_up_support_test.py
@@ -57,4 +57,3 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         ex.execute()
 
         self.assertEqual(runs[0].get_number_of_data_points(), 10)
-        self.assertLessEqual(runs[0].get_total_values()[0], 850)

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -20,6 +20,7 @@
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
+from ..persistence import TestPersistence
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -38,12 +39,16 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
         cnf = Configurator(load_config(self._path + '/issue_16.conf'), DataStore(self._ui),
                            self._ui, exp_name=exp_name,
                            data_file=self._tmp_file)
+        runs = cnf.get_runs()
+        persistence = TestPersistence()
+        for run in runs:
+            run.add_persistence(persistence)
         ex = Executor(cnf.get_runs(), False, False, self._ui)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))
-        self.assertEqual(num_data_points, len(run.get_data_points()))
-        return run.get_data_points()
+        self.assertEqual(num_data_points, run.get_number_of_data_points())
+        return persistence.get_data_points()
 
     def test_records_multiple_data_points_from_single_execution_10(self):
         self._records_data_points('Test1', 10)

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 from ...configurator           import Configurator, load_config
 from ...executor               import Executor
 from ...persistence            import DataStore
+from ..persistence import TestPersistence
 from ..rebench_test_case import ReBenchTestCase
 
 
@@ -38,12 +39,17 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         cnf = Configurator(load_config(self._path + '/issue_31.conf'), DataStore(self._ui),
                            self._ui, exp_name=exp_name,
                            data_file=self._tmp_file)
-        ex = Executor(cnf.get_runs(), False, False, self._ui)
+        runs = cnf.get_runs()
+        persistence = TestPersistence()
+        for run in runs:
+            run.add_persistence(persistence)
+
+        ex = Executor(runs, False, False, self._ui)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))
-        self.assertEqual(num_data_points, len(run.get_data_points()))
-        return run.get_data_points()
+        self.assertEqual(num_data_points, run.get_number_of_data_points())
+        return persistence.get_data_points()
 
     def test_records_multiple_data_points_from_single_execution_10(self):
         self._records_data_points('Test1', 10)

--- a/rebench/tests/persistence.py
+++ b/rebench/tests/persistence.py
@@ -1,0 +1,15 @@
+class TestPersistence(object):
+
+    def __init__(self):
+        self._data_points = []
+
+    def get_data_points(self, run_id=None):
+        if run_id:
+            return [dp for dp in self._data_points if dp.run_id is run_id]
+        return self._data_points
+
+    def persist_data_point(self, data_point):
+        self._data_points.append(data_point)
+
+    def close(self):
+        pass

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -66,11 +66,11 @@ class PersistencyTest(ReBenchTestCase):
         self.assertEqual(num_invocations, run.completed_invocations)
 
     def test_iteration_invocation_semantics(self):
-        ## Executes first time
+        # Executes first time
         ds = DataStore(self._ui)
         cnf = Configurator(load_config(self._path + '/persistency.conf'),
                            ds, self._ui, data_file=self._tmp_file)
-        ds.load_data()
+        ds.load_data(None, False)
 
         self._assert_runs(cnf, 1, 0, 0)
 
@@ -79,16 +79,44 @@ class PersistencyTest(ReBenchTestCase):
 
         self._assert_runs(cnf, 1, 10, 10)
 
-        ## Execute a second time, should not add any data points,
-        ## because goal is already reached
+        # Execute a second time, should not add any data points,
+        # because goal is already reached
         ds2 = DataStore(self._ui)
         cnf2 = Configurator(load_config(self._path + '/persistency.conf'),
                             ds2, self._ui, data_file=self._tmp_file)
-        ds2.load_data()
+        ds2.load_data(None, False)
 
         self._assert_runs(cnf2, 1, 10, 10)
 
         ex2 = Executor(cnf2.get_runs(), False, False, self._ui)
+        ex2.execute()
+
+        self._assert_runs(cnf2, 1, 10, 10)
+
+    def test_data_discarding(self):
+        # Executes first time
+        ds = DataStore(self._ui)
+        cnf = Configurator(load_config(self._path + '/persistency.conf'),
+                           ds, self._ui, data_file=self._tmp_file)
+        ds.load_data(None, False)
+
+        self._assert_runs(cnf, 1, 0, 0)
+
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
+        ex.execute()
+
+        self._assert_runs(cnf, 1, 10, 10)
+
+        # Execute a second time, this time, discard the data first, and then rerun
+        ds2 = DataStore(self._ui)
+        cnf2 = Configurator(load_config(self._path + '/persistency.conf'),
+                            ds2, self._ui, data_file=self._tmp_file)
+        run2 = cnf2.get_runs()
+        ds2.load_data(run2, True)
+
+        self._assert_runs(cnf2, 1, 0, 0)
+
+        ex2 = Executor(run2, False, False, self._ui)
         ex2.execute()
 
         self._assert_runs(cnf2, 1, 10, 10)

--- a/rebench/tests/stats_test.py
+++ b/rebench/tests/stats_test.py
@@ -18,20 +18,8 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-
-## This code is inspired by https://code.google.com/p/python-statlib
-
 import unittest
-from .. import statistics as stats
-
-NUMPY_AND_SCIPY_AVAILABLE = False
-try:
-    import numpy
-    import scipy.stats
-    # import scipy.stats.distributions -- not yet implemented
-    NUMPY_AND_SCIPY_AVAILABLE = True
-except ImportError:
-    NUMPY_AND_SCIPY_AVAILABLE = False
+from ..statistics import StatisticProperties
 
 
 class StatsTest(unittest.TestCase):
@@ -44,136 +32,39 @@ class StatsTest(unittest.TestCase):
         self._mixed = [x if x % 2 == 0 else float(x) + 4.5
                        for x in self._integers]
 
-    def test_mean_simple(self):
-        self.assertEqual(2, stats.mean([1, 2, 3]))
-        self.assertAlmostEqual(2, stats.mean([1.0, 2.0, 3.0]))
+    def _assert(self, stats, mean_val, geo_mean, min_val, max_val, std_dev):
+        self.assertAlmostEqual(mean_val, stats.mean)
+        self.assertAlmostEqual(geo_mean, stats.geom_mean)
 
-        self.assertAlmostEqual(25, stats.mean(self._integers))
-        self.assertAlmostEqual(25, stats.mean(self._floats))
-        self.assertAlmostEqual(25 + 2.31, stats.mean(self._floats2))
-        self.assertAlmostEqual(27.295918367, stats.mean(self._mixed))
+        self.assertEqual(min_val, stats.min)
+        self.assertEqual(max_val, stats.max)
+        self.assertAlmostEqual(std_dev, stats.std_dev)
 
-    @unittest.skipUnless(NUMPY_AND_SCIPY_AVAILABLE,
-                         "NumPy or SciPy is not available")
-    def test_mean_vs_numpy(self):
-        self.assertEqual(numpy.mean([1, 2, 3]),
-                         stats.mean([1, 2, 3]))
-        self.assertAlmostEqual(numpy.mean([1.0, 2.0, 3.0]),
-                               stats.mean([1.0, 2.0, 3.0]))
+    def test_123(self):
+        stats = StatisticProperties()
+        stats.add([1, 2, 3])
+        self._assert(stats, 2, 1.817120592, 1, 3, 0.816496580927726)
 
-        self.assertAlmostEqual(numpy.mean(self._integers),
-                               stats.mean(self._integers))
+        stats = StatisticProperties()
+        stats.add([1.0, 2.0, 3.0])
+        self._assert(stats, 2, 1.817120592, 1.0, 3.0, 0.816496580927726)
 
-        self.assertAlmostEqual(numpy.mean(self._floats),
-                               stats.mean(self._floats))
+    def test_1to49(self):
+        stats = StatisticProperties()
+        stats.add(self._integers)
+        self._assert(stats, 25, 19.112093553, 1, 49, 14.142135623730951)
 
-        self.assertAlmostEqual(numpy.mean(self._floats2),
-                               stats.mean(self._floats2))
+        stats = StatisticProperties()
+        stats.add(self._floats)
+        self._assert(stats, 25, 19.112093553, 1.0, 49.0, 14.142135623730951)
 
-        self.assertAlmostEqual(numpy.mean(self._mixed),
-                               stats.mean(self._mixed))
+    def test_shifted(self):
+        stats = StatisticProperties()
+        stats.add(self._floats2)
+        self._assert(stats, 25 + 2.31, 22.533409416, 1.0 + 2.31, 49.0 + 2.31, 14.142135623730951)
 
-    def test_median_simple(self):
-        self.assertEqual(2.5, stats.median([1, 2, 3, 4]))
-        self.assertAlmostEqual(2.5, stats.median([1.0, 2.0, 3.0, 4.0]))
-
-        self.assertAlmostEqual(25, stats.median(self._integers))
-        self.assertAlmostEqual(25, stats.median(self._floats))
-        self.assertAlmostEqual(25 + 2.31, stats.median(self._floats2))
-        self.assertAlmostEqual(27.5, stats.median(self._mixed))
-
-    @unittest.skipUnless(NUMPY_AND_SCIPY_AVAILABLE,
-                         "NumPy or SciPy is not available")
-    def test_median_vs_numpy(self):
-        self.assertEqual(numpy.median([1, 2, 3, 4]),
-                         stats.median([1, 2, 3, 4]))
-        self.assertAlmostEqual(numpy.median([1.0, 2.0, 3.0, 4.0]),
-                               stats.median([1.0, 2.0, 3.0, 4.0]))
-
-        self.assertAlmostEqual(numpy.median(self._integers),
-                               stats.median(self._integers))
-
-        self.assertAlmostEqual(numpy.median(self._floats),
-                               stats.median(self._floats))
-
-        self.assertAlmostEqual(numpy.median(self._floats2),
-                               stats.median(self._floats2))
-
-        self.assertAlmostEqual(numpy.median(self._mixed),
-                               stats.median(self._mixed))
-
-    def test_geomean_simple(self):
-        self.assertAlmostEqual(1.817120592, stats.geo_mean([1, 2, 3]))
-        self.assertAlmostEqual(1.817120592, stats.geo_mean([1.0, 2.0, 3.0]))
-
-        self.assertAlmostEqual(19.112093553, stats.geo_mean(self._integers))
-        self.assertAlmostEqual(19.112093553, stats.geo_mean(self._floats))
-        self.assertAlmostEqual(22.533409416, stats.geo_mean(self._floats2))
-        self.assertAlmostEqual(22.245044799, stats.geo_mean(self._mixed))
-
-    @unittest.skipUnless(NUMPY_AND_SCIPY_AVAILABLE,
-                         "NumPy or SciPy is not available")
-    def test_geomean_vs_scipy(self):
-        self.assertAlmostEqual(scipy.stats.gmean([1, 2, 3]),
-                               stats.geo_mean([1, 2, 3]))
-        self.assertAlmostEqual(scipy.stats.gmean([1.0, 2.0, 3.0]),
-                               stats.geo_mean([1.0, 2.0, 3.0]))
-
-        self.assertAlmostEqual(scipy.stats.gmean(self._integers),
-                               stats.geo_mean(self._integers))
-
-        self.assertAlmostEqual(scipy.stats.gmean(self._floats),
-                               stats.geo_mean(self._floats))
-
-        self.assertAlmostEqual(scipy.stats.gmean(self._floats2),
-                               stats.geo_mean(self._floats2))
-
-        self.assertAlmostEqual(scipy.stats.gmean(self._mixed),
-                               stats.geo_mean(self._mixed))
-
-    def test_stddev_simple(self):
-        self.assertAlmostEqual(0.8164965809,
-                               stats.stddev([1, 2, 3]))
-        self.assertAlmostEqual(0.8164965809,
-                               stats.stddev([1.0, 2.0, 3.0]))
-
-        self.assertAlmostEqual(14.142135623,
-                               stats.stddev(self._integers))
-
-        self.assertAlmostEqual(14.142135623,
-                               stats.stddev(self._floats))
-
-        self.assertAlmostEqual(14.142135623,
-                               stats.stddev(self._floats2))
-
-        self.assertAlmostEqual(14.319929870,
-                               stats.stddev(self._mixed))
-
-    @unittest.skipUnless(NUMPY_AND_SCIPY_AVAILABLE,
-                         "NumPy or SciPy is not available")
-    def test_stddev_vs_numpy(self):
-        self.assertAlmostEqual(numpy.std([1, 2, 3]),
-                               stats.stddev([1, 2, 3]))
-        self.assertAlmostEqual(numpy.std([1.0, 2.0, 3.0]),
-                               stats.stddev([1.0, 2.0, 3.0]))
-
-        self.assertAlmostEqual(numpy.std(self._integers),
-                               stats.stddev(self._integers))
-
-        self.assertAlmostEqual(numpy.std(self._floats),
-                               stats.stddev(self._floats))
-
-        self.assertAlmostEqual(numpy.std(self._floats2),
-                               stats.stddev(self._floats2))
-
-        self.assertAlmostEqual(numpy.std(self._mixed),
-                               stats.stddev(self._mixed))
-
-# TODO: implement
-#    @unittest.skipUnless(are_numpy_and_scipy_available, "NumPy or SciPy is not available")
-#    def test_norm_distribution(self):
-#        self.fail("not yet implemented")
-#
-#    @unittest.skipUnless(are_numpy_and_scipy_available, "NumPy or SciPy is not available")
-#    def test_t_distribution(self):
-#        self.fail("not yet implemented")
+    def test_mixed(self):
+        stats = StatisticProperties()
+        stats.add(self._mixed)
+        self.assertAlmostEqual(27.295918367, stats.mean)
+        self._assert(stats, 27.295918367, 22.245044799, 2, 53.5, 14.319929870761944)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(name='ReBench',
       entry_points = {
           'console_scripts' : ['rebench = rebench.rebench:main_func']
       },
-      tests_require = ['scipy>=0.8.0'],
       test_suite = 'rebench.tests',
       license = 'MIT'
 )


### PR DESCRIPTION
This PR changes the way ReBench handles data.
It fixes #100.

The key idea is to avoid keeping all data points and measurements in memory.
This is achieved by calculating statistics incrementally.

One major change related to it is how we discard data for reruns, which is now fused with loading that data file. This may speedup data loading, too.

@daumayr this should hopefully fix your issue.