### PR TITLE
Fix string/byte encoding issues

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -28,6 +28,7 @@ from .model.experiment import Experiment
 from .model.exp_run_details import ExpRunDetails
 from .model.reporting import Reporting
 from .model.executor import Executor
+from .subprocess_with_timeout import output_as_str
 from .ui import UIError, escape_braces
 
 # Disable most logging for pykwalify
@@ -106,8 +107,7 @@ def can_set_niceness():
     """
     output = subprocess.check_output(["nice", "-n-20", "echo", "test"],
                                      stderr=subprocess.STDOUT)
-    if type(output) != str:  # pylint: disable=unidiomatic-typecheck
-        output = output.decode('utf-8')
+    output = output_as_str(output)
     if "cannot set niceness" in output or "Permission denied" in output:
         return False
     else:

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -5,6 +5,7 @@ import subprocess
 from cpuinfo import get_cpu_info
 from psutil import virtual_memory
 
+from .subprocess_with_timeout import output_as_str
 
 try:
     from urllib.parse import urlparse
@@ -14,7 +15,7 @@ except ImportError:
 
 
 def _encode_str(out):
-    as_string = out.decode('utf-8')
+    as_string = output_as_str(out)
     if as_string and as_string[-1] == '\n':
         as_string = as_string[:-1]
     return as_string

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -31,8 +31,6 @@ import sys
 from threading import Thread, RLock
 from time import time
 
-from humanfriendly.compat import coerce_string
-
 from . import subprocess_with_timeout as subprocess_timeout
 from .interop.adapter import ExecutionDeliveredNoResults
 from .ui import escape_braces

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -299,12 +299,6 @@ class Executor(object):
 
         return cmdline
 
-    @staticmethod
-    def _read(stream):
-        data = stream.readline()
-        decoded = data.decode('utf-8')
-        return coerce_string(decoded)
-
     def _build_executor_and_suite(self, run_id):
         name = "E:" + run_id.benchmark.suite.executor.name
         build = run_id.benchmark.suite.executor.build
@@ -361,8 +355,8 @@ class Executor(object):
             self._ui.error(msg, run_id, script, path)
             return
 
-        stdout_result = coerce_string(stdout_result.decode('utf-8'))
-        stderr_result = coerce_string(stderr_result.decode('utf-8'))
+        stdout_result = coerce_string(stdout_result)
+        stderr_result = coerce_string(stderr_result)
 
         if self._build_log:
             self.process_output(name, stdout_result, stderr_result)
@@ -459,7 +453,6 @@ class Executor(object):
                 stderr=subprocess.STDOUT, shell=True, verbose=self._debug,
                 timeout=run_id.max_invocation_time,
                 keep_alive_output=_keep_alive)
-            output = output.decode('utf-8')
         except OSError as err:
             run_id.fail_immediately()
             if err.errno == 2:

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -355,9 +355,6 @@ class Executor(object):
             self._ui.error(msg, run_id, script, path)
             return
 
-        stdout_result = coerce_string(stdout_result)
-        stderr_result = coerce_string(stderr_result)
-
         if self._build_log:
             self.process_output(name, stdout_result, stderr_result)
 
@@ -380,7 +377,7 @@ class Executor(object):
         build_command.mark_succeeded()
 
     def process_output(self, name, stdout_result, stderr_result):
-        with open_with_enc(self._build_log, 'a', encoding='utf8') as log_file:
+        with open_with_enc(self._build_log, 'a', encoding='utf-8') as log_file:
             if stdout_result:
                 log_file.write(name + '|STD:')
                 log_file.write(stdout_result)

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -32,8 +32,8 @@ import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, SUPPRESS
 
 from . import __version__ as rebench_version
-from .executor       import Executor, BatchScheduler, RoundRobinScheduler, \
-                            RandomScheduler
+from .executor import Executor, BatchScheduler, RoundRobinScheduler, \
+    RandomScheduler, BenchmarkThreadExceptions
 from .persistence    import DataStore
 from .reporter       import CliReporter
 from .configurator   import Configurator, load_config
@@ -270,6 +270,10 @@ def main_func():
         ui = UI()
         ui.error("\n" + err.message)
         return -1
+    except BenchmarkThreadExceptions as exceptions:
+        ui = UI()
+        for ex in exceptions.exceptions:
+            ui.error(str(ex) + "\n")
 
 
 if __name__ == "__main__":

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -20,12 +20,18 @@ except NameError:
 # Indicate timeout with standard exit code
 E_TIMEOUT = -9
 
-
-def output_as_str(string_like):
-    if string_like is not None and type(string_like) != str:  # pylint: disable=unidiomatic-typecheck
-        return string_like.decode('utf-8')
-    else:
-        return string_like
+if IS_PY3:
+    def output_as_str(string_like):
+        if string_like is not None and type(string_like) != str:  # pylint: disable=unidiomatic-typecheck
+            return string_like.decode('utf-8')
+        else:
+            return string_like
+else:
+    def output_as_str(string_like):
+        if string_like is not None and type(string_like) == str:  # pylint: disable=unidiomatic-typecheck
+            return string_like.decode('utf-8')
+        else:
+            return string_like
 
 
 class _SubprocessThread(Thread):

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -21,6 +21,13 @@ except NameError:
 E_TIMEOUT = -9
 
 
+def output_as_str(string_like):
+    if string_like is not None and type(string_like) != str:  # pylint: disable=unidiomatic-typecheck
+        return string_like.decode('utf-8')
+    else:
+        return string_like
+
+
 class _SubprocessThread(Thread):
 
     def __init__(self, executable_name, args, shell, cwd, verbose, stdout, stderr, stdin_input):
@@ -85,18 +92,20 @@ class _SubprocessThread(Thread):
 
                 for file_no in ret[0]:
                     if file_no == proc.stdout.fileno():
-                        read = proc.stdout.readline()
+                        read = output_as_str(proc.stdout.readline())
                         sys.stdout.write(read)
                         self.stdout_result += read
                     if self._stderr == PIPE and file_no == proc.stderr.fileno():
-                        read = proc.stderr.readline()
+                        read = output_as_str(proc.stderr.readline())
                         sys.stderr.write(read)
                         self.stderr_result += read
 
                 if proc.poll() is not None:
                     break
         else:
-            self.stdout_result, self.stderr_result = proc.communicate()
+            stdout_r, stderr_r = proc.communicate()
+            self.stdout_result = output_as_str(stdout_r)
+            self.stderr_result = output_as_str(stderr_r)
 
 
 def _print_keep_alive(seconds_since_start):

--- a/rebench/tests/features/issue_81_unicode_test.py
+++ b/rebench/tests/features/issue_81_unicode_test.py
@@ -50,7 +50,7 @@ class Issue81UnicodeSuite(ReBenchTestCase):
 
         self.assertTrue(os.path.exists(self._path + '/build.log'))
 
-        with open_with_enc(self._path + '/build.log', 'r', encoding='utf8') as build_file:
+        with open_with_enc(self._path + '/build.log', 'r', encoding='utf-8') as build_file:
             log = build_file.read()
 
         try:

--- a/rebench/tests/mock_http_server.py
+++ b/rebench/tests/mock_http_server.py
@@ -23,6 +23,9 @@ class _RequestHandler(BaseHTTPRequestHandler):
         global _put_requests  # pylint: disable=global-statement
         _put_requests += 1
 
+    def log_request(self, code='-', size='-'):
+        pass
+
 
 class MockHTTPServer(object):
 

--- a/rebench/tests/subprocess_timeout_test.py
+++ b/rebench/tests/subprocess_timeout_test.py
@@ -37,7 +37,6 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              stderr=subprocess.STDOUT,
                                              shell=True, timeout=10)
 
-        output = output.decode('utf-8')
         self.assertEqual(0, return_code)
         self.assertEqual("Done\n", output)
         self.assertEqual(None, err)
@@ -49,7 +48,6 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              stderr=subprocess.STDOUT,
                                              shell=True, timeout=1)
 
-        output = output.decode('utf-8')
         self.assertEqual(sub.E_TIMEOUT, return_code)
         self.assertEqual("", output)
         self.assertEqual(None, err)
@@ -61,7 +59,6 @@ class SubprocessTimeoutTest(unittest.TestCase):
                                              stderr=subprocess.STDOUT,
                                              shell=True, timeout=5)
 
-        output = output.decode('utf-8')
         self.assertEqual(sub.E_TIMEOUT, return_code)
         self.assertEqual("", output)
         self.assertEqual(None, err)

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -21,7 +21,6 @@ import sys
 
 from os import getcwd
 
-from humanfriendly.compat import coerce_string
 from humanfriendly.terminal import terminal_supports_colors, ansi_wrap, auto_encode
 from humanfriendly.terminal.spinners import Spinner
 
@@ -30,7 +29,6 @@ _ERASE_LINE = '\r\x1b[2K'
 
 
 def escape_braces(string):
-    string = coerce_string(string)
     return string.replace('{', '{{').replace('}', '}}')
 
 
@@ -111,13 +109,12 @@ class UI(object):
 
     def output(self, text, *args, **kw):
         self._erase_spinner()
-        auto_encode(sys.stdout, coerce_string(text) + '\n', *args, **kw)
+        auto_encode(sys.stdout, text + '\n', *args, **kw)
         sys.stdout.flush()
 
     def _output(self, text, color, *args, **kw):
         self._erase_spinner()
 
-        text = coerce_string(text)
         if terminal_supports_colors(sys.stdout):
             text = ansi_wrap(text, color=color)
         auto_encode(sys.stdout, text, ind=_DETAIL_INDENT, *args, **kw)


### PR DESCRIPTION
There were some inconsistencies in the string/byte encoding/decoding as unicode.
This hopefully fixes is one and for all.

There are also difference between Linux and macOS when getting output from a pipe.
This should also fix the issue.

This also suppresses logging output from the mock HTTP server used for logging, and fixes an issues with exceptions in with the parallel scheduler.