### PR TITLE
ReBench has issues running in docker, likely because of denoise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,36 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         if: ${{ matrix.coverage && env.COVERALLS_REPO_TOKEN != '' }}
+
+  test-docker:
+    name: Test ReBench in Docker
+    runs-on: ubuntu-latest
+    container:
+      image: python:3
+
+    steps:
+      - name: Check for dockerenv file
+        run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)
+
+      - name: Make Python to be Python3
+        run: ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/bin/pip3 /usr/bin/pip
+
+      - name: Install Time Command
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends time
+      
+      - name: Checkout ReBench
+        uses: actions/checkout@v2
+
+      - name: Install PyTest
+        run: pip install pytest
+
+      - name: Install ReBench dependencies
+        run: pip install .
+
+      - name: Run Test Run
+        run: (cd rebench && rebench ../rebench.conf e:TestRunner2)
+
+      - name: Run Unit Tests
+        run: python -m pytest

--- a/.pylintrc
+++ b/.pylintrc
@@ -54,65 +54,11 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=parameter-unpacking,
-        unpacking-in-except,
-        long-suffix,
-        import-star-module-level,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
-        locally-enabled,
         file-ignored,
         suppressed-message,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        xreadlines-attribute,
-        exception-escape,
-        comprehension-escape,
         ## STEFAN: added new exclusions
         missing-docstring,
         invalid-name,
@@ -124,7 +70,6 @@ disable=parameter-unpacking,
         too-many-locals,
         too-many-branches,
         too-many-public-methods,
-        no-self-use,
         protected-access,
         no-else-return,
         duplicate-code,
@@ -132,7 +77,7 @@ disable=parameter-unpacking,
         super-with-arguments,
         consider-using-f-string,
         raise-missing-from
-        
+
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
@@ -304,13 +249,6 @@ max-line-length=100
 
 # Maximum number of lines in a module
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -19,6 +19,11 @@ try:
 except ValueError:
     rebench_version = "unknown"
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 
 class DenoiseResult(object):
 
@@ -47,6 +52,9 @@ def minimize_noise(show_warnings, ui, for_profiling):
             got_json = False
     except subprocess.CalledProcessError as e:
         output = output_as_str(e.output)
+        got_json = False
+    except FileNotFoundError as e:
+        output = str(e)
         got_json = False
 
     msg = 'Minimizing noise with rebench-denoise failed\n'
@@ -100,6 +108,8 @@ def minimize_noise(show_warnings, ui, for_profiling):
                    + denoise_cmd + '\n'
         elif 'command not found' in output:
             msg += '{ind}Please make sure `rebench-denoise` is on the PATH\n'
+        elif "No such file or directory: 'sudo'" in output:
+            msg += '{ind}sudo is not available. Can\'t use rebench-denoise to manage the system.\n'
         else:
             msg += '{ind}Error: ' + escape_braces(output)
 
@@ -126,7 +136,7 @@ def restore_noise(denoise_result, show_warning, ui):
             if not denoise_result.use_nice:
                 cmd += ['--without-nice']
             subprocess.check_output(cmd + ['restore'], stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             pass
 
     if not denoise_result.succeeded and show_warning:

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -20,9 +20,9 @@ except ValueError:
     rebench_version = "unknown"
 
 try:
-    FileNotFoundError
+    FileNotFoundError  # pylint: disable=used-before-assignment
 except NameError:
-    FileNotFoundError = IOError
+    FileNotFoundError = IOError  # pylint: disable=redefined-builtin
 
 
 class DenoiseResult(object):
@@ -35,7 +35,7 @@ class DenoiseResult(object):
         self.details = details
 
 
-def minimize_noise(show_warnings, ui, for_profiling):
+def minimize_noise(show_warnings, ui, for_profiling):  # pylint: disable=too-many-statements
     result = {}
 
     cmd = ['sudo', '-n', 'rebench-denoise']

--- a/rebench/tests/persistency.conf
+++ b/rebench/tests/persistency.conf
@@ -13,7 +13,7 @@ benchmark_suites:
     TestSuite:
         invocations:  10
         min_iteration_time: 1
-        gauge_adapter: Time
+        gauge_adapter: TestExecutor
         command: 1 FooBar %(benchmark)s 2 3 4
         benchmarks:
             - TestBench


### PR DESCRIPTION
This PR, is more of a way to document issues.

It first avoids ReBench breaking because `sudo` isn't available inside of docker.
But then the PR reveals that some tests break.

Needs further debugging.

@o- may have observed this issue before and simply removed the `rebench-denoise` usage. Looks like we're missing a flag there to prevent the issue.

TODO:
 - [x] think about the error output, move parts into debug/verbose only output, and think about making it more actionable
 - [x] consider handling docker explicitly, and instead of a warning just print a note that denoise is not used.