### PR TITLE
Add ignore_timeout setting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -266,6 +266,8 @@ runs:
 
 **max_invocation_time:**
 
+<a id="max_invocation_time"></a>
+
 Time in seconds after which an invocation is terminated.
 The value -1 indicates that there invocations should never be terminated.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -270,6 +270,7 @@ runs:
 
 Time in seconds after which an invocation is terminated.
 The value -1 indicates that there invocations should never be terminated.
+See also [`ignore_timeouts`](#ignore_timeouts).
 
 Default: `-1`
 
@@ -278,6 +279,25 @@ Example:
 ```yaml
 runs:
   max_invocation_time: 600
+```
+
+---
+
+**ignore_timeouts:**
+
+<a id="ignore_timeouts"></a>
+
+In complex benchmark setups, some benchmarks may take too long
+and the additional data points of longer execution might
+add only minimal additional confidence. For these cases,
+timeouts of executions that take longer than
+[`max_invocation_time`](#max_invocation_time) might be reasonably ignored.
+
+Default: `false`
+
+```yaml
+runs:
+  ignore_timeouts: true
 ```
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,7 +1,7 @@
 # Usage
 
 ReBench is a command-line tool. In the following, we will discuss its usage.
-A basic help can be displayed with the `--help` argument:
+The complete set of options can be displayed with the `--help` argument:
 
 ```bash
 $ rebench --help
@@ -121,7 +121,7 @@ by adding the following line in `/etc/security/limits.conf`:
 user_executing_benchmarks    -       nice            -20
 ```
 
-#### Discarding Data, Rerunning Experiments
+#### Discarding Data, Rerunning Experiments, and Faulty Runs
 
 ReBench's normal execution mode will assume that it should accumulate all data
 until a complete data set is reached.
@@ -133,6 +133,16 @@ Some times, we may want to update some experiments and discard old data:
 ```text
 -c, --clean   Discard old data from the data file (configured in the run description).
 -r, --rerun   Rerun selected experiments, and discard old data from data file.
+```
+
+[Runs](concepts.md#run) may fail for a variety reasons. A benchmark might be
+buggy, the executor may be faulty or unavailable, or the run reaches the
+[`max_invocation_time`](config.md#max_invocation_time).
+To include all data generated for the benchmark until it failed,
+we can use the `-f` option: 
+
+```text
+-f, --faulty  Include results of faulty or failing runs
 ```
 
 #### Execution Order

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -135,7 +135,7 @@ Some times, we may want to update some experiments and discard old data:
 -r, --rerun   Rerun selected experiments, and discard old data from data file.
 ```
 
-[Runs](concepts.md#run) may fail for a variety reasons. A benchmark might be
+[Runs](concepts.md#run) may fail for a variety of reasons. A benchmark might be
 buggy, the executor may be faulty or unavailable, or the run reaches the
 [`max_invocation_time`](config.md#max_invocation_time).
 To include all data generated for the benchmark until it failed,

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -479,7 +479,7 @@ class Executor(object):
                        + "{ind}{ind}The file may not be marked as executable.\n"
                        + "{ind}Return code: %d\n") % (
                            run_id.benchmark.suite.executor.name, return_code)
-            elif return_code == -9:
+            elif return_code == subprocess_timeout.E_TIMEOUT:
                 msg = ("{ind}Run timed out.\n"
                        + "{ind}{ind}Return code: %d\n"
                        + "{ind}{ind}max_invocation_time: %s\n") % (

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -471,7 +471,8 @@ class Executor(object):
             self._ui.error(msg, run_id, cmdline)
             return True
 
-        if return_code != 0 and not self._include_faulty:
+        if return_code != 0 and not self._include_faulty and not (
+                return_code == subprocess_timeout.E_TIMEOUT and run_id.ignore_timeouts):
             run_id.indicate_failed_execution()
             run_id.report_run_failed(cmdline, return_code, output)
             if return_code == 126:

--- a/rebench/model/exp_run_details.py
+++ b/rebench/model/exp_run_details.py
@@ -32,6 +32,8 @@ class ExpRunDetails(object):
                                                     defaults.min_iteration_time))
         max_invocation_time = none_or_int(config.get('max_invocation_time',
                                                      defaults.max_invocation_time))
+        ignore_timeouts = none_or_bool(config.get('ignore_timeouts',
+                                                  defaults.ignore_timeouts))
 
         parallel_interference_factor = none_or_float(config.get(
             'parallel_interference_factor', defaults.parallel_interference_factor))
@@ -42,22 +44,22 @@ class ExpRunDetails(object):
                                                        defaults.retries_after_failure))
 
         return ExpRunDetails(invocations, iterations, warmup, min_iteration_time,
-                             max_invocation_time, parallel_interference_factor, execute_exclusively,
-                             retries_after_failure,
+                             max_invocation_time, ignore_timeouts, parallel_interference_factor,
+                             execute_exclusively, retries_after_failure,
                              defaults.invocations_override, defaults.iterations_override)
 
     @classmethod
     def empty(cls):
-        return ExpRunDetails(None, None, None, None, None, None, None, None, None, None)
+        return ExpRunDetails(None, None, None, None, None, None, None, None, None, None, None)
 
     @classmethod
     def default(cls, invocations_override, iterations_override):
-        return ExpRunDetails(1, 1, None, 50, -1, None, True, 0,
+        return ExpRunDetails(1, 1, None, 50, -1, None, None, True, 0,
                              invocations_override, iterations_override)
 
     def __init__(self, invocations, iterations, warmup, min_iteration_time,
-                 max_invocation_time, parallel_interference_factor, execute_exclusively,
-                 retries_after_failure,
+                 max_invocation_time, ignore_timeouts, parallel_interference_factor,
+                 execute_exclusively, retries_after_failure,
                  invocations_override, iterations_override):
         self._invocations = invocations
         self._iterations = iterations
@@ -65,6 +67,7 @@ class ExpRunDetails(object):
 
         self._min_iteration_time = min_iteration_time
         self._max_invocation_time = max_invocation_time
+        self._ignore_timeouts = ignore_timeouts
         self._parallel_interference_factor = parallel_interference_factor
         self._execute_exclusively = execute_exclusively
         self._retries_after_failure = retries_after_failure
@@ -99,6 +102,10 @@ class ExpRunDetails(object):
     @property
     def max_invocation_time(self):
         return self._max_invocation_time
+
+    @property
+    def ignore_timeouts(self):
+        return self._ignore_timeouts
 
     @property
     def parallel_interference_factor(self):

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -57,6 +57,10 @@ class RunId(object):
         return self._benchmark.run_details.max_invocation_time
 
     @property
+    def ignore_timeouts(self):
+        return self._benchmark.run_details.ignore_timeouts
+
+    @property
     def retries_after_failure(self):
         return self._benchmark.run_details.retries_after_failure
 

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -34,6 +34,13 @@ schema;runs_type:
         Time in second after which an invocation is terminated.
         The value -1 indicates that there is no timeout intended.
       # default: -1 #  can't specify this here, because the defaults override settings
+    ignore_timeouts:
+      type: bool
+      desc: |
+        When max_invocation_time is reached, do not report an error.
+        Instead, accept the data and disregard the timeout.
+        Benchmark setups that are confirmed to be working, for which errors
+        or warnings may confuse users.
     parallel_interference_factor:
       type: float
       desc: |

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -17,6 +17,9 @@ try:
 except NameError:
     IS_PY3 = False
 
+# Indicate timeout with standard exit code
+E_TIMEOUT = -9
+
 
 class _SubprocessThread(Thread):
 
@@ -175,7 +178,7 @@ def _kill_process(pid, recursively, thread):
 
     thread.join()
 
-    return -9, thread.stdout_result, thread.stderr_result
+    return E_TIMEOUT, thread.stdout_result, thread.stderr_result
 
 
 def _get_process_children(pid):

--- a/rebench/tests/features/ignore_timeouts.conf
+++ b/rebench/tests/features/ignore_timeouts.conf
@@ -1,0 +1,59 @@
+default_experiment: GlobalSettings
+
+runs:
+  ignore_timeouts: true
+  max_invocation_time: 1
+
+benchmark_suites:
+    Suite:
+        gauge_adapter: TestExecutor
+        command: Suite %(benchmark)s
+        benchmarks:
+          - Bench1
+
+    SuiteIgnoreTrue:
+        gauge_adapter: TestExecutor
+        command: SuiteIgnoreTrue %(benchmark)s
+        benchmarks:
+            - Bench1
+        ignore_timeouts: true
+
+    SuiteIgnoreFalse:
+        gauge_adapter: TestExecutor
+        command: SuiteIgnoreFalse %(benchmark)s
+        benchmarks:
+            - Bench1
+        ignore_timeouts: false
+
+executors:
+    Runner:
+        path: .
+        executable: ignore_timeouts_vm.py
+        args: "1"
+    RunnerIgnoreTrue:
+        path: .
+        executable: ignore_timeouts_vm.py
+        ignore_timeouts: true
+        args: "2"
+    RunnerIgnoreFalse:
+        path: .
+        executable: ignore_timeouts_vm.py
+        ignore_timeouts: false
+        args: "3"
+
+experiments:
+    GlobalSettings:
+        suites:
+          - Suite
+          - SuiteIgnoreTrue
+          - SuiteIgnoreFalse
+        executions:
+          - Runner
+          - RunnerIgnoreTrue
+          - RunnerIgnoreFalse
+
+    Exec:
+        suites:
+          - SuiteIgnoreTrue
+        executions:
+          - Runner

--- a/rebench/tests/features/ignore_timeouts_test.py
+++ b/rebench/tests/features/ignore_timeouts_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2019 Stefan Marr <http://www.stefan-marr.de/>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+from ..rebench_test_case import ReBenchTestCase
+
+from ...configurator import Configurator, load_config
+from ...executor import Executor
+from ...persistence import DataStore
+
+
+class IgnoreTimeoutsTest(ReBenchTestCase):
+
+    def setUp(self):
+        super(IgnoreTimeoutsTest, self).setUp()
+        self._set_path(__file__)
+
+    def _init(self, exp_name):
+        ds = DataStore(self._ui)
+        cnf = Configurator(load_config(self._path + '/ignore_timeouts.conf'),
+                           ds, self._ui, exp_name=exp_name, data_file=self._tmp_file)
+        ds.load_data(None, False)
+        runs = list(cnf.get_runs())
+        runs = sorted(runs, key=lambda e: e.cmdline())
+        return ds, cnf, runs
+
+    def test_ignore_timeouts_globally(self):
+        # test that the flag is set correctly on the runs
+        _, _, runs = self._init('GlobalSettings')
+
+        self.assertTrue(runs[0].ignore_timeouts)
+        self.assertFalse(runs[1].ignore_timeouts)
+        self.assertTrue(runs[2].ignore_timeouts)
+        self.assertTrue(runs[3].ignore_timeouts)
+        self.assertFalse(runs[4].ignore_timeouts)
+        self.assertTrue(runs[5].ignore_timeouts)
+        self.assertFalse(runs[6].ignore_timeouts)
+        self.assertFalse(runs[7].ignore_timeouts)
+        self.assertTrue(runs[8].ignore_timeouts)
+
+    def test_ignore_timeouts_accepts_data_after_timeout_and_does_not_cause_warnings(self):
+        _, cnf, runs = self._init('Exec')
+        self.assertEqual(1, len(runs))
+
+        ex = Executor(runs, False, False, self._ui)
+        ex.execute()
+
+        self._assert_runs(cnf, 1, 10, 1)
+        self.assertFalse(runs[0].run_failed())

--- a/rebench/tests/features/ignore_timeouts_vm.py
+++ b/rebench/tests/features/ignore_timeouts_vm.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# simple script emulating an executor generating benchmark results
+from __future__ import print_function
+
+import sys
+import random
+from time import sleep
+
+print(sys.argv)
+
+print("Arg: ", sys.argv[1])
+print("Harness Name: ", sys.argv[2])
+print("Bench Name:", sys.argv[3])
+
+for _ in range(10):
+    print("RESULT-total: ", random.triangular(700, 850))
+
+sys.stdout.flush()
+
+sleep(10)

--- a/rebench/tests/subprocess_timeout_test.py
+++ b/rebench/tests/subprocess_timeout_test.py
@@ -50,7 +50,7 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              shell=True, timeout=1)
 
         output = output.decode('utf-8')
-        self.assertEqual(-9, return_code)
+        self.assertEqual(sub.E_TIMEOUT, return_code)
         self.assertEqual("", output)
         self.assertEqual(None, err)
 
@@ -62,7 +62,7 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              shell=True, timeout=5)
 
         output = output.decode('utf-8')
-        self.assertEqual(-9, return_code)
+        self.assertEqual(sub.E_TIMEOUT, return_code)
         self.assertEqual("", output)
         self.assertEqual(None, err)
 


### PR DESCRIPTION
For some benchmark configurations timeouts may be expected, for instance, when optimization are disabled. In such cases, timeouts may be acceptable and can be ignored.

This setting should however be used carefully to avoid missing unexpected timeouts or optimization problems.