### PR TITLE
Fix ReBench schema to be YAML 1.2 compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
       dist: xenial
       before_install:
         - pip install pylint
+    - python: "3.7-dev"
+      dist: xenial
+      before_install:
+        - pip install pylint
+        - pip install ruamel.yaml
     # PyPy versions
     - python: pypy
       env: DO_LINT="echo On PyPy, we won't "

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -119,8 +119,7 @@ schema;benchmark_type_map:
     regex;(.+):
       type: map
       mapping:
-        <<: *EXP_RUN_DETAILS
-        <<: *EXP_VARIABLES
+        <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
         extra_args:
           type: scalar
           desc: This extra argument is appended to the benchmark's command line.
@@ -155,8 +154,7 @@ schema;build_type:
 schema;benchmark_suite_type:
   type: map
   mapping:
-    <<: *EXP_RUN_DETAILS
-    <<: *EXP_VARIABLES
+    <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
     gauge_adapter:
       type: str
       required: yes
@@ -200,8 +198,7 @@ schema;benchmark_suite_type:
 schema;executor_type:
   type: map
   mapping:
-    <<: *EXP_RUN_DETAILS
-    <<: *EXP_VARIABLES
+    <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
     path:
       type: str
       required: no
@@ -239,8 +236,7 @@ schema;exp_exec_type:
     regex;(.+):
       type: map
       mapping:
-        <<: *EXP_RUN_DETAILS
-        <<: *EXP_VARIABLES
+        <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
         suites:
           include: exp_suite_type
 
@@ -248,8 +244,7 @@ schema;experiment_type:
   desc: Defined an experiment for a specific executor
   type: map
   mapping:
-    <<: *EXP_RUN_DETAILS
-    <<: *EXP_VARIABLES
+    <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
     description:
       type: str
       desc: Description of the experiment

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -157,12 +157,12 @@ schema;benchmark_suite_type:
     <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
     gauge_adapter:
       type: str
-      required: yes
+      required: true
       desc: |
         Name of the parser that interpreters the output of the benchmark harness
     command:
       type: str
-      required: yes
+      required: true
       desc: |
         The command for the benchmark harness. It's going to be combined with the
         executor's command line. It supports various format variables, including:
@@ -183,7 +183,7 @@ schema;benchmark_suite_type:
       include: build_type
     benchmarks:
       type: seq
-      required: yes
+      required: true
       matching: any
       sequence:
         - include: benchmark_type_str
@@ -201,13 +201,13 @@ schema;executor_type:
     <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
     path:
       type: str
-      required: no
+      required: false
       desc: |
         Path to the executable.
         If not given, it's up to the shell to find the executable
     executable:
       type: str
-      required: yes
+      required: true
       desc: the name of the executable to be used
     args:
       type: str


### PR DESCRIPTION
This fixes the use of YAML merge operators (<<) to use a list avoiding multiple identical keys. Furthermore, it fixes the use of YAML 1.2 incompatible boolean values.

This addresses #122.