### PR TITLE
Fix data transmission to ReBenchDB on timeout

### DIFF
--- a/rebench/tests/denoise_test.py
+++ b/rebench/tests/denoise_test.py
@@ -1,0 +1,19 @@
+from .rebench_test_case import ReBenchTestCase
+from ..denoise import minimize_noise, restore_noise
+
+
+class DenoiseTest(ReBenchTestCase):
+
+    def setUp(self):
+        super(DenoiseTest, self).setUp()
+        self._set_path(__file__)
+
+    def test_minimize(self):
+        result = minimize_noise(False, self._ui)
+        self.assertIsInstance(result.succeeded, bool)
+        self.assertIsInstance(result.use_nice, bool)
+        self.assertIsInstance(result.use_shielding, bool)
+
+        # if it was successful, try to restore normal settings
+        if result.succeeded:
+            restore_noise(result, False, self._ui)


### PR DESCRIPTION
With the Python 3 support, a bug sneaked in unnoticed.
While the initial HTTP request would use the data encoded as UTF-8 bytes, the retry after a timeout would use the original data string.
Didn't fix a parameter there.

After tracking it down, and fixing it, I refactored the code a little further, put it into a loop, and added a backoff to handle timeouts more gracefully.
The issue with ReBenchDB is that my server is just a little too busy, and the HTTP server had a rather tiny timeout.
The timeout got increased, but, the server is still busy, so...


Unrelated, this PR also adds a test to make sure that denoise has the expected interface.