### PR TITLE
Simply return None if no git repo available

### DIFF
--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -21,7 +21,10 @@ def _encode_str(out):
 
 
 def _exec(cmd):
-    out = subprocess.check_output(cmd)
+    try:
+        out = subprocess.check_output(cmd)
+    except subprocess.CalledProcessError:
+        return None
     return _encode_str(out)
 
 


### PR DESCRIPTION
This prevents an error when ReBench is used in a project without git repo, or, if the repo is corrupt.