### PR TITLE
Fix error reporting issues

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -17,14 +17,22 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+import logging
 import subprocess
 from os.path import dirname
+import yaml
+from pykwalify.core import Core
+from pykwalify.errors import SchemaError
 
 from .model.experiment import Experiment
 from .model.exp_run_details import ExpRunDetails
 from .model.reporting import Reporting
 from .model.executor import Executor
 from .ui import UIError, escape_braces
+
+# Disable most logging for pykwalify
+logging.getLogger('pykwalify').setLevel(logging.CRITICAL)
+logging.getLogger('pykwalify').addHandler(logging.NullHandler())
 
 
 class _ExecutorFilter(object):
@@ -111,15 +119,6 @@ def load_config(file_name):
     Load the file, verify that it conforms to the schema,
     and return the configuration.
     """
-    import yaml
-    from pykwalify.core import Core
-    from pykwalify.errors import SchemaError
-
-    # Disable most logging for pykwalify
-    import logging
-    logging.getLogger('pykwalify').setLevel(logging.CRITICAL)
-    logging.getLogger('pykwalify').addHandler(logging.NullHandler())
-
     try:
         with open(file_name, 'r') as conf_file:
             data = yaml.safe_load(conf_file)

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -476,7 +476,7 @@ class Executor(object):
                    + "{ind}{ind}The command was not found.\n"
                    + "{ind}Return code: %d\n"
                    + "{ind}{ind}%s.\n") % (
-                      run_id.benchmark.suite.executor.name, return_code, output.strip())
+                       run_id.benchmark.suite.executor.name, return_code, output.strip())
             self._ui.error(msg, run_id, cmdline)
             return True
         elif return_code != 0 and not self._include_faulty and not (

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -404,7 +404,7 @@ class Executor(object):
 
         cmdline = self._construct_cmdline(run_id, gauge_adapter)
 
-        terminate = self._check_termination_condition(run_id, termination_check)
+        terminate = self._check_termination_condition(run_id, termination_check, cmdline)
         if not terminate and self._do_builds:
             self._build_executor_and_suite(run_id)
 
@@ -497,7 +497,7 @@ class Executor(object):
         else:
             self._eval_output(output, run_id, gauge_adapter, cmdline)
 
-        return self._check_termination_condition(run_id, termination_check)
+        return self._check_termination_condition(run_id, termination_check, cmdline)
 
     def _eval_output(self, output, run_id, gauge_adapter, cmdline):
         try:
@@ -532,9 +532,9 @@ class Executor(object):
             run_id.report_run_failed(cmdline, 0, output)
 
     @staticmethod
-    def _check_termination_condition(run_id, termination_check):
+    def _check_termination_condition(run_id, termination_check, cmd):
         return termination_check.should_terminate(
-            run_id.get_number_of_data_points())
+            run_id.get_number_of_data_points(), cmd)
 
     def execute(self):
         try:

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -471,7 +471,15 @@ class Executor(object):
             self._ui.error(msg, run_id, cmdline)
             return True
 
-        if return_code != 0 and not self._include_faulty and not (
+        if return_code == 127:
+            msg = ("{ind}Error: Could not execute %s.\n"
+                   + "{ind}{ind}The command was not found.\n"
+                   + "{ind}Return code: %d\n"
+                   + "{ind}{ind}%s.\n") % (
+                      run_id.benchmark.suite.executor.name, return_code, output.strip())
+            self._ui.error(msg, run_id, cmdline)
+            return True
+        elif return_code != 0 and not self._include_faulty and not (
                 return_code == subprocess_timeout.E_TIMEOUT and run_id.ignore_timeouts):
             run_id.indicate_failed_execution()
             run_id.report_run_failed(cmdline, return_code, output)

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -218,7 +218,7 @@ class RunId(object):
     def is_completed(self, ui):
         """ Check whether the termination condition is satisfied. """
         return self.get_termination_check(ui).should_terminate(
-            self.get_number_of_data_points())
+            self.get_number_of_data_points(), None)
 
     def run_failed(self):
         return (self._termination_check.fails_consecutively() or

--- a/rebench/model/termination_check.py
+++ b/rebench/model/termination_check.py
@@ -48,19 +48,19 @@ class TerminationCheck(object):
                     number_of_data_points > 10 and (
                         self._failed_execution_count > number_of_data_points / 2)))
 
-    def should_terminate(self, number_of_data_points):
+    def should_terminate(self, number_of_data_points, cmd):
         if self._fail_immediately:
-            self._ui.warning("{ind}Marked to fail immediately.\n", self._run_id)
+            self._ui.warning("{ind}Marked to fail immediately.\n", self._run_id, cmd)
         if self.fails_consecutively():
             msg = "{ind}Execution has failed, benchmark is aborted.\n"
             if self._consecutive_erroneous_executions > 0:
                 msg += "{ind}{ind}The benchmark failed "
                 msg += str(self._consecutive_erroneous_executions) + " times in a row.\n"
-            self._ui.warning(msg, self._run_id)
+            self._ui.warning(msg, self._run_id, cmd)
             return True
         elif self.has_too_many_failures(number_of_data_points):
             self._ui.warning(
-                "{ind}Many runs are failing, benchmark is aborted.\n", self._run_id)
+                "{ind}Many runs are failing, benchmark is aborted.\n", self._run_id, cmd)
             return True
         elif self._run_id.completed_invocations >= self._run_id.invocations:
             return True

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -243,10 +243,12 @@ def main_func():
         rebench = ReBench()
         return 0 if rebench.run() else -1
     except KeyboardInterrupt:
-        rebench.ui.debug_error_info("Aborted by user request\n")
+        ui = UI()
+        ui.debug_error_info("Aborted by user request\n")
         return -1
     except UIError as err:
-        rebench.ui.error(err.message)
+        ui = UI()
+        ui.error("\n" + err.message)
         return -1
 
 

--- a/rebench/tests/model/runs_config_test.py
+++ b/rebench/tests/model/runs_config_test.py
@@ -37,45 +37,45 @@ class RunsConfigTestCase(ReBenchTestCase):
 
     def test_termination_check_basic(self):
         check = TerminationCheck(self._run, self._ui)
-        self.assertFalse(check.should_terminate(0))
+        self.assertFalse(check.should_terminate(0, None))
 
         # start 9 times, but expect to be done only after 10
         for i in range(1, 10):
             dp = DataPoint(self._run)
             dp.add_measurement(Measurement(i, 1, 0, 'ms', self._run))
             self._run.loaded_data_point(dp, False)
-        self.assertFalse(check.should_terminate(0))
+        self.assertFalse(check.should_terminate(0, None))
 
         dp = DataPoint(self._run)
         dp.add_measurement(Measurement(10, 1, 0, 'ms', self._run))
         self._run.loaded_data_point(dp, False)
-        self.assertTrue(check.should_terminate(0))
+        self.assertTrue(check.should_terminate(0, None))
 
     def test_terminate_not_determine_by_number_of_data_points(self):
         check = TerminationCheck(self._run, self._ui)
-        self.assertFalse(check.should_terminate(0))
-        self.assertFalse(check.should_terminate(10))
-        self.assertFalse(check.should_terminate(10000))
+        self.assertFalse(check.should_terminate(0, None))
+        self.assertFalse(check.should_terminate(10, None))
+        self.assertFalse(check.should_terminate(10000, None))
 
     def test_consecutive_fails(self):
         check = TerminationCheck(self._run, self._ui)
-        self.assertFalse(check.should_terminate(0))
+        self.assertFalse(check.should_terminate(0, None))
 
         for _ in range(0, 2):
             check.indicate_failed_execution()
-            self.assertFalse(check.should_terminate(0))
+            self.assertFalse(check.should_terminate(0, None))
 
         check.indicate_failed_execution()
-        self.assertTrue(check.should_terminate(0))
+        self.assertTrue(check.should_terminate(0, None))
 
     def test_too_many_fails(self):
         check = TerminationCheck(self._run, self._ui)
-        self.assertFalse(check.should_terminate(0))
+        self.assertFalse(check.should_terminate(0, None))
 
         for _ in range(0, 6):
             check.indicate_failed_execution()
             check.indicate_successful_execution()
-            self.assertFalse(check.should_terminate(0))
+            self.assertFalse(check.should_terminate(0, None))
 
         check.indicate_failed_execution()
-        self.assertTrue(check.should_terminate(0))
+        self.assertTrue(check.should_terminate(0, None))


### PR DESCRIPTION
- make sure there's a UI instance when reporting errors
- pass command line details so that we see the command when an error occurs during termination checks
- handle the unix error code 127, which indicates that the executor is not found