### PR TITLE
Add support for filtering experiments by machine

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -544,13 +544,14 @@ As well as:
 - `input_sizes`
 - `cores`
 - `variable_values`
+- `machines`
 
 Run configurations are generated from the cross product of all `input_sizes`,
-`cores`, and `variable_values` for a benchmark.
+`cores`, `variable_values`, and `machines` for a benchmark.
 
 ## Benchmark
 
-A benchmark can simply be a name. However, some times one might want
+A benchmark can simply be a name. However, sometimes one might want
 to define extra properties.
 
 **extra_args:**
@@ -604,7 +605,7 @@ way to adjust the amount of computation performed.
 in form of a sequence literal: `[small, large]`.
 
 Run configurations are generated from the cross product of all `input_sizes`,
-`cores`, and `variable_values` for a benchmark. 
+`cores`, `variable_values` and `machines` for a benchmark. 
 The specific input size can be used, e.g., in the command as in the example below.
 
 Example:
@@ -630,7 +631,7 @@ In practice, it can be used more flexibly and as just another variable that can 
 any list of strings.
 
 Run configurations are generated from the cross product of all `input_sizes`,
-`cores`, and `variable_values` for a benchmark.
+`cores`, `variable_values`, and `machines` for a benchmark.
 The specific core setting can be used, e.g., in the command as in the example below.
 
 Example:
@@ -652,7 +653,7 @@ Another dimension by which the benchmark execution can be varied.
 It takes a list of strings, or arbitrary values really.
 
 Run configurations are generated from the cross product of all `input_sizes`,
-`cores`, and `variable_values` for a benchmark.
+`cores`, `variable_values`, and `machines` for a benchmark.
 The specific variable value can be used, e.g., in the command as in the example below.
 
 Example:
@@ -667,6 +668,40 @@ benchmark_suites:
               - Sequential
               - Parallel
               - Random
+```
+
+---
+
+**machines:**
+
+A dimension by which the benchmark execution can be varied.
+It takes a list of strings, or arbitrary values really.
+The typical use case is to name one or more machines on which the benchmark
+is to be executed.
+
+Run configurations are generated from the cross product of all `input_sizes`,
+`cores`, `variable_values`, and `machines` for a benchmark.
+The specific machine can be used, e.g., in the command, or often more useful
+as a filter when running `rebench`.
+
+Example:
+
+```yaml
+benchmark_suites:
+  ExampleSuite:
+    command: Harness %(machine)s
+    benchmarks:
+        - Benchmark2:
+            machines:
+              - machine1
+              - machine2
+```
+
+Example filter command line, which would execute only the benchmarks
+tagged with `machine1`:
+
+```shell
+rebench rebench.conf m:machine1
 ```
 
 ---
@@ -770,7 +805,7 @@ executors:
 **run details and variables:**
 
 An executor can additionally use the keys for [run details](#runs) and [variables](#benchmark)
-(`input_sizes`, `cores`, `variable_values`).
+(`input_sizes`, `cores`, `variable_values`, `machines`).
 
 ## Experiments
 
@@ -872,7 +907,7 @@ experiments:
 **run details and variables:**
 
 An experiment can additionally use the keys for [run details](#runs) and
-[variables](#benchmark) (`input_sizes`, `cores`, `variable_values`).
+[variables](#benchmark) (`input_sizes`, `cores`, `variable_values`, `machines`).
 Note, this is possible on the main experiment, but also separately for each
 of the defined executions.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,8 +16,8 @@ Argument:
 
   e:$       filter experiments to only include the named executor, example: e:EXEC1 e:EXEC3
   s:$       filter experiments to only include the named suite and possibly benchmark
-              example: s:Suite1 s:Suite2:Bench3
   m:$       filter experiments to only include the named machine, example: m:machine1 m:machine2
+              example: s:Suite1 s:*:Bench3
 ...
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,7 @@ The complete set of options can be displayed with the `--help` argument:
 
 ```bash
 $ rebench --help
-Usage: rebench [options] <config> [exp_name] [e:$]* [s:$]*
+Usage: rebench [options] <config> [exp_name] [e:$]* [s:$]* [m:$]*
 
 Argument:
   config    required argument, file containing the experiment to be executed
