### PR TITLE
Fix JMHAdapter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -128,7 +128,9 @@ disable=parameter-unpacking,
         protected-access,
         no-else-return,
         duplicate-code,
-        useless-object-inheritance
+        useless-object-inheritance,
+        super-with-arguments,
+        raise-missing-from
         
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/rebench/interop/jmh_adapter.py
+++ b/rebench/interop/jmh_adapter.py
@@ -31,7 +31,8 @@ class JMHAdapter(GaugeAdapter):
     An adapter for parsing logs produced by JMH, a Java benchmarking harness.
     """
     # we need to capture both measurement iterations and warmup iterations
-    re_result_line = re.compile(r"^(Iteration|# Warmup Iteration)\s+(\d+):\s+(\d+(?:\.\d+)?)\s+(.+)")
+    re_result_line = re.compile(
+        r"^(Iteration|# Warmup Iteration)\s+(\d+):\s+(\d+(?:\.\d+)?)\s+(.+)")
     re_bench = re.compile(r"^# Benchmark: (.+)")
     re_complete = re.compile("Run complete")
 
@@ -41,7 +42,8 @@ class JMHAdapter(GaugeAdapter):
 
         for line in data.split("\n"):
             # Early exit for completed runs. JMH will print out some info after 'Run complete'
-            # that include an error column, which will be considered as an error by check_for_error() heuristics.
+            # that include an error column, which will be considered as an error
+            # by check_for_error() heuristics.
             if self.re_complete.search(line):
                 return data_points
 

--- a/rebench/tests/features/issue_32_jmh_support_test.py
+++ b/rebench/tests/features/issue_32_jmh_support_test.py
@@ -37,11 +37,13 @@ class Issue32JMHSupport(TestCase):
         adapter = JMHAdapter(False)
         data_points = adapter.parse_data(self._data, None, 1)
 
-        self.assertEqual(4 * 20, len(data_points))
+        self.assertEqual(4  # number of experiments
+                         * 2  # warmup and the considered operations
+                         * 20, len(data_points))
 
-        for i in range(0, 60):
+        for i in range(0, 120):
             self.assertAlmostEqual(830000, data_points[i].get_total_value(),
                                    delta=60000)
-        for i in range(60, 80):
+        for i in range(140, 160):
             self.assertAlmostEqual(86510, data_points[i].get_total_value(),
                                    delta=4000)


### PR DESCRIPTION
This pull request fixes a few issues of `JMHAdapter` to work with JMH 1.25.
* Changes to `re_result_line` to capture results for both measurement iterations and warmup iterations. 
  * Due to this change, match groups are changed accordingly. 
* Add a check for 'Run complete'. `parse_data()` returns immediately when a match for run completion is found. 