### PR TITLE
Change the -S switch to a -R to disable all data reporting

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -198,8 +198,8 @@ And, Codespeed needs details on the concrete execution:
 -I, --disable-inc-report  Creates a final report at the end instead of reporting
                           incrementally.
 
--S, --disable-codespeed   Override the configuration and disable reporting to
-                          Codespeed.
+-R, --disable-data-reporting Override the configuration and disable any reporting
+                          to Codespeed and ReBenchDB.
 ```
 
 [1]: https://github.com/tobami/codespeed/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,25 +102,6 @@ We can override this setting with the following parameters:
                  Disables execution of build commands for executors and suites.
 ```
 
-#### Niceness
-
-It is highly recommended to run benchmarks on an idle machine with all
-unnecessary services disabled.
-However, even if the machine is idle, it can happen that other processes
-might desire processing time, which can lead to noise in the measurements.
-To prevent such effects, it is recommended to run benchmarks with the highest
-possible priority. On Linux systems, this is typically achieved with
-the `nice` command and a niceness setting of `-20` (i.e., the process behaves
-very much not-nice).
-
-Typically, this requires admin/root rights.
-On Ubuntu, one can however allow a user to set negative niceness values
-by adding the following line in `/etc/security/limits.conf`:
-
-```text
-user_executing_benchmarks    -       nice            -20
-```
-
 #### Discarding Data, Rerunning Experiments, and Faulty Runs
 
 ReBench's normal execution mode will assume that it should accumulate all data

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -199,8 +199,10 @@ class Configurator(object):
 
     @property
     def use_rebench_db(self):
-        return self._rebench_db and (self._rebench_db.get('send_to_rebench_db', False)
-                                     or self._rebench_db.get('record_all', False))
+        report_results = self._options is None or self._options.use_data_reporting
+        return report_results and self._rebench_db and (
+            self._rebench_db.get('send_to_rebench_db', False)
+            or self._rebench_db.get('record_all', False))
 
     def _process_cli_options(self):
         if self._options is None:

--- a/rebench/model/reporting.py
+++ b/rebench/model/reporting.py
@@ -25,7 +25,7 @@ class Reporting(object):
 
     @classmethod
     def compile(cls, reporting, root_reporting, options, ui):
-        if "codespeed" in reporting and options and options.use_codespeed:
+        if "codespeed" in reporting and options and options.use_data_reporting:
             codespeed = CodespeedReporting(reporting, options, ui).get_reporter()
         else:
             codespeed = root_reporting.codespeed_reporter

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -148,7 +148,7 @@ Argument:
                                'This overrides the configuration\'s setting.')
 
         codespeed = parser.add_argument_group(
-            'Reporting to Codespeed',
+            'Reporting to Result Trackers',
             'Some of these parameters are mandatory for reporting to Codespeed')
         codespeed.add_argument('--commit-id', dest='commit_id', default=None,
                                help='MANDATORY: when Codespeed reporting is '
@@ -170,11 +170,11 @@ Argument:
                                default=True, help='Creates a report at the '
                                                   'end instead of reporting '
                                                   'incrementally.')
-        codespeed.add_argument('-S', '--disable-codespeed',
-                               action='store_false', dest='use_codespeed',
+        codespeed.add_argument('-R', '--disable-data-reporting',
+                               action='store_false', dest='use_data_reporting',
                                default=True,
                                help='Override configuration and '
-                                    'disable reporting to Codespeed.')
+                                    'disable any reporting to Codespeed and ReBenchDB.')
 
         rebench_db = parser.add_argument_group(
             'Reporting to ReBenchDB',
@@ -199,7 +199,6 @@ Argument:
                                      'be recorded, i.e., to which the commit'
                                      ' belongs. If not provided, ReBench will try to get'
                                      ' the name from git.')
-
 
         return parser
 

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -105,7 +105,7 @@ class ExecutorTest(ReBenchTestCase):
     def test_execution_with_quick_set(self):
         self._set_path(__file__)
         option_parser = ReBench().shell_options()
-        cmd_config = option_parser.parse_args(['-S', '-q', 'persistency.conf'])
+        cmd_config = option_parser.parse_args(['-R', '-q', 'persistency.conf'])
         self.assertTrue(cmd_config.quick)
 
         cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
@@ -122,7 +122,7 @@ class ExecutorTest(ReBenchTestCase):
     def test_execution_with_invocation_and_iteration_set(self):
         self._set_path(__file__)
         option_parser = ReBench().shell_options()
-        cmd_config = option_parser.parse_args(['-S', '-in=2', '-it=2', 'persistency.conf'])
+        cmd_config = option_parser.parse_args(['-R', '-in=2', '-it=2', 'persistency.conf'])
         self.assertEqual(2, cmd_config.invocations)
         self.assertEqual(2, cmd_config.iterations)
 


### PR DESCRIPTION
This PR brings the Codespeed and ReBenchDB command-line support on par.

We can now disable sending data to ReBenchDB without having to change the configuration.