### PR TITLE
Ensure empty string for unset variable, and maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '2.7', '3.7', '3.8-dev', 'pypy3' ]
+        python-version: [ '2.7', '3.7', '3.9', 'pypy3' ]
         yaml-parser: ['', 'ruamel']
         include:
           - python-version: 2.7
@@ -16,7 +16,7 @@ jobs:
         exclude:
           - python-version: 2.7
             yaml-parser: ruamel
-          - python-version: '3.8-dev'
+          - python-version: 3.9
             yaml-parser: ruamel
           - python-version: pypy3
             yaml-parser: ruamel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '2.7', '3.7', '3.8-dev', 'pypy3' ]
         yaml-parser: ['', 'ruamel']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           pip install pylint
           pylint rebench
-        if: startsWith(matrix.python-version, 'pypy') == false
+        if: startsWith(matrix.python-version, '3.')
 
       - name: Upload coverage results to Coveralls
         run: coveralls

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -106,7 +106,7 @@ def load_config(file_name):
     and return the configuration.
     """
     try:
-        with open(file_name, 'r') as conf_file:
+        with open(file_name, 'r') as conf_file:  # pylint: disable=unspecified-encoding
             data = yaml.safe_load(conf_file)
             validator = Core(
                 source_data=data,

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -175,7 +175,7 @@ class Configurator(object):
         self._data_store = data_store
         self._process_cli_options()
 
-        self._build_commands = dict()
+        self._build_commands = {}
 
         self._run_filter = _RunFilter(run_filter)
 

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -11,6 +11,7 @@ from math import log, floor
 from multiprocessing import Pool
 from cpuinfo import get_cpu_info
 
+from .ui import escape_braces
 from .subprocess_with_timeout import output_as_str
 
 try:
@@ -97,7 +98,7 @@ def minimize_noise(show_warnings, ui):
         elif 'command not found' in output:
             msg += '{ind}Please make sure `rebench-denoise` is on the PATH\n'
         else:
-            msg += '{ind}Error: ' + output
+            msg += '{ind}Error: ' + escape_braces(output)
 
     if not success and show_warnings:
         ui.warning(msg)

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -201,7 +201,7 @@ def _set_scaling_governor(governor, num_cores):
     try:
         for cpu_i in range(num_cores):
             filename = "/sys/devices/system/cpu/cpu" + str(cpu_i) + "/cpufreq/scaling_governor"
-            with open(filename, "w") as gov_file:
+            with open(filename, "w") as gov_file:  # pylint: disable=unspecified-encoding
                 gov_file.write(governor + "\n")
     except IOError:
         return "failed"
@@ -216,6 +216,7 @@ def _set_no_turbo(with_no_turbo):
         value = "0"
 
     try:
+        # pylint: disable-next=unspecified-encoding
         with open("/sys/devices/system/cpu/intel_pstate/no_turbo", "w") as nt_file:
             nt_file.write(value + "\n")
     except IOError:
@@ -225,9 +226,11 @@ def _set_no_turbo(with_no_turbo):
 
 def _minimize_perf_sampling():
     try:
+        # pylint: disable-next=unspecified-encoding
         with open("/proc/sys/kernel/perf_cpu_time_max_percent", "w") as perc_file:
             perc_file.write("1\n")
 
+        # pylint: disable-next=unspecified-encoding
         with open("/proc/sys/kernel/perf_event_max_sample_rate", "w") as sample_file:
             sample_file.write("1\n")
     except IOError:
@@ -238,6 +241,7 @@ def _minimize_perf_sampling():
 
 def _restore_perf_sampling():
     try:
+        # pylint: disable-next=unspecified-encoding
         with open("/proc/sys/kernel/perf_cpu_time_max_percent", "w") as perc_file:
             perc_file.write("25\n")
     except IOError:

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -312,7 +312,7 @@ def _test(num_cores):
     lower = _shield_lower_bound(num_cores)
     upper = _shield_upper_bound(num_cores)
     core_cnt = upper - lower + 1
-    pool = Pool(core_cnt)
+    pool = Pool(core_cnt)  # pylint: disable=consider-using-with
 
     print("Test on %d cores" % core_cnt)
 

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -23,7 +23,7 @@ def _encode_str(out):
 
 def _exec(cmd):
     try:
-        with open(os.devnull, 'w') as dev_null_f:
+        with open(os.devnull, 'w') as dev_null_f:  # pylint: disable=unspecified-encoding
             out = subprocess.check_output(cmd, stderr=dev_null_f)
     except subprocess.CalledProcessError:
         return None

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -38,7 +38,7 @@ def determine_source_details():
     if _source:
         return _source
 
-    result = dict()
+    result = {}
 
     is_git_repo = _exec(['git', 'rev-parse']) is not None
     if not is_git_repo:
@@ -81,19 +81,22 @@ _environment = None
 
 def init_env_for_test():
     global _environment  # pylint: disable=global-statement
-    _environment = dict()
-    _environment['hostName'] = 'test'
-    _environment['userName'] = 'test'
+    _environment = {
+        'hostName': 'test',
+        'userName': 'test'
+    }
 
 
 def init_environment(denoise_result, ui):
-    result = dict()
-    result['userName'] = getpass.getuser()
-    result['manualRun'] = not ('CI' in os.environ and os.environ['CI'] == 'true')
-
     u_name = os.uname()
-    result['hostName'] = u_name[1]
-    result['osType'] = u_name[0]
+    result = {
+        'userName': getpass.getuser(),
+        'manualRun': not ('CI' in os.environ and os.environ['CI'] == 'true'),
+        'hostName': u_name[1],
+        'osType': u_name[0],
+        'memory': virtual_memory().total,
+        'denoise': denoise_result.details
+    }
 
     try:
         cpu_info = _get_cpu_info_internal()
@@ -108,13 +111,10 @@ def init_environment(denoise_result, ui):
         ui.warning('Was not able to determine the type of CPU used and its clock speed.'
                    + ' Thus, these details will not be recorded with the data.')
 
-    result['memory'] = virtual_memory().total
     result['software'] = []
     result['software'].append({'name': 'kernel', 'version': u_name[3]})
     result['software'].append({'name': 'kernel-release', 'version': u_name[2]})
     result['software'].append({'name': 'architecture', 'version': u_name[4]})
-
-    result['denoise'] = denoise_result.details
 
     global _environment  # pylint: disable=global-statement
     _environment = result

--- a/rebench/model/benchmark.py
+++ b/rebench/model/benchmark.py
@@ -126,11 +126,11 @@ class Benchmark(object):
                 '' if self._extra_args is None else str(self._extra_args)]
 
     def as_dict(self):
-        result = dict()
-        result['name'] = self._name
-        result['runDetails'] = self._run_details.as_dict()
-        result['suite'] = self._suite.as_dict()
-        return result
+        return {
+            'name': self._name,
+            'runDetails': self._run_details.as_dict(),
+            'suite': self._suite.as_dict()
+        }
 
     @classmethod
     def from_str_list(cls, data_store, str_list):

--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -104,10 +104,11 @@ class BenchmarkSuite(object):
         return "Suite(%s, %s)" % (self._name, self._command)
 
     def as_dict(self):
-        result = dict()
-        result['name'] = self._name
-        result['executor'] = self._executor.as_dict()
+        result = {
+            'name': self._name,
+            'executor': self._executor.as_dict(),
+            'desc': self._desc
+        }
         if self._build:
             result['build'] = [b.as_dict() for b in self._build]
-        result['desc'] = self._desc
         return result

--- a/rebench/model/build_cmd.py
+++ b/rebench/model/build_cmd.py
@@ -77,7 +77,7 @@ class BuildCommand(object):
         return hash((self._cmd, self._location))
 
     def as_dict(self):
-        result = dict()
-        result['cmd'] = self._cmd
-        result['location'] = self._location
-        return result
+        return {
+            'cmd': self._cmd,
+            'location': self._location
+        }

--- a/rebench/model/executor.py
+++ b/rebench/model/executor.py
@@ -95,9 +95,10 @@ class Executor(object):
         return self._variables
 
     def as_dict(self):
-        result = dict()
-        result['name'] = self._name
+        result = {
+            'name': self._name,
+            'desc': self._description
+        }
         if self._build:
             result['build'] = [b.as_dict() for b in self._build]
-        result['desc'] = self._description
         return result

--- a/rebench/model/exp_run_details.py
+++ b/rebench/model/exp_run_details.py
@@ -120,8 +120,8 @@ class ExpRunDetails(object):
         return self._retries_after_failure
 
     def as_dict(self):
-        result = dict()
-        result['warmup'] = self._warmup
-        result['minIterationTime'] = self._min_iteration_time
-        result['maxInvocationTime'] = self._max_invocation_time
-        return result
+        return {
+            'warmup': self._warmup,
+            'minIterationTime': self._min_iteration_time,
+            'maxInvocationTime': self._max_invocation_time
+        }

--- a/rebench/model/measurement.py
+++ b/rebench/model/measurement.py
@@ -92,10 +92,10 @@ class Measurement(object):
                            criterion, line_number, filename)
 
     def as_dict(self):
-        result = dict()
-        result['c'] = self._criterion
-        result['in'] = self._invocation
-        result['it'] = self._iteration
-        result['u'] = self._unit
-        result['v'] = self._value
-        return result
+        return {
+            'c': self._criterion,
+            'in': self._invocation,
+            'it': self._iteration,
+            'u': self._unit,
+            'v': self._value
+        }

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -316,15 +316,15 @@ class RunId(object):
         return result
 
     def as_dict(self):
-        result = dict()
-        result['benchmark'] = self._benchmark.as_dict()
-        result['cores'] = self._cores
-        result['inputSize'] = self._input_size
-        result['varValue'] = self._var_value
-        result['extraArgs'] = str(self._benchmark.extra_args)
-        result['cmdline'] = self.cmdline()
-        result['location'] = self.location
-        return result
+        return {
+            'benchmark': self._benchmark.as_dict(),
+            'cores': self._cores,
+            'inputSize': self._input_size,
+            'varValue': self._var_value,
+            'extraArgs': str(self._benchmark.extra_args),
+            'cmdline': self.cmdline(),
+            'location': self.location
+        }
 
     @classmethod
     def from_str_list(cls, data_store, str_list):

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -248,8 +248,10 @@ class RunId(object):
                              'warmup': self._benchmark.run_details.warmup}
         except ValueError as err:
             self._report_format_issue_and_exit(string, err)
+            return None
         except TypeError as err:
             self._report_format_issue_and_exit(string, err)
+            return None
         except KeyError as err:
             msg = ("The configuration of %s contains improper Python format strings.\n"
                    + "{ind}The command line configured is: %s\n"

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -239,12 +239,12 @@ class RunId(object):
     def _expand_vars(self, string):
         try:
             return string % {'benchmark': self._benchmark.command,
-                             'cores': self._cores,
+                             'cores': self.cores_as_str,
                              'executor': self._benchmark.suite.executor.name,
-                             'input': self._input_size,
+                             'input': self.input_size_as_str,
                              'iterations': self.iterations,
                              'suite': self._benchmark.suite.name,
-                             'variable': self._var_value,
+                             'variable': self.var_value_as_str,
                              'warmup': self._benchmark.run_details.warmup}
         except ValueError as err:
             self._report_format_issue_and_exit(string, err)

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -389,10 +389,10 @@ class _ReBenchDB(_ConcretePersistence):
                 measurements = dp.measurements_as_dict(criteria)
                 num_measurements += len(measurements['m'])
                 dp_data.append(measurements)
-            data = dict()
-            data['runId'] = run_id.as_dict()
-            data['d'] = dp_data
-            all_data.append(data)
+            all_data.append({
+                'runId': run_id.as_dict(),
+                'd': dp_data
+            })
 
         criteria_index = []
         for c, idx in criteria.items():

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -185,6 +185,7 @@ class _FilePersistence(_ConcretePersistence):
 
     @staticmethod
     def _truncate_file(filename):
+        # pylint: disable-next=unspecified-encoding
         with open(filename, 'w'):
             pass
 
@@ -192,6 +193,7 @@ class _FilePersistence(_ConcretePersistence):
         if not os.path.exists(self._data_filename):
             self._start_time = None
             return
+        # pylint: disable-next=unspecified-encoding
         with open(self._data_filename, 'r') as data_file:
             self._start_time = self._read_first_meta_block(data_file)
 
@@ -217,11 +219,13 @@ class _FilePersistence(_ConcretePersistence):
         try:
             if current_runs:
                 with NamedTemporaryFile('w', delete=False) as target:
+                    # pylint: disable-next=unspecified-encoding
                     with open(self._data_filename, 'r') as data_file:
                         self._process_lines(data_file, current_runs, target)
                     os.unlink(self._data_filename)
                     shutil.move(target.name, self._data_filename)
             else:
+                # pylint: disable-next=unspecified-encoding
                 with open(self._data_filename, 'r') as data_file:
                     self._process_lines(data_file, current_runs, None)
         except IOError:
@@ -293,6 +297,7 @@ class _FilePersistence(_ConcretePersistence):
         shebang_line += "# Source: " + json.dumps(determine_source_details()) + "\n"
 
         try:
+            # pylint: disable-next=unspecified-encoding,consider-using-with
             data_file = open(self._data_filename, 'a+')
             data_file.write(shebang_line)
             data_file.flush()

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -299,6 +299,7 @@ def main_func():
         ui = UI()
         for ex in exceptions.exceptions:
             ui.error(str(ex) + "\n")
+        return -1
 
 
 if __name__ == "__main__":

--- a/rebench/rebenchdb.py
+++ b/rebench/rebenchdb.py
@@ -89,7 +89,7 @@ class ReBenchDB(object):
         payload = json.dumps(payload_data, separators=(',', ':'), ensure_ascii=True)
 
         # self._ui.output("Saving JSON Payload of size: %d\n" % len(payload))
-        with open("payload.json", "w") as text_file:
+        with open("payload.json", "w") as text_file:  # pylint: disable=unspecified-encoding
             text_file.write(payload)
 
         try:

--- a/rebench/statistics.py
+++ b/rebench/statistics.py
@@ -66,11 +66,8 @@ class StatisticProperties(object):
                                                 ((sample - prev_mean) * (sample - self.mean)))
             self.std_dev = math.sqrt(self._variance_times_num_samples / self.num_samples)
 
-            if self.min > sample:
-                self.min = sample
-
-            if self.max < sample:
-                self.max = sample
+            self.min = min(self.min, sample)
+            self.max = max(self.max, sample)
 
     def as_tuple(self):
         return (self.mean,

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -62,6 +62,7 @@ class _SubprocessThread(Thread):
         try:
             self._started_cv.acquire()
             stdin = PIPE if self._stdin_input else None
+            # pylint: disable-next=consider-using-with
             proc = Popen(self._args, shell=self._shell, cwd=self._cwd,
                          stdin=stdin, stdout=self._stdout, stderr=self._stderr)
             self._pid = proc.pid
@@ -197,6 +198,7 @@ def _kill_process(pid, recursively, thread):
 
 
 def _get_process_children(pid):
+    # pylint: disable-next=consider-using-with
     proc = Popen('pgrep -P %d' % pid, shell=True, stdout=PIPE, stderr=PIPE)
     stdout, _stderr = proc.communicate()
     result = [int(p) for p in stdout.split()]

--- a/rebench/tests/features/issue_110_setup_run_test.py
+++ b/rebench/tests/features/issue_110_setup_run_test.py
@@ -51,6 +51,7 @@ class Issue110Test(ReBenchTestCase):
         file_name = 'build.log'
         file_path = self._path + '/' + file_name
         if os.path.isfile(file_path):
+            # pylint: disable-next=unspecified-encoding
             with open(file_path, 'r') as log_file:
                 lines = log_file.read().strip().split("\n")
                 return set(lines)

--- a/rebench/tests/features/issue_19.conf
+++ b/rebench/tests/features/issue_19.conf
@@ -7,6 +7,7 @@ benchmark_suites:
     Suite:
         gauge_adapter: TestExecutor
         command: TestBenchMarks %(benchmark)s %(input)s
+        input_sizes: [1]
         benchmarks:
             - Bench1
             - Bench2

--- a/rebench/tests/features/issue_32_jmh_support_test.py
+++ b/rebench/tests/features/issue_32_jmh_support_test.py
@@ -30,6 +30,7 @@ class Issue32JMHSupport(TestCase):
 
     def setUp(self):
         self._path = dirname(realpath(__file__))
+        # pylint: disable-next=unspecified-encoding
         with open(self._path + "/issue_32_jmh.data") as data_file:
             self._data = data_file.read()
 

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -41,6 +41,7 @@ class Issue58BuildExecutor(ReBenchTestCase):
             os.remove(self._path + '/build.log')
 
     def _read_log(self):
+        # pylint: disable-next=unspecified-encoding
         with open(self._path + '/build.log', 'r') as log_file:
             return log_file.read()
 

--- a/rebench/tests/features/issue_59_build_suite_test.py
+++ b/rebench/tests/features/issue_59_build_suite_test.py
@@ -61,6 +61,7 @@ class Issue59BuildSuite(ReBenchTestCase):
             self.assertEqual("Bench1", runs[0].benchmark.name)
             self.assertEqual(2, runs[0].get_number_of_data_points())
             self.assertTrue(os.path.isfile(self._path + '/issue_59_cnt'))
+            # pylint: disable-next=unspecified-encoding
             with open(self._path + '/issue_59_cnt', 'r') as build_cnt:
                 content = build_cnt.read()
             self.assertEqual("I\n", content)

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,18 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+import sys
 
 from setuptools import setup, find_packages
 from rebench import __version__ as rebench_version
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+if sys.version_info[0] < 3:
+    pykwalify_version = 'pykwalify==1.7.0'
+else:
+    pykwalify_version = 'pykwalify>=1.8.0'
 
 setup(name='ReBench',
       version=rebench_version,
@@ -38,7 +44,7 @@ setup(name='ReBench',
       package_data={'rebench': ['rebench-schema.yml']},
       install_requires=[
           'PyYAML>=3.12',
-          'pykwalify>=1.6.1',
+          pykwalify_version,
           'humanfriendly>=8.0',
           'py-cpuinfo==7.0.0',
           'psutil>=5.6.7'


### PR DESCRIPTION
When setting the variables cores, input sizes, and variable values directly on a benchmark, the command line is generated with `None` values for the other benchmarks where it isn't set, which is problematic in most cases.
Thus, here we make sure we use the string version of the arguments, which already encode this as an empty string.

To make GitHub Actions green, there are also a number of other fixes:
 - fix pykwalify version for Python 2.7, and update for the rest
 - test on Python 3.9 instead of 3.8-dev
 - fix various lint issues