### PR TITLE
Fix how settings are inherited, strictly follow documentation

### DIFF
--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -27,7 +27,7 @@ from .exp_variables import ExpVariables
 class BenchmarkSuite(object):
 
     @classmethod
-    def compile(cls, suite_name, suite, executor, run_details, variables, build_commands):
+    def compile(cls, suite_name, suite, executor, build_commands):
         gauge_adapter = suite.get('gauge_adapter')
         command = suite.get('command')
 
@@ -40,8 +40,8 @@ class BenchmarkSuite(object):
         description = suite.get('description')
         desc = suite.get('desc')
 
-        run_details = ExpRunDetails.compile(suite, run_details)
-        variables = ExpVariables.compile(suite, variables)
+        run_details = ExpRunDetails.compile(suite, executor.run_details)
+        variables = ExpVariables.compile(suite, executor.variables)
 
         return BenchmarkSuite(suite_name, executor, gauge_adapter, command, location,
                               build, benchmarks_config, description or desc, run_details, variables)

--- a/rebench/tests/bugs/issue_112.conf
+++ b/rebench/tests/bugs/issue_112.conf
@@ -1,0 +1,20 @@
+default_experiment: Test
+
+benchmark_suites:
+    Suite:
+        gauge_adapter: TestExecutor
+        command: TestBenchMarks %(benchmark)s
+        benchmarks:
+            - Bench1
+executors:
+    TestRunner1:
+        path: .
+        executable: vm-one-result.py
+
+experiments:
+    Test:
+        invocations: 10
+        suites:
+         - Suite
+        executions:
+         - TestRunner1

--- a/rebench/tests/bugs/issue_112.conf
+++ b/rebench/tests/bugs/issue_112.conf
@@ -1,7 +1,17 @@
 default_experiment: Test
 
+runs:
+    invocations: 5
+
 benchmark_suites:
     Suite:
+        gauge_adapter: TestExecutor
+        command: TestBenchMarks %(benchmark)s
+        benchmarks:
+            - Bench1
+
+    SuiteWithSetting:
+        invocations:  3
         gauge_adapter: TestExecutor
         command: TestBenchMarks %(benchmark)s
         benchmarks:
@@ -12,9 +22,28 @@ executors:
         executable: vm-one-result.py
 
 experiments:
-    Test:
+    ExpSetting:
         invocations: 10
         suites:
          - Suite
         executions:
          - TestRunner1
+
+    ExecSetting:
+        executions:
+            - TestRunner1:
+                  invocations: 7
+                  suites:
+                      - Suite
+
+    GlobalSetting:
+        suites:
+            - Suite
+        executions:
+            - TestRunner1
+
+    SuiteSetting:
+        suites:
+            - SuiteWithSetting
+        executions:
+            - TestRunner1

--- a/rebench/tests/bugs/issue_112_invocations_setting_ignored_test.py
+++ b/rebench/tests/bugs/issue_112_invocations_setting_ignored_test.py
@@ -1,0 +1,29 @@
+from ..rebench_test_case import ReBenchTestCase
+
+from ...persistence import DataStore
+from ...configurator import Configurator, load_config
+from ...executor import Executor
+
+
+class Issue112Test(ReBenchTestCase):
+
+    def setUp(self):
+        super(Issue112Test, self).setUp()
+        self._set_path(__file__)
+
+    def test_iteration_invocation_semantics(self):
+        # Executes first time
+        ds = DataStore(self._ui)
+        cnf = Configurator(load_config(self._path + '/issue_112.conf'),
+                           ds, self._ui, data_file=self._tmp_file)
+        ds.load_data(None, False)
+
+        # Has not executed yet, check that there is simply
+        self._assert_runs(cnf, 1, 0, 0)
+
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
+        ex.execute()
+
+        self._assert_runs(cnf, 1, 10, 10)
+        self.assertTrue(False)
+

--- a/rebench/tests/bugs/issue_112_invocations_setting_ignored_test.py
+++ b/rebench/tests/bugs/issue_112_invocations_setting_ignored_test.py
@@ -11,11 +11,11 @@ class Issue112Test(ReBenchTestCase):
         super(Issue112Test, self).setUp()
         self._set_path(__file__)
 
