### PR TITLE
Fix rendering of docs on readthedocs.io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: ReBench Project documentation
 site_author: ReBench contributors
 
 pages:
-  - 'ReBench: Execute and Document Benchmarks Reproducibly': index.md
+  - Home:           index.md
   - Basic Concepts: concepts.md
   - Usage:          usage.md
   - Configuration:  config.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: 'ReBench: Execute and Document Benchmarks Reproducibly'
-site_description: ReBench Project documentation
-site_author: ReBench contributors
+site_description: ReBench documentation
+site_author: 'ReBench contributors, see AUTHORS.md'
 
 pages:
   - Home:           index.md


### PR DESCRIPTION
Somehow their rendering template changed in a way that the title for the first page/home is causing the first lines of text to be hidden.