### PR TITLE
Update py-cpuinfo to 7.0 and publish to PyPI on release publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -20,9 +20,9 @@
 import logging
 import subprocess
 from os.path import dirname
-import yaml
 from pykwalify.core import Core
 from pykwalify.errors import SchemaError
+import yaml
 
 from .model.experiment import Experiment
 from .model.exp_run_details import ExpRunDetails

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='ReBench',
           'PyYAML>=3.12',
           'pykwalify>=1.6.1',
           'humanfriendly>=8.0',
-          'py-cpuinfo==6.0.0',
+          'py-cpuinfo==7.0.0',
           'psutil>=5.6.7'
       ],
       entry_points = {


### PR DESCRIPTION
- py-cpuinfo 7.0 has a few bug fixes
- trigger uploading to PyPI when a release is published, which is an event distinct from creation
- and reorder imports to make linter happy