-    def test_iteration_invocation_semantics(self):
+    def test_invocation_setting_on_experiment(self):
         # Executes first time
         ds = DataStore(self._ui)
         cnf = Configurator(load_config(self._path + '/issue_112.conf'),
-                           ds, self._ui, data_file=self._tmp_file)
+                           ds, self._ui, exp_name='ExpSetting', data_file=self._tmp_file)
         ds.load_data(None, False)
 
         # Has not executed yet, check that there is simply
@@ -25,5 +25,48 @@ class Issue112Test(ReBenchTestCase):
         ex.execute()
 
         self._assert_runs(cnf, 1, 10, 10)
-        self.assertTrue(False)
 
+    def test_invocation_setting_on_experiment_execution_detail(self):
+        # Executes first time
+        ds = DataStore(self._ui)
+        cnf = Configurator(load_config(self._path + '/issue_112.conf'),
+                           ds, self._ui, exp_name='ExecSetting', data_file=self._tmp_file)
+        ds.load_data(None, False)
+
+        # Has not executed yet, check that there is simply
+        self._assert_runs(cnf, 1, 0, 0)
+
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
+        ex.execute()
+
+        self._assert_runs(cnf, 1, 7, 7)
+
+    def test_invocation_setting_for_global_run_details(self):
+        # Executes first time
+        ds = DataStore(self._ui)
+        cnf = Configurator(load_config(self._path + '/issue_112.conf'),
+                           ds, self._ui, exp_name='GlobalSetting', data_file=self._tmp_file)
+        ds.load_data(None, False)
+
+        # Has not executed yet, check that there is simply
+        self._assert_runs(cnf, 1, 0, 0)
+
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
+        ex.execute()
+
+        self._assert_runs(cnf, 1, 5, 5)
+
+    def test_invocation_setting_in_suite(self):
+        # Executes first time
+        ds = DataStore(self._ui)
+        cnf = Configurator(load_config(self._path + '/issue_112.conf'),
+                           ds, self._ui, exp_name='SuiteSetting', data_file=self._tmp_file)
+        ds.load_data(None, False)
+
+        # Has not executed yet, check that there is simply
+        self._assert_runs(cnf, 1, 0, 0)
+
+        ex = Executor(cnf.get_runs(), False, False, self._ui)
+        ex.execute()
+
+        self._assert_runs(cnf, 1, 3, 3)

--- a/rebench/tests/bugs/vm-one-result.py
+++ b/rebench/tests/bugs/vm-one-result.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# simple script emulating an executor generating benchmark results
+from __future__ import print_function
+
+import sys
+import random
+
+print(sys.argv)
+
+print("Harness Name: ", sys.argv[1])
+print("Bench Name:", sys.argv[2])
+
+print("RESULT-total: ", random.triangular(700, 850))

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -57,14 +57,6 @@ class PersistencyTest(ReBenchTestCase):
 
         self.assertEqual(deserialized.run_id, measurement.run_id)
 
-    def _assert_runs(self, cnf, num_runs, num_dps, num_invocations):
-        runs = cnf.get_runs()
-        self.assertEqual(num_runs, len(runs))
-        run = list(runs)[0]
-
-        self.assertEqual(num_dps, run.get_number_of_data_points())
-        self.assertEqual(num_invocations, run.completed_invocations)
-
     def test_iteration_invocation_semantics(self):
         # Executes first time
         ds = DataStore(self._ui)

--- a/rebench/tests/rebench_test_case.py
+++ b/rebench/tests/rebench_test_case.py
@@ -45,3 +45,18 @@ class ReBenchTestCase(TestCase):
     def tearDown(self):
         os.remove(self._tmp_file)
         sys.exit = self._sys_exit
+
+    def _assert_runs(self, cnf, num_runs, num_dps, num_invocations):
+        """
+        :param cnf: Configurator
+        :param num_runs: expected number of runs
+        :param num_dps: expected number of data points
+        :param num_invocations: expected number of invocations
+        :return:
+        """
+        runs = cnf.get_runs()
+        self.assertEqual(num_runs, len(runs))
+        run = list(runs)[0]
+
+        self.assertEqual(num_dps, run.get_number_of_data_points())
+        self.assertEqual(num_invocations, run.completed_invocations)


### PR DESCRIPTION
This fixes #112.

Simplify the implementation, and remove a strange deviation from the simple case.
We kept the executor objects globally, which meant they were not configured in the context of an experiment.

This change fixes this by not keeping them anymore, but instantiate them as all other settings.