@@ -16,8 +16,8 @@ Argument:
 
   e:$       filter experiments to only include the named executor, example: e:EXEC1 e:EXEC3
   s:$       filter experiments to only include the named suite and possibly benchmark
-  m:$       filter experiments to only include the named machine, example: m:machine1 m:machine2
               example: s:Suite1 s:*:Bench3
+  m:$       filter experiments to only include the named machines, example: m:machine1 m:machine2
 ...
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ Argument:
   e:$       filter experiments to only include the named executor, example: e:EXEC1 e:EXEC3
   s:$       filter experiments to only include the named suite and possibly benchmark
               example: s:Suite1 s:Suite2:Bench3
-
+  m:$       filter experiments to only include the named machine, example: m:machine1 m:machine2
 ...
 ```
 

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -66,11 +66,21 @@ class _BenchmarkFilter(_SuiteFilter):
         return bench.name == self._benchmark_name
 
 
+class _MachineFilter(object):
+
+    def __init__(self, machine):
+        self._machine = machine
+
+    def matches(self, bench):
+        return bench.suite.machine == self._machine
+
+
 class _RunFilter(object):
 
     def __init__(self, run_filters):
         self._executor_filters = []
         self._suite_filters = []
+        self._machine_filters = []
 
         if not run_filters:
             return
@@ -83,6 +93,8 @@ class _RunFilter(object):
                 self._suite_filters.append(_SuiteFilter(parts[1]))
             elif parts[0] == "s" and len(parts) == 3:
                 self._suite_filters.append(_BenchmarkFilter(parts[1], parts[2]))
+            elif parts[0] == "m" and len(parts) == 2:
+                self._suite_filters.append(_MachineFilter(parts[1]))
             else:
                 raise Exception("Unknown filter expression: " + run_filter)
 

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -73,8 +73,8 @@ class _MachineFilter(object):
     def __init__(self, machine):
         self._machine = machine
 
-    def matches(self, bench):
-        return bench.suite.machine == self._machine
+    def matches(self, machine):
+        return machine == self._machine
 
 
 class _RunFilter(object):
@@ -96,13 +96,16 @@ class _RunFilter(object):
             elif parts[0] == "s" and len(parts) == 3:
                 self._suite_filters.append(_BenchmarkFilter(parts[1], parts[2]))
             elif parts[0] == "m" and len(parts) == 2:
-                self._suite_filters.append(_MachineFilter(parts[1]))
+                self._machine_filters.append(_MachineFilter(parts[1]))
             else:
                 raise Exception("Unknown filter expression: " + run_filter)
 
-    def applies(self, bench):
+    def applies_to_bench(self, bench):
         return (self._match(self._executor_filters, bench) and
                 self._match(self._suite_filters, bench))
+
+    def applies_to_machine(self, machine):
+        return self._match(self._machine_filters, machine)
 
     @staticmethod
     def _match(filters, bench):

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -51,6 +51,8 @@ class _SuiteFilter(object):
         self._name = name
 
     def matches(self, bench):
+        if self._name == "*":
+            return True
         return bench.suite.name == self._name
 
 

--- a/rebench/model/exp_variables.py
+++ b/rebench/model/exp_variables.py
@@ -26,16 +26,18 @@ class ExpVariables(object):
         input_sizes = config.get('input_sizes', defaults.input_sizes)
         cores = config.get('cores', defaults.cores)
         variable_values = config.get('variable_values', defaults.variable_values)
-        return ExpVariables(input_sizes, cores, variable_values)
+        machines = config.get('machines', defaults.machines)
+        return ExpVariables(input_sizes, cores, variable_values, machines)
 
     @classmethod
     def empty(cls):
-        return ExpVariables([''], [1], [''])
+        return ExpVariables([''], [1], [''], [None])
 
-    def __init__(self, input_sizes, cores, variable_values):
+    def __init__(self, input_sizes, cores, variable_values, machines):
         self._input_sizes = input_sizes
         self._cores = cores
         self._variable_values = variable_values
+        self._machines = machines
 
     @property
     def input_sizes(self):
@@ -48,3 +50,7 @@ class ExpVariables(object):
     @property
     def variable_values(self):
         return self._variable_values
+
+    @property
+    def machines(self):
+        return self._machines

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -73,12 +73,13 @@ class Experiment(object):
             for cores in variables.cores:
                 for input_size in variables.input_sizes:
                     for var_val in variables.variable_values:
-                        run = self._data_store.create_run_id(
-                            bench, cores, input_size, var_val)
-                        bench.add_run(run)
-                        runs.add(run)
-                        run.add_reporting(self._reporting)
-                        run.add_persistence(self._persistence)
+                        for machine in variables.machines:
+                            run = self._data_store.create_run_id(
+                                bench, cores, input_size, var_val, machine)
+                            bench.add_run(run)
+                            runs.add(run)
+                            run.add_reporting(self._reporting)
+                            run.add_persistence(self._persistence)
         return runs
 
     def _compile_executors_and_benchmark_suites(self, executions, suites, configurator):

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -66,14 +66,17 @@ class Experiment(object):
     def _compile_runs(self, configurator):
         runs = set()
 
+        # pylint: disable-next=too-many-nested-blocks
         for bench in self._benchmarks:
-            if not configurator.run_filter.applies(bench):
+            if not configurator.run_filter.applies_to_bench(bench):
                 continue
             variables = bench.variables
             for cores in variables.cores:
                 for input_size in variables.input_sizes:
                     for var_val in variables.variable_values:
                         for machine in variables.machines:
+                            if not configurator.run_filter.applies_to_machine(machine):
+                                continue
                             run = self._data_store.create_run_id(
                                 bench, cores, input_size, var_val, machine)
                             bench.add_run(run)

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -67,7 +67,7 @@ class DataStore(object):
             self._files[filename] = p
         return self._files[filename]
 
-    def create_run_id(self, benchmark, cores, input_size, var_value):
+    def create_run_id(self, benchmark, cores, input_size, var_value, machine):
         if isinstance(cores, str) and cores.isdigit():
             cores = int(cores)
         if input_size == '':
@@ -75,7 +75,7 @@ class DataStore(object):
         if var_value == '':
             var_value = None
 
-        run = RunId(benchmark, cores, input_size, var_value)
+        run = RunId(benchmark, cores, input_size, var_value, machine)
         if run in self._run_ids:
             return self._run_ids[run]
         else:

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -125,6 +125,12 @@ schema;variables:
       # default: ['']  # that's the semantics, but pykwalify does not support it
       sequence:
         - type: scalar
+    machines:
+      type: seq
+      desc: Another dimension by which the benchmark execution can be varied.
+      # default: ['']  # that's the semantics, but pykwalify does not support it
+      sequence:
+        - type: scalar
 
 schema;benchmark_type_str:
   type: str

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -68,7 +68,7 @@ Argument:
 
   e:$       filter experiments to only include the named executor, example: e:EXEC1 e:EXEC3
   s:$       filter experiments to only include the named suite and possibly benchmark
-            example: s:Suite1 s:Suite2:Bench3
+            example: s:Suite1 s:*:Bench3
 
             Note, filters are combined with `or` semantics in the same group,
             i.e., executor or suite, and at least one filter needs to match per group.

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -57,7 +57,7 @@ class ReBench(object):
         return self._ui
 
     def shell_options(self):
-        usage = """%(prog)s [options] <config> [exp_name] [e:$]* [s:$]*
+        usage = """%(prog)s [options] <config> [exp_name] [e:$]* [s:$]* [m:$]*
         
 Argument:
   config    required argument, file containing the experiment to be executed
@@ -72,6 +72,8 @@ Argument:
 
             Note, filters are combined with `or` semantics in the same group,
             i.e., executor or suite, and at least one filter needs to match per group.
+            The suite name can also be given as * to match all possible suites.
+  m:$       filter experiments to only include the named machines, example: m:machine1 m:machine2
 """
 
         parser = ArgumentParser(

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -212,9 +212,11 @@ Argument:
     def determine_exp_name_and_filters(filters):
         exp_name = filters[0] if filters and (
             not filters[0].startswith("e:") and
-            not filters[0].startswith("s:")) else None
+            not filters[0].startswith("s:") and
+            not filters[0].startswith("m:")) else None
         exp_filter = [f for f in filters if (f.startswith("e:") or
-                                             f.startswith("s:"))]
+                                             f.startswith("s:") or
+                                             f.startswith("m:"))]
         return exp_name, exp_filter
 
     def _report_completion(self):

--- a/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
+++ b/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
@@ -41,7 +41,7 @@ class Issue4RunEquality(unittest.TestCase):
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite, None,
                               '3', ExpRunDetails.empty(), None, DataStore(TestDummyUI()))
-        return RunId(benchmark, 1, 2, None)
+        return RunId(benchmark, 1, 2, None, None)
 
     @staticmethod
     def _create_hardcoded_run_id():
@@ -51,7 +51,7 @@ class Issue4RunEquality(unittest.TestCase):
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite,
                               None, None, ExpRunDetails.empty(), None, DataStore(TestDummyUI()))
-        return RunId(benchmark, 1, None, None)
+        return RunId(benchmark, 1, None, None, None)
 
     def test_hardcoded_equals_template_constructed(self):
         hard_coded = self._create_hardcoded_run_id()

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -80,6 +80,14 @@ class ConfiguratorTest(ReBenchTestCase):
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
 
+    def test_star_filter_for_suite(self):
+        filter_args = ['s:*:Bench1']
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
+
+        runs = cnf.get_runs()
+        self.assertEqual(20, len(runs))
+
     def test_only_running_non_existing_stuff(self):
         filter_args = ['s:non-existing', 'e:non-existing']
         cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
@@ -103,6 +111,30 @@ class ConfiguratorTest(ReBenchTestCase):
 
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
+
+    def test_machine_filter_m1(self):
+        filter_args = ['m:machine1']
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
+
+        runs = cnf.get_runs()
+        self.assertEqual(24, len(runs))
+
+    def test_machine_filter_m2(self):
+        filter_args = ['m:machine2']
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
+
+        runs = cnf.get_runs()
+        self.assertEqual(14, len(runs))
+
+    def test_machine_filter_m1_and_m2(self):
+        filter_args = ['m:machine1', 'm:machine2']
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
+                           self._ui, run_filter=filter_args)
+
+        runs = cnf.get_runs()
+        self.assertEqual(14 + 24, len(runs))
 
 
 # allow command-line execution

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -45,7 +45,7 @@ class PersistencyTest(ReBenchTestCase):
                               suite, None, None, ExpRunDetails.default(None, None),
                               None, data_store)
 
-        run_id = RunId(benchmark, 1000, 44, 'sdf sdf sdf sdfsf')
+        run_id = RunId(benchmark, 1000, 44, 'sdf sdf sdf sdfsf', 'machine-22')
         measurement = Measurement(43, 45, 2222.2222, 'ms', run_id, 'foobar crit')
 
         serialized = measurement.as_str_list()

--- a/rebench/tests/test.conf
+++ b/rebench/tests/test.conf
@@ -40,6 +40,8 @@ benchmark_suites:
         variable_values: # this is an other dimension, over which the runs need to be varied
             - val1
             - val2
+        machines:
+            - machine1
     TestSuite2:
         gauge_adapter: TestExecutor
         command: TestBenchMarks %(benchmark)s %(input)s %(variable)s
@@ -49,6 +51,8 @@ benchmark_suites:
             - Bench1:
                 extra_args: "%(cores)s 3000"
             - Bench2
+        machines:
+            - machine2
     TestBrokenCommandFormatSuite:
         gauge_adapter: TestExecutor
         command: TestBenchMarks %(benchmark) %(input) %(variable) # conversion is not indicated, needs to be %(benchmark)s to indicate string conversion


### PR DESCRIPTION
This PR brings support for dividing up the workload on different machines as desired by #157.

It also sneaks in a small tweak to suite filtering, which allows to filter only by benchmark by using `*` for a suite name.

Example: `rebench rebench.conf s:*:Bench`

Back to filtering by machines:

This PR introduces the new variable `machines` alongside `variable_values`, `cores`, and `input_sizes`.
It is handled exactly the same and can be annotated on all places where the other variables can be used.
So, one can tag a suite for a specific machine, an executor, or perhaps most useful, specific benchmarks.
`machines` takes an array of values, all of which will be used to generated experiments, as a cross-product with the other variables.

Example configuration:

```yaml
benchmark_suites:
  ExampleSuite:
    command: Harness %(machine)s
    benchmarks:
        - Benchmark2:
            machines:
              - machine1
              - machine2
```

To run the experiments on `machine1`, we can use:

```shell
rebench rebench.conf m:machine1
```
