### PR TITLE
Make code a bit more pythonic

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -130,6 +130,7 @@ disable=parameter-unpacking,
         duplicate-code,
         useless-object-inheritance,
         super-with-arguments,
+        consider-using-f-string,
         raise-missing-from
         
 # Enable the message, report, category or checker with the given id(s). You can

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -188,7 +188,7 @@ class Configurator(object):
             self._rebench_db['send_to_rebench_db'] = cli_options.send_to_rebench_db
 
         self._options = cli_options
-        self._ui = ui
+        self.ui = ui
         self._data_store = data_store
         self._process_cli_options()
 
@@ -204,7 +204,7 @@ class Configurator(object):
 
     @property
     def ui(self):
-        return self._ui
+        return self.ui
 
     @property
     def build_log(self):
@@ -247,14 +247,14 @@ class Configurator(object):
 
         self._rebench_db_connector = ReBenchDB(
             self._rebench_db['db_url'], self._rebench_db['project_name'],
-            self._options.experiment_name, self._ui)
+            self._options.experiment_name, self.ui)
         return self._rebench_db_connector
 
     def _process_cli_options(self):
         if self._options is None:
             return
 
-        self._ui.init(self._options.verbose, self._options.debug)
+        self.ui.init(self._options.verbose, self._options.debug)
 
     @property
     def do_builds(self):

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -153,10 +153,10 @@ class Configurator(object):
                  exp_name=None, data_file=None, build_log=None, run_filter=None):
         self._raw_config_for_debugging = raw_config  # kept around for debugging only
 
-        self._build_log = build_log or raw_config.get('build_log', 'build.log')
-        self._data_file = data_file or raw_config.get('default_data_file', 'rebench.data')
+        self.build_log = build_log or raw_config.get('build_log', 'build.log')
+        self.data_file = data_file or raw_config.get('default_data_file', 'rebench.data')
         self._exp_name = exp_name or raw_config.get('default_experiment', 'all')
-        self._artifact_review = raw_config.get('artifact_review', False)
+        self.artifact_review = raw_config.get('artifact_review', False)
 
         self._rebench_db_connector = None
 
@@ -179,22 +179,22 @@ class Configurator(object):
         if rdb_cfg:
             rdb_cfg = rdb_cfg.get('rebenchdb', None)
         if rdb_cfg:
-            self._rebench_db = rdb_cfg
+            self.rebench_db = rdb_cfg
         else:
-            self._rebench_db = {}
+            self.rebench_db = {}
         if cli_options:
             if cli_options.db_server:
-                self._rebench_db['db_url'] = cli_options.db_server
-            self._rebench_db['send_to_rebench_db'] = cli_options.send_to_rebench_db
+                self.rebench_db['db_url'] = cli_options.db_server
+            self.rebench_db['send_to_rebench_db'] = cli_options.send_to_rebench_db
 
-        self._options = cli_options
+        self.options = cli_options
         self.ui = ui
-        self._data_store = data_store
+        self.data_store = data_store
         self._process_cli_options()
 
-        self._build_commands = {}
+        self.build_commands = {}
 
-        self._run_filter = _RunFilter(run_filter)
+        self.run_filter = _RunFilter(run_filter)
 
         self._executors = raw_config.get('executors', {})
         self._suites_config = raw_config.get('benchmark_suites', {})
@@ -203,27 +203,11 @@ class Configurator(object):
         self._experiments = self._compile_experiments(experiments)
 
     @property
-    def ui(self):
-        return self.ui
-
-    @property
-    def build_log(self):
-        return self._build_log
-
-    @property
-    def rebench_db(self):
-        return self._rebench_db
-
-    @property
-    def artifact_review(self):
-        return self._artifact_review
-
-    @property
     def use_rebench_db(self):
-        report_results = self._options is None or self._options.use_data_reporting
-        return report_results and self._rebench_db and (
-            self._rebench_db.get('send_to_rebench_db', False)
-            or self._rebench_db.get('record_all', False))
+        report_results = self.options is None or self.options.use_data_reporting
+        return report_results and self.rebench_db and (
+            self.rebench_db.get('send_to_rebench_db', False)
+            or self.rebench_db.get('record_all', False))
 
     def get_rebench_db_connector(self):
         if not self.use_rebench_db:
@@ -231,11 +215,11 @@ class Configurator(object):
         if self._rebench_db_connector:
             return self._rebench_db_connector
 
-        if 'project_name' not in self._rebench_db:
+        if 'project_name' not in self.rebench_db:
             raise ConfigurationError(
                 "No project_name defined in configuration file under reporting.rebenchdb.")
 
-        if not self._options.experiment_name:
+        if not self.options.experiment_name:
             raise ConfigurationError(
                 "The experiment was not named, which is mandatory. "
                 "This is needed to identify the data uniquely. "
@@ -246,31 +230,27 @@ class Configurator(object):
                 "Use the --experiment option to set the name.")
 
         self._rebench_db_connector = ReBenchDB(
-            self._rebench_db['db_url'], self._rebench_db['project_name'],
-            self._options.experiment_name, self.ui)
+            self.rebench_db['db_url'], self.rebench_db['project_name'],
+            self.options.experiment_name, self.ui)
         return self._rebench_db_connector
 
     def _process_cli_options(self):
-        if self._options is None:
+        if self.options is None:
             return
 
-        self.ui.init(self._options.verbose, self._options.debug)
+        self.ui.init(self.options.verbose, self.options.debug)
 
     @property
     def do_builds(self):
-        return self._options is not None and self._options.do_builds
+        return self.options is not None and self.options.do_builds
 
     @property
     def discard_old_data(self):
-        return self._options is not None and self._options.clean
+        return self.options is not None and self.options.clean
 
     @property
     def experiment_name(self):
         return self._exp_name
-
-    @property
-    def data_file(self):
-        return self._data_file
 
     @property
     def reporting(self):
@@ -280,29 +260,13 @@ class Configurator(object):
     def run_details(self):
         return self._root_run_details
 
-    @property
-    def options(self):
-        return self._options
-
-    @property
-    def build_commands(self):
-        return self._build_commands
-
-    @property
-    def run_filter(self):
-        return self._run_filter
-
-    @property
-    def data_store(self):
-        return self._data_store
-
     def has_executor(self, executor_name):
         return executor_name in self._executors
 
     def get_executor(self, executor_name, run_details, variables):
         executor = Executor.compile(
             executor_name, self._executors[executor_name],
-            run_details, variables, self._build_commands)
+            run_details, variables, self.build_commands)
         return executor
 
     def get_suite(self, suite_name):
@@ -322,9 +286,9 @@ class Configurator(object):
     def get_runs(self):
         runs = set()
         for exp in list(self._experiments.values()):
-            runs |= exp.get_runs()
+            runs |= exp.runs
 
-        if self._options and self._options.setup_only:
+        if self.options and self.options.setup_only:
             # filter out runs we don't need to trigger a build
             runs_with_builds = set()
             build_commands = set()

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -124,7 +124,7 @@ def init_environment(denoise_result, ui):
 
 
 def determine_environment():
-    global _environment  # pylint: disable=global-statement
+    global _environment  # pylint: disable=global-statement,global-variable-not-assigned
     if _environment:
         return _environment
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -48,7 +48,7 @@ class RunScheduler(object):
 
     def __init__(self, executor, ui):
         self._executor = executor
-        self._ui = ui
+        self.ui = ui
         self._runs_completed = 0
         self._start_time = time()
         self._total_num_runs = 0
@@ -77,7 +77,7 @@ class RunScheduler(object):
         return floor(hour), floor(minute), floor(sec)
 
     def _indicate_progress(self, completed_task, run):
-        if not self._ui.spinner_initialized():
+        if not self.ui.spinner_initialized():
             return
 
         if completed_task:
@@ -90,21 +90,21 @@ class RunScheduler(object):
         run_details = run.as_simple_string().replace(" None", "")
         label = "Running Benchmarks: %70s\tmean: %10.1f\ttime left: %02d:%02d:%02d" \
                 % (run_details, art_mean, hour, minute, sec)
-        self._ui.step_spinner(self._runs_completed, label)
+        self.ui.step_spinner(self._runs_completed, label)
 
     def indicate_build(self, run_id):
         run_id_names = run_id.as_str_list()
-        self._ui.step_spinner(
+        self.ui.step_spinner(
             self._runs_completed, "Run build for %s %s" % (run_id_names[1], run_id_names[2]))
 
     def execute(self):
         self._total_num_runs = len(self._executor.runs)
-        runs = self._filter_out_completed_runs(self._executor.runs, self._ui)
+        runs = self._filter_out_completed_runs(self._executor.runs, self.ui)
         completed_runs = self._total_num_runs - len(runs)
         self._runs_completed = completed_runs
 
-        with self._ui.init_spinner(self._total_num_runs):
-            self._ui.step_spinner(completed_runs)
+        with self.ui.init_spinner(self._total_num_runs):
+            self.ui.step_spinner(completed_runs)
             self._process_remaining_runs(runs)
 
 
@@ -210,7 +210,7 @@ class ParallelScheduler(RunScheduler):
     def _process_sequential_runs(self, runs):
         seq_runs, par_runs = self._split_runs(runs)
 
-        scheduler = self._seq_scheduler_class(self._executor, self._ui)
+        scheduler = self._seq_scheduler_class(self._executor, self.ui)
         scheduler._process_remaining_runs(seq_runs)
 
         return par_runs
@@ -244,7 +244,7 @@ class ParallelScheduler(RunScheduler):
         return per_thread
 
     def get_local_scheduler(self):
-        return self._seq_scheduler_class(self._executor, self._ui)
+        return self._seq_scheduler_class(self._executor, self.ui)
 
     def acquire_work(self):
         with self._lock:
@@ -270,7 +270,7 @@ class Executor(object):
         self._use_shielding = use_shielding
 
         self._do_builds = do_builds
-        self._ui = ui
+        self.ui = ui
         self._include_faulty = include_faulty
         self._debug = debug
         self._scheduler = self._create_scheduler(scheduler)
@@ -289,9 +289,9 @@ class Executor(object):
                 if not run.execute_exclusively:
                     i += 1
             if i > 1:
-                return ParallelScheduler(self, scheduler, self._ui)
+                return ParallelScheduler(self, scheduler, self.ui)
 
-        return scheduler(self, self._ui)
+        return scheduler(self, self.ui)
 
     def _construct_cmdline(self, run_id, gauge_adapter):
         cmdline = ""
@@ -339,10 +339,10 @@ class Executor(object):
         script = build_command.command
 
         self._scheduler.indicate_build(run_id)
-        self._ui.debug_output_info("Start build\n", None, script, path)
+        self.ui.debug_output_info("Start build\n", None, script, path)
 
         def _keep_alive(seconds):
-            self._ui.warning(
+            self.ui.warning(
                 "Keep alive. current job runs since %dmin\n" % (seconds / 60), run_id, script, path)
 
         try:
@@ -362,7 +362,7 @@ class Executor(object):
                        + "{ind}{ind}File name: %s\n") % (name, err.strerror, err.filename)
             else:
                 msg = str(err)
-            self._ui.error(msg, run_id, script, path)
+            self.ui.error(msg, run_id, script, path)
             return
 
         if self._build_log:
@@ -373,14 +373,14 @@ class Executor(object):
             run_id.fail_immediately()
             run_id.report_run_failed(
                 script, return_code, "Build of " + name + " failed.")
-            self._ui.error("{ind}Build of " + name + " failed.\n", None, script, path)
+            self.ui.error("{ind}Build of " + name + " failed.\n", None, script, path)
             if stdout_result and stdout_result.strip():
                 lines = escape_braces(stdout_result).split('\n')
-                self._ui.error("{ind}stdout:\n\n{ind}{ind}"
+                self.ui.error("{ind}stdout:\n\n{ind}{ind}"
                                + "\n{ind}{ind}".join(lines) + "\n")
             if stderr_result and stderr_result.strip():
                 lines = escape_braces(stderr_result).split('\n')
-                self._ui.error("{ind}stderr:\n\n{ind}{ind}"
+                self.ui.error("{ind}stderr:\n\n{ind}{ind}"
                                + "\n{ind}{ind}".join(lines) + "\n")
             raise FailedBuilding(name, build_command)
 
@@ -396,7 +396,7 @@ class Executor(object):
                 log_file.write(stderr_result)
 
     def execute_run(self, run_id):
-        termination_check = run_id.get_termination_check(self._ui)
+        termination_check = run_id.get_termination_check(self.ui)
 
         run_id.report_start_run()
 
@@ -420,7 +420,7 @@ class Executor(object):
             if (not run_id.is_failed() and run_id.min_iteration_time
                     and mean_of_totals < run_id.min_iteration_time
                     and not self._artifact_review):
-                self._ui.warning(
+                self.ui.warning(
                     ("{ind}Warning: Low mean run time.\n"
                      + "{ind}{ind}The mean (%.1f) is lower than min_iteration_time (%d)\n")
                     % (mean_of_totals, run_id.min_iteration_time), run_id, cmdline)
@@ -450,10 +450,10 @@ class Executor(object):
         # execute the external program here
 
         try:
-            self._ui.debug_output_info("{ind}Starting run\n", run_id, cmdline)
+            self.ui.debug_output_info("{ind}Starting run\n", run_id, cmdline)
 
             def _keep_alive(seconds):
-                self._ui.warning(
+                self.ui.warning(
                     "Keep alive. current job runs since %dmin\n" % (seconds / 60), run_id, cmdline)
 
             (return_code, output, _) = subprocess_timeout.run(
@@ -469,7 +469,7 @@ class Executor(object):
                        + "{ind}{ind}File name: %s\n") % (err.strerror, err.filename)
             else:
                 msg = str(err)
-            self._ui.error(msg, run_id, cmdline)
+            self.ui.error(msg, run_id, cmdline)
             return True
 
         if return_code == 127:
@@ -478,7 +478,7 @@ class Executor(object):
                    + "{ind}Return code: %d\n"
                    + "{ind}{ind}%s.\n") % (
                        run_id.benchmark.suite.executor.name, return_code, output.strip())
-            self._ui.error(msg, run_id, cmdline)
+            self.ui.error(msg, run_id, cmdline)
             return True
         elif return_code != 0 and not self._include_faulty and not (
                 return_code == subprocess_timeout.E_TIMEOUT and run_id.ignore_timeouts):
@@ -497,11 +497,11 @@ class Executor(object):
             else:
                 msg = "{ind}Run failed. Return code: %d\n" % return_code
 
-            self._ui.error(msg, run_id, cmdline)
+            self.ui.error(msg, run_id, cmdline)
 
             if output and output.strip():
                 lines = escape_braces(output).split('\n')
-                self._ui.error("{ind}Output:\n\n{ind}{ind}"
+                self.ui.error("{ind}Output:\n\n{ind}{ind}"
                                + "\n{ind}{ind}".join(lines) + "\n")
         else:
             self._eval_output(output, run_id, gauge_adapter, cmdline)
@@ -535,7 +535,7 @@ class Executor(object):
                 i += 1
 
             run_id.indicate_successful_execution()
-            self._ui.verbose_output_info(msg, run_id, cmdline)
+            self.ui.verbose_output_info(msg, run_id, cmdline)
         except ExecutionDeliveredNoResults:
             run_id.indicate_failed_execution()
             run_id.report_run_failed(cmdline, 0, output)

--- a/rebench/model/benchmark.py
+++ b/rebench/model/benchmark.py
@@ -48,15 +48,25 @@ class Benchmark(object):
     def __init__(self, name, command, gauge_adapter, suite, variables, extra_args,
                  run_details, codespeed_name, data_store):
         assert run_details is None or isinstance(run_details, ExpRunDetails)
-        self._name = name
-        self._command = command
-        self._extra_args = extra_args
-        self._codespeed_name = codespeed_name
-        self._run_details = run_details
-        self._gauge_adapter = gauge_adapter
-        self._suite = suite
+        self.name = name
 
-        self._variables = variables
+        """
+        We distinguish between the benchmark name, used for reporting, and the
+        command that is passed to the benchmark executor.
+        If no command was specified in the config, the name is used instead.
+        See the compile(.) method for details.
+
+        :return: the command to be passed to the benchmark invocation
+        """
+        self.command = command
+
+        self.extra_args = extra_args
+        self.codespeed_name = codespeed_name
+        self.run_details = run_details
+        self.gauge_adapter = gauge_adapter
+        self.suite = suite
+
+        self.variables = variables
 
         # the compiled runs, these might be shared with other benchmarks/suites
         self._runs = set()
@@ -67,69 +77,29 @@ class Benchmark(object):
         self._runs.add(run)
 
     @property
-    def name(self):
-        return self._name
-
-    @property
-    def command(self):
-        """
-        We distinguish between the benchmark name, used for reporting, and the
-        command that is passed to the benchmark executor.
-        If no command was specified in the config, the name is used instead.
-        See the compile(.) method for details.
-
-        :return: the command to be passed to the benchmark invocation
-        """
-        return self._command
-
-    @property
-    def codespeed_name(self):
-        return self._codespeed_name
-
-    @property
-    def extra_args(self):
-        return self._extra_args
-
-    @property
-    def run_details(self):
-        return self._run_details
-
-    @property
-    def gauge_adapter(self):
-        return self._gauge_adapter
-
-    @property
-    def suite(self):
-        return self._suite
-
-    @property
-    def variables(self):
-        return self._variables
-
-    @property
     def execute_exclusively(self):
-        return self._run_details.execute_exclusively
+        return self.run_details.execute_exclusively
 
     def __str__(self):
         return "%s, executor:%s, suite:%s, args:'%s'" % (
-            self._name, self._suite.executor.name, self._suite.name, self._extra_args or '')
+            self.name, self.suite.executor.name, self.suite.name, self.extra_args or '')
 
     def as_simple_string(self):
-        if self._extra_args:
-            return "%s (%s, %s, %s)"  % (self._name, self._suite.executor.name,
-                                         self._suite.name, self._extra_args)
+        if self.extra_args:
+            return "%s (%s, %s, %s)"  % (self.name, self.suite.executor.name,
+                                         self.suite.name, self.extra_args)
         else:
-            return "%s (%s, %s)" % (self._name, self._suite.executor.name, self._suite.name)
+            return "%s (%s, %s)" % (self.name, self.suite.executor.name, self.suite.name)
 
     def as_str_list(self):
-        return [self._name, self._suite.executor.name, self._suite.name,
-                '' if self._extra_args is None else str(self._extra_args)]
+        return [self.name, self.suite.executor.name, self.suite.name,
+                '' if self.extra_args is None else str(self.extra_args)]
 
     def as_dict(self):
         return {
-            'name': self._name,
-            'runDetails': self._run_details.as_dict(),
-            'suite': self._suite.as_dict()
+            'name': self.name,
+            'runDetails': self.run_details.as_dict(),
+            'suite': self.suite.as_dict()
         }
 
     @classmethod

--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -49,66 +49,29 @@ class BenchmarkSuite(object):
     def __init__(self, suite_name, executor, gauge_adapter, command, location, build,
                  benchmarks_config, desc, run_details, variables):
         """Specialize the benchmark suite for the given executor"""
-        self._name = suite_name
-        self._executor = executor
-        self._gauge_adapter = gauge_adapter
-        self._command = command
-        self._location = location
-        self._build = build
-        self._benchmarks_config = benchmarks_config
+        self.name = suite_name
+        self.executor = executor
+        self.gauge_adapter = gauge_adapter
+        self.command = command
+        self.location = location
+        self.build = build
+
+        # This is the raw configuration, i.e., the list of benchmarks and their properties.
+        self.benchmarks_config = benchmarks_config
+
         self._desc = desc
-        self._run_details = run_details
-        self._variables = variables
-
-    @property
-    def variables(self):
-        return self._variables
-
-    @property
-    def location(self):
-        return self._location
-
-    @property
-    def run_details(self):
-        return self._run_details
-
-    @property
-    def build(self):
-        return self._build
-
-    @property
-    def executor(self):
-        return self._executor
-
-    @property
-    def benchmarks_config(self):
-        """
-        This is the raw configuration, i.e.,
-        the list of benchmarks and their properties.
-        """
-        return self._benchmarks_config
-
-    @property
-    def gauge_adapter(self):
-        return self._gauge_adapter
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def command(self):
-        return self._command
+        self.run_details = run_details
+        self.variables = variables
 
     def __str__(self):
-        return "Suite(%s, %s)" % (self._name, self._command)
+        return "Suite(%s, %s)" % (self.name, self.command)
 
     def as_dict(self):
         result = {
-            'name': self._name,
-            'executor': self._executor.as_dict(),
+            'name': self.name,
+            'executor': self.executor.as_dict(),
             'desc': self._desc
         }
-        if self._build:
-            result['build'] = [b.as_dict() for b in self._build]
+        if self.build:
+            result['build'] = [b.as_dict() for b in self.build]
         return result

--- a/rebench/model/build_cmd.py
+++ b/rebench/model/build_cmd.py
@@ -38,46 +38,30 @@ class BuildCommand(object):
         return build_command
 
     def __init__(self, cmd, location):
-        self._cmd = cmd
-        self._location = location
-        self._built = False
-        self._build_failed = False
-
-    @property
-    def command(self):
-        return self._cmd
-
-    @property
-    def location(self):
-        return self._location
-
-    @property
-    def is_built(self):
-        return self._built
-
-    @property
-    def is_failed_build(self):
-        return self._build_failed
+        self.command = cmd
+        self.location = location
+        self.is_built = False
+        self.build_failed = False
 
     def mark_succeeded(self):
-        self._built = True
+        self.is_built = True
 
     def mark_failed(self):
-        self._build_failed = True
+        self.build_failed = True
 
     def __eq__(self, other):
         return (isinstance(other, self.__class__) and
-                self._cmd == other._cmd and
-                self._location == other._location)
+                self.command == other.command and
+                self.location == other.location)
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash((self._cmd, self._location))
+        return hash((self.command, self.location))
 
     def as_dict(self):
         return {
-            'cmd': self._cmd,
-            'location': self._location
+            'cmd': self.command,
+            'location': self.location
         }

--- a/rebench/model/data_point.py
+++ b/rebench/model/data_point.py
@@ -22,29 +22,21 @@ from ..ui import UIError
 
 class DataPoint(object):
     def __init__(self, run_id):
-        self._run_id = run_id
+        self.run_id = run_id
         self._measurements = []
         self._total = None
-        self._invocation = -1
-
-    @property
-    def run_id(self):
-        return self._run_id
-
-    @property
-    def invocation(self):
-        return self._invocation
+        self.invocation = -1
 
     def number_of_measurements(self):
         return len(self._measurements)
 
     def add_measurement(self, measurement):
-        if self._invocation == -1:
-            self._invocation = measurement.invocation
-        elif self._invocation != measurement.invocation:
+        if self.invocation == -1:
+            self.invocation = measurement.invocation
+        elif self.invocation != measurement.invocation:
             raise UIError("A data point is expected to represent a single invocation " +
                           "but we got invocation " + str(measurement.invocation) +
-                          " and " + str(self._invocation) + "\n", None)
+                          " and " + str(self.invocation) + "\n", None)
 
         self._measurements.append(measurement)
         if measurement.is_total():
@@ -77,7 +69,7 @@ class DataPoint(object):
             if criterion not in criteria:
                 criteria[criterion] = len(criteria)
             data.append({'v': m.value, 'c': criteria[criterion]})
-        assert self._invocation == invocation
+        assert self.invocation == invocation
 
         return {
             'in': invocation,

--- a/rebench/model/executor.py
+++ b/rebench/model/executor.py
@@ -50,55 +50,23 @@ class Executor(object):
         """Specializing the executor details in the run definitions with the settings from
            the executor definitions
         """
-        self._name = name
+        self.name = name
 
-        self._path = path
-        self._executable = executable
-        self._args = args
+        self.path = path
+        self.executable = executable
+        self.args = args
 
-        self._build = build
-        self._description = description
+        self.build = build
+        self.description = description
 
-        self._run_details = run_details
-        self._variables = variables
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def path(self):
-        return self._path
-
-    @property
-    def executable(self):
-        return self._executable
-
-    @property
-    def args(self):
-        return self._args
-
-    @property
-    def build(self):
-        return self._build
-
-    @property
-    def description(self):
-        return self._description
-
-    @property
-    def run_details(self):
-        return self._run_details
-
-    @property
-    def variables(self):
-        return self._variables
+        self.run_details = run_details
+        self.variables = variables
 
     def as_dict(self):
         result = {
-            'name': self._name,
-            'desc': self._description
+            'name': self.name,
+            'desc': self.description
         }
-        if self._build:
-            result['build'] = [b.as_dict() for b in self._build]
+        if self.build:
+            result['build'] = [b.as_dict() for b in self.build]
         return result

--- a/rebench/model/exp_run_details.py
+++ b/rebench/model/exp_run_details.py
@@ -61,67 +61,23 @@ class ExpRunDetails(object):
                  max_invocation_time, ignore_timeouts, parallel_interference_factor,
                  execute_exclusively, retries_after_failure,
                  invocations_override, iterations_override):
-        self._invocations = invocations
-        self._iterations = iterations
-        self._warmup = warmup
+        self.invocations = invocations
+        self.iterations = iterations
+        self.warmup = warmup
 
-        self._min_iteration_time = min_iteration_time
-        self._max_invocation_time = max_invocation_time
-        self._ignore_timeouts = ignore_timeouts
-        self._parallel_interference_factor = parallel_interference_factor
-        self._execute_exclusively = execute_exclusively
-        self._retries_after_failure = retries_after_failure
+        self.min_iteration_time = min_iteration_time
+        self.max_invocation_time = max_invocation_time
+        self.ignore_timeouts = ignore_timeouts
+        self.parallel_interference_factor = parallel_interference_factor
+        self.execute_exclusively = execute_exclusively
+        self.retries_after_failure = retries_after_failure
 
-        self._invocations_override = invocations_override
-        self._iterations_override = iterations_override
-
-    @property
-    def invocations(self):
-        return self._invocations
-
-    @property
-    def iterations(self):
-        return self._iterations
-
-    @property
-    def invocations_override(self):
-        return self._invocations_override
-
-    @property
-    def iterations_override(self):
-        return self._iterations_override
-
-    @property
-    def warmup(self):
-        return self._warmup
-
-    @property
-    def min_iteration_time(self):
-        return self._min_iteration_time
-
-    @property
-    def max_invocation_time(self):
-        return self._max_invocation_time
-
-    @property
-    def ignore_timeouts(self):
-        return self._ignore_timeouts
-
-    @property
-    def parallel_interference_factor(self):
-        return self._parallel_interference_factor
-
-    @property
-    def execute_exclusively(self):
-        return self._execute_exclusively
-
-    @property
-    def retries_after_failure(self):
-        return self._retries_after_failure
+        self.invocations_override = invocations_override
+        self.iterations_override = iterations_override
 
     def as_dict(self):
         return {
-            'warmup': self._warmup,
-            'minIterationTime': self._min_iteration_time,
-            'maxInvocationTime': self._max_invocation_time
+            'warmup': self.warmup,
+            'minIterationTime': self.min_iteration_time,
+            'maxInvocationTime': self.max_invocation_time
         }

--- a/rebench/model/exp_variables.py
+++ b/rebench/model/exp_variables.py
@@ -34,23 +34,7 @@ class ExpVariables(object):
         return ExpVariables([''], [1], [''], [None])
 
     def __init__(self, input_sizes, cores, variable_values, machines):
-        self._input_sizes = input_sizes
-        self._cores = cores
-        self._variable_values = variable_values
-        self._machines = machines
-
-    @property
-    def input_sizes(self):
-        return self._input_sizes
-
-    @property
-    def cores(self):
-        return self._cores
-
-    @property
-    def variable_values(self):
-        return self._variable_values
-
-    @property
-    def machines(self):
-        return self._machines
+        self.input_sizes = input_sizes
+        self.cores = cores
+        self.variable_values = variable_values
+        self.machines = machines

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -47,7 +47,7 @@ class Experiment(object):
 
     def __init__(self, name, description, data_file, reporting, run_details,
                  variables, configurator, executions, suites):
-        self._name = name
+        self.name = name
         self._description = description
         self._data_file = data_file
 
@@ -61,7 +61,7 @@ class Experiment(object):
         self._suites = self._compile_executors_and_benchmark_suites(
             executions, suites, configurator)
         self._benchmarks = self._compile_benchmarks()
-        self._runs = self._compile_runs(configurator)
+        self.runs = self._compile_runs(configurator)
 
     def _compile_runs(self, configurator):
         runs = set()
@@ -118,10 +118,3 @@ class Experiment(object):
                 bench_cfgs.append(Benchmark.compile(
                     bench, suite, self._data_store))
         return bench_cfgs
-
-    @property
-    def name(self):
-        return self._name
-
-    def get_runs(self):
-        return self._runs

--- a/rebench/model/measurement.py
+++ b/rebench/model/measurement.py
@@ -23,61 +23,29 @@ from .run_id import RunId
 class Measurement(object):
     def __init__(self, invocation, iteration, value, unit,
                  run_id, criterion='total', line_number=None, filename=None):
-        self._invocation = invocation
-        self._iteration = iteration
-        self._value = value
-        self._unit = unit
-        self._run_id = run_id
-        self._criterion = criterion
+        self.invocation = invocation
+        self.iteration = iteration
+        self.value = value
+        self.unit = unit
+        self.run_id = run_id
+        self.criterion = criterion
         assert unit is not None
-        self._line_number = line_number
-        self._filename = filename
+        self.line_number = line_number
+        self.filename = filename
 
     def is_total(self):
-        return self._criterion == 'total'
-
-    @property
-    def invocation(self):
-        return self._invocation
-
-    @property
-    def iteration(self):
-        return self._iteration
-
-    @property
-    def criterion(self):
-        return self._criterion
-
-    @property
-    def value(self):
-        return self._value
-
-    @property
-    def unit(self):
-        return self._unit
-
-    @property
-    def run_id(self):
-        return self._run_id
-
-    @property
-    def filename(self):
-        return self._filename
-
-    @property
-    def line_number(self):
-        return self._line_number
+        return self.criterion == 'total'
 
     def as_str_list(self):
-        if isinstance(self._value, float):
+        if isinstance(self.value, float):
             val = "%f" % self.value
         else:
             val = "%s" % self.value
 
-        return [str(self._invocation), str(self._iteration),
+        return [str(self.invocation), str(self.iteration),
                 val,
-                self._unit,
-                self._criterion] + self._run_id.as_str_list()
+                self.unit,
+                self.criterion] + self.run_id.as_str_list()
 
     @classmethod
     def from_str_list(cls, data_store, str_list, line_number=None, filename=None):
@@ -93,9 +61,9 @@ class Measurement(object):
 
     def as_dict(self):
         return {
-            'c': self._criterion,
-            'in': self._invocation,
-            'it': self._iteration,
-            'u': self._unit,
-            'v': self._value
+            'c': self.criterion,
+            'in': self.invocation,
+            'it': self.iteration,
+            'u': self.unit,
+            'v': self.value
         }

--- a/rebench/model/reporting.py
+++ b/rebench/model/reporting.py
@@ -26,7 +26,7 @@ class Reporting(object):
     @classmethod
     def compile(cls, reporting, root_reporting, options, ui):
         if "codespeed" in reporting and options and options.use_data_reporting:
-            codespeed = CodespeedReporting(reporting, options, ui).get_reporter()
+            codespeed = CodespeedReporting(reporting, options, ui).reporter
         else:
             codespeed = root_reporting.codespeed_reporter
         # We ignore the entry for ReBenchDB here,
@@ -41,23 +41,15 @@ class Reporting(object):
         return Reporting(None, cli_reporter)
 
     def __init__(self, codespeed_reporter, cli_reporter):
-        self._codespeed_reporter = codespeed_reporter
-        self._cli_reporter = cli_reporter
-
-    @property
-    def codespeed_reporter(self):
-        return self._codespeed_reporter
-
-    @property
-    def cli_reporter(self):
-        return self._cli_reporter
+        self.codespeed_reporter = codespeed_reporter
+        self.cli_reporter = cli_reporter
 
     def get_reporters(self):
         result = []
-        if self._cli_reporter:
-            result.append(self._cli_reporter)
-        if self._codespeed_reporter:
-            result.append(self._codespeed_reporter)
+        if self.cli_reporter:
+            result.append(self.cli_reporter)
+        if self.codespeed_reporter:
+            result.append(self.codespeed_reporter)
         return result
 
 
@@ -69,12 +61,12 @@ class CodespeedReporting(object):
         if options.commit_id is None:
             raise ConfigurationError("--commit-id has to be set on the command "
                                      "line for codespeed reporting.")
-        self._commit_id = options.commit_id
+        self.commit_id = options.commit_id
 
         if options.environment is None:
             raise ConfigurationError("--environment has to be set on the "
                                      "command line for codespeed reporting.")
-        self._environment = options.environment
+        self.environment = options.environment
 
         if "project" not in codespeed and options.project is None:
             raise ConfigurationError("The config file needs to configure a "
@@ -82,49 +74,18 @@ class CodespeedReporting(object):
                                      "section, or --project has to be given on "
                                      "the command line.")
         if options.project is not None:
-            self._project = options.project
+            self.project = options.project
         else:
-            self._project = codespeed["project"]
+            self.project = codespeed["project"]
 
         if "url" not in codespeed:
             raise ConfigurationError("The config file needs to define a URL to "
                                      "codespeed in the reporting.codespeed "
                                      "section")
-        self._url = codespeed["url"]
+        self.url = codespeed["url"]
 
-        self._report_incrementally = options.report_incrementally
-        self._branch = options.branch
-        self._executable = options.executable
+        self.report_incrementally = options.report_incrementally
+        self.branch = options.branch
+        self.executable = options.executable
 
-        self._reporter = CodespeedReporter(self, ui)
-
-    @property
-    def report_incrementally(self):
-        return self._report_incrementally
-
-    @property
-    def branch(self):
-        return self._branch
-
-    @property
-    def executable(self):
-        return self._executable
-
-    @property
-    def project(self):
-        return self._project
-
-    @property
-    def commit_id(self):
-        return self._commit_id
-
-    @property
-    def environment(self):
-        return self._environment
-
-    @property
-    def url(self):
-        return self._url
-
-    def get_reporter(self):
-        return self._reporter
+        self.reporter = CodespeedReporter(self, ui)

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -28,53 +28,53 @@ from ..ui import UIError
 class RunId(object):
 
     def __init__(self, benchmark, cores, input_size, var_value, machine):
-        self._benchmark = benchmark
-        self._cores = cores
-        self._input_size = input_size
-        self._var_value = var_value
-        self._machine = machine
+        self.benchmark = benchmark
+        self.cores = cores
+        self.input_size = input_size
+        self.var_value = var_value
+        self.machine = machine
 
         self._reporters = set()
         self._persistence = set()
-        self._statistics = StatisticProperties()
-        self._total_unit = None
+        self.statistics = StatisticProperties()
+        self.total_unit = None
 
         self._termination_check = None
         self._cmdline = None
-        self._failed = True
+        self.is_failed = True
 
         self._max_invocation = 0
 
     @property
     def warmup_iterations(self):
-        return self._benchmark.run_details.warmup
+        return self.benchmark.run_details.warmup
 
     @property
     def min_iteration_time(self):
-        return self._benchmark.run_details.min_iteration_time
+        return self.benchmark.run_details.min_iteration_time
 
     @property
     def max_invocation_time(self):
-        return self._benchmark.run_details.max_invocation_time
+        return self.benchmark.run_details.max_invocation_time
 
     @property
     def ignore_timeouts(self):
-        return self._benchmark.run_details.ignore_timeouts
+        return self.benchmark.run_details.ignore_timeouts
 
     @property
     def retries_after_failure(self):
-        return self._benchmark.run_details.retries_after_failure
+        return self.benchmark.run_details.retries_after_failure
 
     @property
     def iterations(self):
-        run_details = self._benchmark.run_details
+        run_details = self.benchmark.run_details
         if run_details.iterations_override is not None:
             return run_details.iterations_override
         return run_details.iterations
 
     @property
     def invocations(self):
-        run_details = self._benchmark.run_details
+        run_details = self.benchmark.run_details
         if run_details.invocations_override is not None:
             return run_details.invocations_override
         return run_details.invocations
@@ -85,62 +85,42 @@ class RunId(object):
 
     @property
     def execute_exclusively(self):
-        return self._benchmark.run_details.execute_exclusively
-
-    @property
-    def benchmark(self):
-        return self._benchmark
-
-    @property
-    def cores(self):
-        return self._cores
-
-    @property
-    def input_size(self):
-        return self._input_size
+        return self.benchmark.run_details.execute_exclusively
 
     @property
     def cores_as_str(self):
-        return '' if self._cores is None else str(self._cores)
+        return '' if self.cores is None else str(self.cores)
 
     @property
     def input_size_as_str(self):
-        return '' if self._input_size is None else str(self._input_size)
+        return '' if self.input_size is None else str(self.input_size)
 
     @property
     def var_value_as_str(self):
-        return '' if self._var_value is None else str(self._var_value)
-
-    @property
-    def var_value(self):
-        return self._var_value
-
-    @property
-    def machine(self):
-        return self._machine
+        return '' if self.var_value is None else str(self.var_value)
 
     @property
     def machine_as_str(self):
-        return '' if self._machine is None else str(self._machine)
+        return '' if self.machine is None else str(self.machine)
 
     @property
     def location(self):
-        if not self._benchmark.suite.location:
+        if not self.benchmark.suite.location:
             return None
-        return self._expand_vars(self._benchmark.suite.location)
+        return self._expand_vars(self.benchmark.suite.location)
 
     def build_commands(self):
         commands = set()
-        builds = self._benchmark.suite.executor.build
+        builds = self.benchmark.suite.executor.build
         if builds:
             commands.update(builds)
-        builds = self._benchmark.suite.build
+        builds = self.benchmark.suite.build
         if builds:
             commands.update(builds)
         return commands
 
     def requires_warmup(self):
-        return self._benchmark.run_details.warmup > 0
+        return self.benchmark.run_details.warmup > 0
 
     def fail_immediately(self):
         self._termination_check.fail_immediately()
@@ -149,11 +129,8 @@ class RunId(object):
         self._termination_check.indicate_failed_execution()
 
     def indicate_successful_execution(self):
-        self._failed = False
+        self.is_failed = False
         self._termination_check.indicate_successful_execution()
-
-    def is_failed(self):
-        return self._failed
 
     def add_reporter(self, reporter):
         self._reporters.add(reporter)
@@ -167,7 +144,7 @@ class RunId(object):
 
     def report_run_completed(self, cmdline):
         for reporter in self._reporters:
-            reporter.run_completed(self, self._statistics, cmdline)
+            reporter.run_completed(self, self.statistics, cmdline)
         for persistence in self._persistence:
             persistence.run_completed()
 
@@ -195,10 +172,10 @@ class RunId(object):
 
     def _new_data_point(self, data_point, warmup):
         self._max_invocation = max(self._max_invocation, data_point.invocation)
-        if self._total_unit is None:
-            self._total_unit = data_point.get_total_unit()
+        if self.total_unit is None:
+            self.total_unit = data_point.get_total_unit()
         if not warmup:
-            self._statistics.add_sample(data_point.get_total_value())
+            self.statistics.add_sample(data_point.get_total_value())
 
     def loaded_data_point(self, data_point, warmup):
         for persistence in self._persistence:
@@ -212,16 +189,10 @@ class RunId(object):
             persistence.persist_data_point(data_point)
 
     def get_number_of_data_points(self):
-        return self._statistics.num_samples
+        return self.statistics.num_samples
 
     def get_mean_of_totals(self):
-        return self._statistics.mean
-
-    def get_statistics(self):
-        return self._statistics
-
-    def get_total_unit(self):
-        return self._total_unit
+        return self.statistics.mean
 
     def get_termination_check(self, ui):
         if self._termination_check is None:
@@ -243,20 +214,20 @@ class RunId(object):
 
     def as_simple_string(self):
         return "%s %s %s %s %s" % (
-            self._benchmark.as_simple_string(),
-            self._cores, self._input_size, self._var_value, self._machine)
+            self.benchmark.as_simple_string(),
+            self.cores, self.input_size, self.var_value, self.machine)
 
     def _expand_vars(self, string):
         try:
-            return string % {'benchmark': self._benchmark.command,
+            return string % {'benchmark': self.benchmark.command,
                              'cores': self.cores_as_str,
-                             'executor': self._benchmark.suite.executor.name,
+                             'executor': self.benchmark.suite.executor.name,
                              'input': self.input_size_as_str,
                              'iterations': self.iterations,
-                             'suite': self._benchmark.suite.name,
+                             'suite': self.benchmark.suite.name,
                              'variable': self.var_value_as_str,
                              'machine': self.machine_as_str,
-                             'warmup': self._benchmark.run_details.warmup}
+                             'warmup': self.benchmark.run_details.warmup}
         except ValueError as err:
             self._report_format_issue_and_exit(string, err)
             return None
@@ -268,7 +239,7 @@ class RunId(object):
                    + "{ind}The command line configured is: %s\n"
                    + "{ind}%s is not supported as key.\n"
                    + "{ind}Only benchmark, input, variable, cores, and warmup are supported.\n") % (
-                       self._benchmark.name, string, err)
+                       self.benchmark.name, string, err)
             raise UIError(msg, err)
 
     def cmdline(self):
@@ -278,18 +249,18 @@ class RunId(object):
 
     def _construct_cmdline(self):
         cmdline = ""
-        if self._benchmark.suite.executor.path:
-            cmdline = self._benchmark.suite.executor.path + "/"
+        if self.benchmark.suite.executor.path:
+            cmdline = self.benchmark.suite.executor.path + "/"
 
-        cmdline += self._benchmark.suite.executor.executable
+        cmdline += self.benchmark.suite.executor.executable
 
-        if self._benchmark.suite.executor.args:
-            cmdline += " " + str(self._benchmark.suite.executor.args)
+        if self.benchmark.suite.executor.args:
+            cmdline += " " + str(self.benchmark.suite.executor.args)
 
-        cmdline += " " + self._benchmark.suite.command
+        cmdline += " " + self.benchmark.suite.command
 
-        if self._benchmark.extra_args:
-            cmdline += " " + str(self._benchmark.extra_args)
+        if self.benchmark.extra_args:
+            cmdline += " " + str(self.benchmark.extra_args)
 
         cmdline = self._expand_vars(cmdline)
 
@@ -307,7 +278,7 @@ class RunId(object):
         msg = ("The configuration of the benchmark %s contains an improper Python format string.\n"
                + "{ind}The command line configured is: %s\n"
                + "{ind}Error: %s\n") % (
-                   self._benchmark.name, cmdline, err)
+                   self.benchmark.name, cmdline, err)
 
         # figure out which format misses a conversion type
         without_conversion_type = re.findall(
@@ -320,7 +291,7 @@ class RunId(object):
         raise UIError(msg, err)
 
     def as_str_list(self):
-        result = self._benchmark.as_str_list()
+        result = self.benchmark.as_str_list()
 
         result.append(self.cores_as_str)
         result.append(self.input_size_as_str)
@@ -331,12 +302,12 @@ class RunId(object):
 
     def as_dict(self):
         return {
-            'benchmark': self._benchmark.as_dict(),
-            'cores': self._cores,
-            'inputSize': self._input_size,
-            'varValue': self._var_value,
-            'machine': self._machine,
-            'extraArgs': str(self._benchmark.extra_args),
+            'benchmark': self.benchmark.as_dict(),
+            'cores': self.cores,
+            'inputSize': self.input_size,
+            'varValue': self.var_value,
+            'machine': self.machine,
+            'extraArgs': str(self.benchmark.extra_args),
             'cmdline': self.cmdline(),
             'location': self.location
         }
@@ -349,10 +320,10 @@ class RunId(object):
 
     def __str__(self):
         return "RunId(%s, %s, %s, %s, %s, %s, %d)" % (
-            self._benchmark.name,
-            self._cores,
-            self._benchmark.extra_args,
-            self._input_size or '',
-            self._var_value  or '',
-            self._machine or '',
-            self._benchmark.run_details.warmup or 0)
+            self.benchmark.name,
+            self.cores,
+            self.benchmark.extra_args,
+            self.input_size or '',
+            self.var_value  or '',
+            self.machine or '',
+            self.benchmark.run_details.warmup or 0)

--- a/rebench/model/termination_check.py
+++ b/rebench/model/termination_check.py
@@ -22,7 +22,7 @@
 class TerminationCheck(object):
     def __init__(self, run_id, ui):
         self._run_id = run_id
-        self._ui = ui
+        self.ui = ui
         self._consecutive_erroneous_executions = 0
         self._failed_execution_count = 0
         self._fail_immediately = False
@@ -50,16 +50,16 @@ class TerminationCheck(object):
 
     def should_terminate(self, number_of_data_points, cmd):
         if self._fail_immediately:
-            self._ui.warning("{ind}Marked to fail immediately.\n", self._run_id, cmd)
+            self.ui.warning("{ind}Marked to fail immediately.\n", self._run_id, cmd)
         if self.fails_consecutively():
             msg = "{ind}Execution has failed, benchmark is aborted.\n"
             if self._consecutive_erroneous_executions > 0:
                 msg += "{ind}{ind}The benchmark failed "
                 msg += str(self._consecutive_erroneous_executions) + " times in a row.\n"
-            self._ui.warning(msg, self._run_id, cmd)
+            self.ui.warning(msg, self._run_id, cmd)
             return True
         elif self.has_too_many_failures(number_of_data_points):
-            self._ui.warning(
+            self.ui.warning(
                 "{ind}Many runs are failing, benchmark is aborted.\n", self._run_id, cmd)
             return True
         elif self._run_id.completed_invocations >= self._run_id.invocations:

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -42,7 +42,7 @@ class DataStore(object):
         self._files = {}
         self._run_ids = {}
         self._bench_cfgs = {}
-        self._ui = ui
+        self.ui = ui
 
     def load_data(self, runs, discard_run_data):
         for persistence in list(self._files.values()):
@@ -62,11 +62,11 @@ class DataStore(object):
             if configurator.options and configurator.options.branch:
                 source['branchOrTag'] = configurator.options.branch
 
-            p = _FilePersistence(filename, self, configurator, self._ui)
-            self._ui.debug_output_info('ReBenchDB enabled: {e}\n', e=configurator.use_rebench_db)
+            p = _FilePersistence(filename, self, configurator, self.ui)
+            self.ui.debug_output_info('ReBenchDB enabled: {e}\n', e=configurator.use_rebench_db)
 
             if configurator.use_rebench_db:
-                db = _ReBenchDB(configurator, self, self._ui)
+                db = _ReBenchDB(configurator, self, self.ui)
                 p = _CompositePersistence(p, db)
 
             self._files[filename] = p
@@ -133,7 +133,7 @@ class _ConcretePersistence(_AbstractPersistence):
     def __init__(self, data_store, ui):
         self._data_store = data_store
         self._start_time = None
-        self._ui = ui
+        self.ui = ui
 
 
 class _CompositePersistence(_AbstractPersistence):
@@ -236,7 +236,7 @@ class _FilePersistence(_ConcretePersistence):
                 with open(self._data_filename, 'r') as data_file:
                     self._process_lines(data_file, current_runs, None)
         except IOError:
-            self._ui.debug_error_info("No data loaded, since %s does not exist.\n"
+            self.ui.debug_error_info("No data loaded, since %s does not exist.\n"
                                       % self._data_filename)
         return self._start_time
 
@@ -285,11 +285,11 @@ class _FilePersistence(_ConcretePersistence):
             except ValueError as err:
                 msg = str(err)
                 if not errors:
-                    self._ui.debug_error_info("Failed loading data from data file: "
+                    self.ui.debug_error_info("Failed loading data from data file: "
                                               + self._data_filename + "\n")
                 if msg not in errors:
                     # Configuration is not available, skip data point
-                    self._ui.debug_error_info("{ind}" + msg + "\n")
+                    self.ui.debug_error_info("{ind}" + msg + "\n")
                     errors.add(msg)
 
     def _open_file_and_append_execution_comment(self):
@@ -375,7 +375,7 @@ class _ReBenchDB(_ConcretePersistence):
     def send_data(self):
         current_time = time()
         time_past = current_time - self._last_send
-        self._ui.debug_output_info(
+        self.ui.debug_output_info(
             "ReBenchDB: data last send {seconds}s ago\n",
             seconds=round(time_past, 2))
         if time_past >= self._cache_for_seconds:
@@ -388,7 +388,7 @@ class _ReBenchDB(_ConcretePersistence):
                 self._cache = {}
 
     def _send_data(self, cache):
-        self._ui.debug_output_info("ReBenchDB: Prepare data for sending\n")
+        self.ui.debug_output_info("ReBenchDB: Prepare data for sending\n")
         num_measurements = 0
         all_data = []
         criteria = {}
@@ -407,7 +407,7 @@ class _ReBenchDB(_ConcretePersistence):
         for c, idx in criteria.items():
             criteria_index.append({'c': c[0], 'u': c[1], 'i': idx})
 
-        self._ui.debug_output_info(
+        self.ui.debug_output_info(
             "ReBenchDB: Send {num_m} measures. startTime: {st}\n",
             num_m=num_measurements, st=self._start_time)
         return self._rebench_db.send_results({

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -50,11 +50,7 @@ class ReBench(object):
         self.version = rebench_version
         self.options = None
         self._config = None
-        self._ui = UI()
-
-    @property
-    def ui(self):
-        return self._ui
+        self.ui = UI()
 
     def shell_options(self):
         usage = """%(prog)s [options] <config> [exp_name] [e:$]* [s:$]* [m:$]*
@@ -232,17 +228,17 @@ Argument:
         if argv is None:
             argv = sys.argv
 
-        data_store = DataStore(self._ui)
+        data_store = DataStore(self.ui)
         opt_parser = self.shell_options()
         args = opt_parser.parse_args(argv[1:])
 
-        cli_reporter = CliReporter(args.verbose, self._ui)
+        cli_reporter = CliReporter(args.verbose, self.ui)
 
         exp_name, exp_filter = self.determine_exp_name_and_filters(args.exp_filter)
 
         try:
             config = load_config(args.config[0])
-            self._config = Configurator(config, data_store, self._ui, args,
+            self._config = Configurator(config, data_store, self.ui, args,
                                         cli_reporter, exp_name, args.data_file,
                                         args.build_log, exp_filter)
         except ConfigurationError as exc:
@@ -255,8 +251,8 @@ Argument:
 
         denoise_result = None
         try:
-            denoise_result = minimize_noise(not self._config.artifact_review, self._ui)
-            init_environment(denoise_result, self._ui)
+            denoise_result = minimize_noise(not self._config.artifact_review, self.ui)
+            init_environment(denoise_result, self.ui)
 
             data_store.load_data(runs, self._config.options.do_rerun)
 
@@ -265,17 +261,17 @@ Argument:
 
             return self.execute_experiment(runs, use_nice, use_shielding)
         finally:
-            restore_noise(denoise_result, not self._config.artifact_review, self._ui)
+            restore_noise(denoise_result, not self._config.artifact_review, self.ui)
 
     def execute_experiment(self, runs, use_nice, use_shielding):
-        self._ui.verbose_output_info("Execute experiment: " + self._config.experiment_name + "\n")
+        self.ui.verbose_output_info("Execute experiment: " + self._config.experiment_name + "\n")
 
         scheduler_class = {'batch':       BatchScheduler,
                            'round-robin': RoundRobinScheduler,
                            'random':      RandomScheduler}.get(self._config.options.scheduler)
 
         executor = Executor(runs, self._config.do_builds,
-                            self._ui,
+                            self.ui,
                             self._config.options.include_faulty,
                             self._config.options.debug,
                             scheduler_class,
@@ -286,7 +282,7 @@ Argument:
             return True
         else:
             if self._config.artifact_review:
-                self._ui.output("Executing benchmarks for Artifact Review"
+                self.ui.output("Executing benchmarks for Artifact Review"
                                 + " using the reported settings.")
             return executor.execute()
 

--- a/rebench/rebenchdb.py
+++ b/rebench/rebenchdb.py
@@ -31,7 +31,7 @@ def get_current_time():
 class ReBenchDB(object):
 
     def __init__(self, server_base_url, project_name, experiment_name, ui):
-        self._ui = ui
+        self.ui = ui
 
         if not server_base_url:
             raise UIError("ReBenchDB expected server address, but got: %s" % server_base_url, None)
@@ -53,7 +53,7 @@ class ReBenchDB(object):
         success, response = self._send_to_rebench_db(benchmark_data, '/results')
 
         if success:
-            self._ui.verbose_output_info(
+            self.ui.verbose_output_info(
                 "ReBenchDB: Sent {num_m} results to ReBenchDB, response was: {resp}\n",
                 num_m=num_measurements, resp=response)
 
@@ -63,12 +63,12 @@ class ReBenchDB(object):
         success, response = self._send_to_rebench_db({'endTime': end_time}, '/completion')
 
         if success:
-            self._ui.verbose_output_info(
+            self.ui.verbose_output_info(
                 "ReBenchDB was notified of completion of {project} {exp} at {time}\n" +
                 "{ind} Its response was: {resp}\n",
                 project=self._project_name, exp=self._experiment_name, time=end_time, resp=response)
         else:
-            self._ui.error("Reporting completion to ReBenchDB failed.\n" +
+            self.ui.error("Reporting completion to ReBenchDB failed.\n" +
                            "{ind}Error: {response}", response=response)
 
         return success, response
@@ -89,7 +89,7 @@ class ReBenchDB(object):
 
         payload = json.dumps(payload_data, separators=(',', ':'), ensure_ascii=True)
 
-        # self._ui.output("Saving JSON Payload of size: %d\n" % len(payload))
+        # self.ui.output("Saving JSON Payload of size: %d\n" % len(payload))
         with open("payload.json", "w") as text_file:  # pylint: disable=unspecified-encoding
             text_file.write(payload)
 
@@ -104,14 +104,14 @@ class ReBenchDB(object):
                 return True, response
             except TypeError as te:
                 # can't handle this, just abort
-                self._ui.error("{ind}Error: Reporting to ReBenchDB failed.\n"
+                self.ui.error("{ind}Error: Reporting to ReBenchDB failed.\n"
                                + "{ind}{ind}" + str(te) + "\n")
                 return False, None
             except (IOError, HTTPException) as error:
                 if attempts > 0:
                     # let's retry, the benchmark server might just time out, as usual
                     # but let it breath a little
-                    self._ui.verbose_output_info(
+                    self.ui.verbose_output_info(
                         "ReBenchDB: had issue reporting data. Trying again after "
                         + str(wait_sec) + "seconds.\n"
                         + "{ind}{ind}" + str(error) + "\n")
@@ -119,6 +119,6 @@ class ReBenchDB(object):
                     sleep(wait_sec)
                     wait_sec *= 2
                 else:
-                    self._ui.error("{ind}Error: Reporting to ReBenchDB failed.\n"
+                    self.ui.error("{ind}Error: Reporting to ReBenchDB failed.\n"
                                    + "{ind}{ind}" + str(error) + "\n")
                     return False, None

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -97,7 +97,7 @@ class CliReporter(TextReporter):
     def __init__(self, executes_verbose, ui):
         super(CliReporter, self).__init__()
         self._num_runs = None
-        self._ui = ui
+        self.ui = ui
         self._runs_completed = 0
         self._start_time = None
         self._runs_remaining = 0
@@ -111,7 +111,7 @@ class CliReporter(TextReporter):
         self._runs_remaining -= 1
 
     def report_job_completed(self, run_ids):
-        self._ui.output("\n\n" + format_pretty_table(
+        self.ui.output("\n\n" + format_pretty_table(
             self._generate_all_output(run_ids),
             ['Benchmark', 'Executor', 'Suite', 'Extra', 'Core', 'Size', 'Var',
              '#Samples', 'Mean (ms)'],
@@ -135,7 +135,7 @@ class CodespeedReporter(Reporter):
         self._cache_for_seconds = 30
         self._cache = {}
         self._last_send = time()
-        self._ui = ui
+        self.ui = ui
 
     def run_completed(self, run_id, statistics, cmdline):
         if not self._incremental_report:
@@ -224,7 +224,7 @@ class CodespeedReporter(Reporter):
             # is not yet properly initialized, let's try again for those cases
             try:
                 response = self._send_payload(payload)
-                self._ui.verbose_error_info("Sent %d results to Codespeed, response was: %s\n"
+                self.ui.verbose_error_info("Sent %d results to Codespeed, response was: %s\n"
                                             % (len(results), response))
             except (IOError, HTTPException) as error:
                 envs = list({i['environment'] for i in results})
@@ -238,7 +238,7 @@ class CodespeedReporter(Reporter):
                        + "{ind}{ind}executables: %s\n") % (
                            envs, projects, benchmarks, executables)
 
-                self._ui.error(
+                self.ui.error(
                     "{ind}Error: Reporting to Codespeed failed.\n"
                     + "{ind}{ind}" + str(error) + "\n"
                     + "{ind}{ind}This is most likely caused by either a wrong URL in the\n"

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -247,7 +247,7 @@ class CodespeedReporter(Reporter):
                     + "{ind}{ind}" + msg + "\n", run_id)
 
     def _prepare_result(self, run_id):
-        return self._format_for_codespeed(run_id, run_id.get_statistics())
+        return self._format_for_codespeed(run_id, run_id.statistics)
 
     def report_job_completed(self, run_ids):
         if self._incremental_report:

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -86,8 +86,7 @@ class _SubprocessThread(Thread):
         return self._pid
 
     def process_output(self, proc):
-        if self._verbose and self._stdout == PIPE and (self._stderr == PIPE or
-                                                       self._stderr == STDOUT):
+        if self._verbose and self._stdout == PIPE and self._stderr in (PIPE, STDOUT):
             self.stdout_result = ""
             self.stderr_result = ""
 

--- a/rebench/tests/bugs/issue_111_report_ignores_warmup_test.py
+++ b/rebench/tests/bugs/issue_111_report_ignores_warmup_test.py
@@ -31,16 +31,16 @@ class Issue111Test(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_invocation_and_mean_with_warmup_2(self):
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/issue_111.conf'),
-                           ds, self._ui, exp_name='test-warmup-2', data_file=self._tmp_file)
+                           ds, self.ui, exp_name='test-warmup-2', data_file=self._tmp_file)
         runs = cnf.get_runs()
         ds.load_data(runs, False)
 
         # Has not executed yet, check that there is simply
         self._assert_runs(cnf, 1, 0, 0)
 
-        ex = Executor(runs, False, self._ui)
+        ex = Executor(runs, False, self.ui)
         ex.execute()
 
         self._assert_runs(cnf, 1, 7, 1)
@@ -48,9 +48,9 @@ class Issue111Test(ReBenchTestCase):
         self.assertEqual(run.get_mean_of_totals(), 10)
 
         # Reload data from file, and confirm we get the same result
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/issue_111.conf'),
-                           ds, self._ui, exp_name='test-warmup-2', data_file=self._tmp_file)
+                           ds, self.ui, exp_name='test-warmup-2', data_file=self._tmp_file)
         runs = cnf.get_runs()
         ds.load_data(runs, False)
 
@@ -59,16 +59,16 @@ class Issue111Test(ReBenchTestCase):
         self.assertEqual(run.get_mean_of_totals(), 10)
 
     def test_invocation_and_mean_with_warmup_0(self):
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/issue_111.conf'),
-                           ds, self._ui, exp_name='test-warmup-0', data_file=self._tmp_file)
+                           ds, self.ui, exp_name='test-warmup-0', data_file=self._tmp_file)
         runs = cnf.get_runs()
         ds.load_data(runs, False)
 
         # Has not executed yet, check that there is simply
         self._assert_runs(cnf, 1, 0, 0)
 
-        ex = Executor(runs, False, self._ui)
+        ex = Executor(runs, False, self.ui)
         ex.execute()
 
         self._assert_runs(cnf, 1, 9, 1)
@@ -76,9 +76,9 @@ class Issue111Test(ReBenchTestCase):
         self.assertEqual(run.get_mean_of_totals(), 230)
 
         # Reload data from file, and confirm we get the same result
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/issue_111.conf'),
-                           ds, self._ui, exp_name='test-warmup-0', data_file=self._tmp_file)
+                           ds, self.ui, exp_name='test-warmup-0', data_file=self._tmp_file)
         runs = cnf.get_runs()
         ds.load_data(runs, False)
 

--- a/rebench/tests/bugs/issue_112_invocations_setting_ignored_test.py
+++ b/rebench/tests/bugs/issue_112_invocations_setting_ignored_test.py
@@ -32,15 +32,15 @@ class Issue112Test(ReBenchTestCase):
 
     def _test(self, exp_name, exp_result):
         # Executes first time
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/issue_112.conf'),
-                           ds, self._ui, exp_name=exp_name, data_file=self._tmp_file)
+                           ds, self.ui, exp_name=exp_name, data_file=self._tmp_file)
         ds.load_data(None, False)
 
         # Has not executed yet, check that there is simply
         self._assert_runs(cnf, 1, 0, 0)
 
-        ex = Executor(cnf.get_runs(), False, self._ui)
+        ex = Executor(cnf.get_runs(), False, self.ui)
         ex.execute()
 
         self._assert_runs(cnf, 1, exp_result, exp_result)

--- a/rebench/tests/bugs/issue_117_input_size_setting_ignored_test.py
+++ b/rebench/tests/bugs/issue_117_input_size_setting_ignored_test.py
@@ -31,9 +31,9 @@ class Issue117Test(ReBenchTestCase):
 
     def _test(self, exp_name, num_runs, exp_input_sizes):
         # Executes first time
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/issue_117.conf'),
-                           ds, self._ui, exp_name=exp_name, data_file=self._tmp_file)
+                           ds, self.ui, exp_name=exp_name, data_file=self._tmp_file)
         ds.load_data(None, False)
 
         # Has not executed yet, check that there is simply

--- a/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
+++ b/rebench/tests/bugs/issue_27_invalid_run_not_handled_test.py
@@ -31,12 +31,12 @@ class Issue27InvalidRunNotHandled(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_execution_should_recognize_invalid_run_and_continue_normally(self):
-        cnf = Configurator(load_config(self._path + '/issue_27.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_27.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
 
-        ex = Executor([runs[0]], False, self._ui)
+        ex = Executor([runs[0]], False, self.ui)
         ex.execute()
 
         self.assertEqual(runs[0].get_number_of_data_points(), 0)

--- a/rebench/tests/bugs/issue_54_extra_args_test.py
+++ b/rebench/tests/bugs/issue_54_extra_args_test.py
@@ -12,7 +12,7 @@ class Issue54Test(ReBenchTestCase):
 
     def test_expansion_of_extra_args(self):
         cnf = Configurator(load_config(self._path + '/issue_54.conf'),
-                           DataStore(self._ui), self._ui, None, 'Test')
+                           DataStore(self.ui), self.ui, None, 'Test')
 
         runs = cnf.get_runs()
         self.assertEqual(1, len(runs))

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -32,29 +32,29 @@ class ConfiguratorTest(ReBenchTestCase):
 
     def test_experiment_name_from_cli(self):
         cnf = Configurator(load_config(self._path + '/test.conf'),
-                           DataStore(self._ui), self._ui, None, 'Test')
+                           DataStore(self.ui), self.ui, None, 'Test')
 
         self.assertEqual('Test', cnf.experiment_name)
 
     def test_experiment_name_from_config_file(self):
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
-                           self._ui, None)
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
+                           self.ui, None)
         self.assertEqual('Test', cnf.experiment_name)
 
     def test_number_of_experiments_smallconf(self):
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                           self._ui, None)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                           self.ui, None)
         self.assertEqual(1, len(cnf.get_experiments()))
 
     @unittest.skip
     def test_number_of_experiments_testconf(self):
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
-                           self._ui, None, None, 'all')
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
+                           self.ui, None, None, 'all')
         self.assertEqual(6, len(cnf.get_experiments()))
 
     def test_get_experiment(self):
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                           self._ui, None)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                           self.ui, None)
         exp = cnf.get_experiment('Test')
         self.assertIsNotNone(exp)
         return exp
@@ -67,71 +67,71 @@ class ConfiguratorTest(ReBenchTestCase):
     # Support for running a selected experiment
     def test_only_running_test_runner2(self):
         filter_args = ['e:TestRunner2']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
 
     def test_only_running_bench1(self):
         filter_args = ['s:Suite:Bench1']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
 
     def test_star_filter_for_suite(self):
         filter_args = ['s:*:Bench1']
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(20, len(runs))
 
     def test_only_running_non_existing_stuff(self):
         filter_args = ['s:non-existing', 'e:non-existing']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(0, len(runs))
 
     def test_only_running_bench1_and_test_runner2(self):
         filter_args = ['s:Suite:Bench1', 'e:TestRunner2']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(2, len(runs))
 
     def test_only_running_bench1_or_bench2_and_test_runner2(self):
         filter_args = ['s:Suite:Bench1', 's:Suite:Bench2', 'e:TestRunner2']
-        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(2 * 2, len(runs))
 
     def test_machine_filter_m1(self):
         filter_args = ['m:machine1']
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(24, len(runs))
 
     def test_machine_filter_m2(self):
         filter_args = ['m:machine2']
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(14, len(runs))
 
     def test_machine_filter_m1_and_m2(self):
         filter_args = ['m:machine1', 'm:machine2']
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
-                           self._ui, run_filter=filter_args)
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
+                           self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
         self.assertEqual(14 + 24, len(runs))

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -61,7 +61,7 @@ class ConfiguratorTest(ReBenchTestCase):
 
     def test_get_runs(self):
         exp = self.test_get_experiment()
-        runs = exp.get_runs()
+        runs = exp.runs
         self.assertEqual(2 * 2 * 2, len(runs))
 
     # Support for running a selected experiment

--- a/rebench/tests/denoise_test.py
+++ b/rebench/tests/denoise_test.py
@@ -9,11 +9,11 @@ class DenoiseTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_minimize(self):
-        result = minimize_noise(False, self._ui)
+        result = minimize_noise(False, self.ui)
         self.assertIsInstance(result.succeeded, bool)
         self.assertIsInstance(result.use_nice, bool)
         self.assertIsInstance(result.use_shielding, bool)
 
         # if it was successful, try to restore normal settings
         if result.succeeded:
-            restore_noise(result, False, self._ui)
+            restore_noise(result, False, self.ui)

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -39,21 +39,21 @@ class ExecutorTest(ReBenchTestCase):
     def test_setup_and_run_benchmark(self):
         options = ReBench().shell_options().parse_args(['dummy'])
 
-        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self._ui),
-                           self._ui, options,
+        cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
+                           self.ui, options,
                            None, 'Test', data_file=self._tmp_file)
 
-        ex = Executor(cnf.get_runs(), cnf.do_builds, self._ui)
+        ex = Executor(cnf.get_runs(), cnf.do_builds, self.ui)
         ex.execute()
 
     def test_broken_command_format_with_ValueError(self):
         with self.assertRaises(UIError) as err:
             options = ReBench().shell_options().parse_args(['dummy'])
             cnf = Configurator(load_config(self._path + '/test.conf'),
-                               DataStore(self._ui), self._ui, options,
+                               DataStore(self.ui), self.ui, options,
                                None, 'TestBrokenCommandFormat',
                                data_file=self._tmp_file)
-            ex = Executor(cnf.get_runs(), cnf.do_builds, self._ui)
+            ex = Executor(cnf.get_runs(), cnf.do_builds, self.ui)
             ex.execute()
         self.assertIsInstance(err.exception.source_exception, ValueError)
 
@@ -61,10 +61,10 @@ class ExecutorTest(ReBenchTestCase):
         with self.assertRaises(UIError) as err:
             options = ReBench().shell_options().parse_args(['dummy'])
             cnf = Configurator(load_config(self._path + '/test.conf'),
-                               DataStore(self._ui), self._ui, options,
+                               DataStore(self.ui), self.ui, options,
                                None, 'TestBrokenCommandFormat2',
                                data_file=self._tmp_file)
-            ex = Executor(cnf.get_runs(), cnf.do_builds, self._ui)
+            ex = Executor(cnf.get_runs(), cnf.do_builds, self.ui)
             ex.execute()
             self.assertIsInstance(err.exception.source_exception, TypeError)
 
@@ -77,7 +77,7 @@ class ExecutorTest(ReBenchTestCase):
         for run in runs:
             run.add_persistence(persistence)
 
-        ex = Executor(runs, cnf.do_builds, self._ui)
+        ex = Executor(runs, cnf.do_builds, self.ui)
         ex.execute()
         for run in runs:
             data_points = persistence.get_data_points(run)
@@ -92,13 +92,13 @@ class ExecutorTest(ReBenchTestCase):
 
     def test_basic_execution(self):
         cnf = Configurator(load_config(self._path + '/small.conf'),
-                           DataStore(self._ui), self._ui, None,
+                           DataStore(self.ui), self.ui, None,
                            data_file=self._tmp_file)
         self._basic_execution(cnf)
 
     def test_basic_execution_with_magic_all(self):
         cnf = Configurator(load_config(self._path + '/small.conf'),
-                           DataStore(self._ui), self._ui, None, None,
+                           DataStore(self.ui), self.ui, None, None,
                            'all', data_file=self._tmp_file)
         self._basic_execution(cnf)
 
@@ -108,12 +108,12 @@ class ExecutorTest(ReBenchTestCase):
         cmd_config = option_parser.parse_args(['-R', '-q', 'persistency.conf'])
         self.assertTrue(cmd_config.quick)
 
-        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
-                           self._ui, cmd_config, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self.ui),
+                           self.ui, cmd_config, data_file=self._tmp_file)
         runs = cnf.get_runs()
         self.assertEqual(1, len(runs))
 
-        ex = Executor(runs, False, self._ui)
+        ex = Executor(runs, False, self.ui)
         ex.execute()
         run = list(runs)[0]
 
@@ -126,12 +126,12 @@ class ExecutorTest(ReBenchTestCase):
         self.assertEqual(2, cmd_config.invocations)
         self.assertEqual(2, cmd_config.iterations)
 
-        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
-                           self._ui, cmd_config, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self.ui),
+                           self.ui, cmd_config, data_file=self._tmp_file)
         runs = cnf.get_runs()
         self.assertEqual(1, len(runs))
 
-        ex = Executor(runs, False, self._ui)
+        ex = Executor(runs, False, self.ui)
         ex.execute()
         run = list(runs)[0]
 

--- a/rebench/tests/features/ignore_timeouts_test.py
+++ b/rebench/tests/features/ignore_timeouts_test.py
@@ -31,9 +31,9 @@ class IgnoreTimeoutsTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def _init(self, exp_name):
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/ignore_timeouts.conf'),
-                           ds, self._ui, exp_name=exp_name, data_file=self._tmp_file)
+                           ds, self.ui, exp_name=exp_name, data_file=self._tmp_file)
         ds.load_data(None, False)
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.cmdline())
@@ -57,7 +57,7 @@ class IgnoreTimeoutsTest(ReBenchTestCase):
         _, cnf, runs = self._init('Exec')
         self.assertEqual(1, len(runs))
 
-        ex = Executor(runs, False, self._ui)
+        ex = Executor(runs, False, self.ui)
         ex.execute()
 
         self._assert_runs(cnf, 1, 10, 1)

--- a/rebench/tests/features/issue_110_setup_run_test.py
+++ b/rebench/tests/features/issue_110_setup_run_test.py
@@ -38,7 +38,7 @@ class Issue110Test(ReBenchTestCase):
         self._set_path(__file__)
         self._cleanup_file('build.log')
         self._cleanup_file('rebench.data')
-        self._data_store = DataStore(self._ui)
+        self._data_store = DataStore(self.ui)
         self._cli_options = ReBench().shell_options().parse_args(['-d', '--setup-only', 'dummy'])
 
     def tearDown(self):
@@ -68,12 +68,12 @@ class Issue110Test(ReBenchTestCase):
                              "incorrect num of invocations")
 
     def _execute(self, cnf):
-        ex = Executor(cnf.get_runs(), True, self._ui, build_log=cnf.build_log)
+        ex = Executor(cnf.get_runs(), True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
     def test_complete(self):
         cnf = Configurator(load_config(self._path + '/issue_110.conf'),
-                           self._data_store, self._ui, self._cli_options,
+                           self._data_store, self.ui, self._cli_options,
                            exp_name='Complete', data_file=self._tmp_file)
         self._data_store.load_data(None, False)
 
@@ -106,7 +106,7 @@ class Issue110Test(ReBenchTestCase):
 
     def test_a1(self):
         cnf = Configurator(load_config(self._path + '/issue_110.conf'),
-                           self._data_store, self._ui, self._cli_options,
+                           self._data_store, self.ui, self._cli_options,
                            exp_name='A1', data_file=self._tmp_file)
         self._data_store.load_data(None, False)
 
@@ -121,7 +121,7 @@ class Issue110Test(ReBenchTestCase):
 
     def test_b2(self):
         cnf = Configurator(load_config(self._path + '/issue_110.conf'),
-                           self._data_store, self._ui, self._cli_options,
+                           self._data_store, self.ui, self._cli_options,
                            exp_name='B2', data_file=self._tmp_file)
         self._data_store.load_data(None, False)
 
@@ -136,7 +136,7 @@ class Issue110Test(ReBenchTestCase):
 
     def test_suite_with_build(self):
         cnf = Configurator(load_config(self._path + '/issue_110.conf'),
-                           self._data_store, self._ui, self._cli_options,
+                           self._data_store, self.ui, self._cli_options,
                            exp_name='SuiteWithBuild', data_file=self._tmp_file)
         self._data_store.load_data(None, False)
 

--- a/rebench/tests/features/issue_15_warm_up_support_test.py
+++ b/rebench/tests/features/issue_15_warm_up_support_test.py
@@ -38,8 +38,8 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_run_id_indicates_warm_up_iterations_required(self):
-        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         self.assertGreaterEqual(len(runs), 1)
 
@@ -47,8 +47,8 @@ class Issue15WarmUpSupportTest(ReBenchTestCase):
         self.assertGreater(runs[0].warmup_iterations, 0)
 
     def test_warm_up_results_should_be_ignored(self):
-        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_15.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         self.assertEqual(runs[0].get_number_of_data_points(), 0)
         self.assertEqual(runs[0].warmup_iterations, 13)

--- a/rebench/tests/features/issue_16_multiple_data_points_test.py
+++ b/rebench/tests/features/issue_16_multiple_data_points_test.py
@@ -36,14 +36,14 @@ class Issue16MultipleDataPointsTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def _records_data_points(self, exp_name, num_data_points):
-        cnf = Configurator(load_config(self._path + '/issue_16.conf'), DataStore(self._ui),
-                           self._ui, exp_name=exp_name,
+        cnf = Configurator(load_config(self._path + '/issue_16.conf'), DataStore(self.ui),
+                           self.ui, exp_name=exp_name,
                            data_file=self._tmp_file)
         runs = cnf.get_runs()
         persistence = TestPersistence()
         for run in runs:
             run.add_persistence(persistence)
-        ex = Executor(cnf.get_runs(), False, self._ui)
+        ex = Executor(cnf.get_runs(), False, self.ui)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_19_one_data_point_test.py
+++ b/rebench/tests/features/issue_19_one_data_point_test.py
@@ -79,13 +79,13 @@ class OneMeasurementAtATime(Issue19OneDataPointAtATime):
         self._run_count[run_id] = self._run_count.get(run_id, 0) + 1
 
     def test_one_measurement_at_a_time_and_correct_number_of_data_points(self):
-        cnf = Configurator(load_config(self._path + '/issue_19.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_19.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file)
         reporter = TestReporter(self)
         for run in cnf.get_runs():
             run.add_reporter(reporter)
 
-        ex = Executor(cnf.get_runs(), False, self._ui, False, False,
+        ex = Executor(cnf.get_runs(), False, self.ui, False, False,
                       RoundRobinScheduler)
         ex.execute()
 

--- a/rebench/tests/features/issue_31_multivariate_data_points_test.py
+++ b/rebench/tests/features/issue_31_multivariate_data_points_test.py
@@ -36,15 +36,15 @@ class Issue31MultivariateDataPointsTest(ReBenchTestCase):
         self._set_path(__file__)
 
     def _records_data_points(self, exp_name, num_data_points):
-        cnf = Configurator(load_config(self._path + '/issue_31.conf'), DataStore(self._ui),
-                           self._ui, exp_name=exp_name,
+        cnf = Configurator(load_config(self._path + '/issue_31.conf'), DataStore(self.ui),
+                           self.ui, exp_name=exp_name,
                            data_file=self._tmp_file)
         runs = cnf.get_runs()
         persistence = TestPersistence()
         for run in runs:
             run.add_persistence(persistence)
 
-        ex = Executor(runs, False, self._ui)
+        ex = Executor(runs, False, self.ui)
         ex.execute()
         self.assertEqual(1, len(cnf.get_runs()))
         run = next(iter(cnf.get_runs()))

--- a/rebench/tests/features/issue_34_accept_faulty_runs_test.py
+++ b/rebench/tests/features/issue_34_accept_faulty_runs_test.py
@@ -31,12 +31,12 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_faulty_runs_rejected_without_switch(self):
-        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, self._ui, False)
+        ex = Executor(runs, False, self.ui, False)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].benchmark.name)
@@ -57,12 +57,12 @@ class Issue34AcceptFaultyRuns(ReBenchTestCase):
         self.assertFalse(options.include_faulty)
 
     def test_faulty_runs_accepted_with_switch(self):
-        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/issue_34.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, self._ui, True)
+        ex = Executor(runs, False, self.ui, True)
         ex.execute()
 
         self.assertEqual("error-code", runs[0].benchmark.name)

--- a/rebench/tests/features/issue_57_binary_on_path_test.py
+++ b/rebench/tests/features/issue_57_binary_on_path_test.py
@@ -30,13 +30,13 @@ class Issue57ExecutableOnPath(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_sleep_gives_results(self):
-        store = DataStore(self._ui)
+        store = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/issue_57.conf'), store,
-                           self._ui, data_file=self._tmp_file)
+                           self.ui, data_file=self._tmp_file)
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, False, self._ui, False)
+        ex = Executor(runs, False, self.ui, False)
         ex.execute()
 
         self.assertEqual("Bench1", runs[0].benchmark.name)

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -46,12 +46,12 @@ class Issue58BuildExecutor(ReBenchTestCase):
             return log_file.read()
 
     def test_build_executor_simple_cmd(self):
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file, exp_name='A')
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file, exp_name='A')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, True, self._ui, build_log=cnf.build_log)
+        ex = Executor(runs, True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -62,12 +62,12 @@ class Issue58BuildExecutor(ReBenchTestCase):
             os.remove(self._path + '/vm_58a.sh')
 
     def test_build_executor_cmd_list(self):
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file, exp_name='B')
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file, exp_name='B')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, True, self._ui, build_log=cnf.build_log)
+        ex = Executor(runs, True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -86,13 +86,13 @@ class Issue58BuildExecutor(ReBenchTestCase):
             "E:BashA|STD:standard\nE:BashA|ERR:error\n", log)
 
     def test_broken_build_prevents_experiments(self):
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file,
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file,
                            exp_name='C')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, True, self._ui, build_log=cnf.build_log)
+        ex = Executor(runs, True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -108,13 +108,13 @@ class Issue58BuildExecutor(ReBenchTestCase):
             "E:BashC|STD:standard\nE:BashC|ERR:error\n", log)
 
     def test_build_is_run_only_once_for_same_command(self):
-        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file,
+        cnf = Configurator(load_config(self._path + '/issue_58.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file,
                            exp_name='AandAA')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, True, self._ui, build_log=cnf.build_log)
+        ex = Executor(runs, True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
         os.remove(self._path + '/vm_58a.sh')

--- a/rebench/tests/features/issue_59_build_suite_test.py
+++ b/rebench/tests/features/issue_59_build_suite_test.py
@@ -33,12 +33,12 @@ class Issue59BuildSuite(ReBenchTestCase):
         self._set_path(__file__)
 
     def test_build_suite1(self):
-        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file, exp_name='A')
+        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file, exp_name='A')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, True, self._ui, build_log=cnf.build_log)
+        ex = Executor(runs, True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
         try:
@@ -49,12 +49,12 @@ class Issue59BuildSuite(ReBenchTestCase):
             os.remove(self._path + '/issue_59_cnt')
 
     def test_build_suite_same_command_executed_once_only(self):
-        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file, exp_name='Test')
+        cnf = Configurator(load_config(self._path + '/issue_59.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file, exp_name='Test')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, True, self._ui, build_log=cnf.build_log)
+        ex = Executor(runs, True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
         try:

--- a/rebench/tests/features/issue_81_unicode_test.py
+++ b/rebench/tests/features/issue_81_unicode_test.py
@@ -37,12 +37,12 @@ class Issue81UnicodeSuite(ReBenchTestCase):
             os.remove(self._path + '/build.log')
 
     def test_building(self):
-        cnf = Configurator(load_config(self._path + '/issue_81.conf'), DataStore(self._ui),
-                           self._ui, data_file=self._tmp_file, exp_name='Test')
+        cnf = Configurator(load_config(self._path + '/issue_81.conf'), DataStore(self.ui),
+                           self.ui, data_file=self._tmp_file, exp_name='Test')
         runs = list(cnf.get_runs())
         runs = sorted(runs, key=lambda e: e.benchmark.name)
 
-        ex = Executor(runs, True, self._ui, build_log=cnf.build_log)
+        ex = Executor(runs, True, self.ui, build_log=cnf.build_log)
         ex.execute()
 
         self.assertEqual("Bench1", runs[0].benchmark.name)

--- a/rebench/tests/mock_http_server.py
+++ b/rebench/tests/mock_http_server.py
@@ -54,5 +54,5 @@ class MockHTTPServer(object):
         self._server.shutdown()
 
     def get_number_of_put_requests(self):
-        global _put_requests  # pylint: disable=global-statement
+        global _put_requests  # pylint: disable=global-statement,global-variable-not-assigned
         return _put_requests

--- a/rebench/tests/model/runs_config_test.py
+++ b/rebench/tests/model/runs_config_test.py
@@ -29,14 +29,14 @@ class RunsConfigTestCase(ReBenchTestCase):
 
     def setUp(self):
         super(RunsConfigTestCase, self).setUp()
-        self._cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self._ui),
-                                 self._ui, None,
+        self._cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),
+                                 self.ui, None,
                                  data_file=self._tmp_file)
         runs = self._cnf.get_runs()
         self._run = list(runs)[0]
 
     def test_termination_check_basic(self):
-        check = TerminationCheck(self._run, self._ui)
+        check = TerminationCheck(self._run, self.ui)
         self.assertFalse(check.should_terminate(0, None))
 
         # start 9 times, but expect to be done only after 10
@@ -52,13 +52,13 @@ class RunsConfigTestCase(ReBenchTestCase):
         self.assertTrue(check.should_terminate(0, None))
 
     def test_terminate_not_determine_by_number_of_data_points(self):
-        check = TerminationCheck(self._run, self._ui)
+        check = TerminationCheck(self._run, self.ui)
         self.assertFalse(check.should_terminate(0, None))
         self.assertFalse(check.should_terminate(10, None))
         self.assertFalse(check.should_terminate(10000, None))
 
     def test_consecutive_fails(self):
-        check = TerminationCheck(self._run, self._ui)
+        check = TerminationCheck(self._run, self.ui)
         self.assertFalse(check.should_terminate(0, None))
 
         for _ in range(0, 2):
@@ -69,7 +69,7 @@ class RunsConfigTestCase(ReBenchTestCase):
         self.assertTrue(check.should_terminate(0, None))
 
     def test_too_many_fails(self):
-        check = TerminationCheck(self._run, self._ui)
+        check = TerminationCheck(self._run, self.ui)
         self.assertFalse(check.should_terminate(0, None))
 
         for _ in range(0, 6):

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -36,7 +36,7 @@ from ..rebench import ReBench
 class PersistencyTest(ReBenchTestCase):
 
     def test_de_serialization(self):
-        data_store = DataStore(self._ui)
+        data_store = DataStore(self.ui)
         executor = ExecutorConf("MyVM", '', '',
                                 None, None, None, None, None)
         suite = BenchmarkSuite("MySuite", executor, '', '', None, None,
@@ -61,56 +61,56 @@ class PersistencyTest(ReBenchTestCase):
 
     def test_iteration_invocation_semantics(self):
         # Executes first time
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/persistency.conf'),
-                           ds, self._ui, data_file=self._tmp_file)
+                           ds, self.ui, data_file=self._tmp_file)
         ds.load_data(None, False)
 
         self._assert_runs(cnf, 1, 0, 0)
 
-        ex = Executor(cnf.get_runs(), False, self._ui)
+        ex = Executor(cnf.get_runs(), False, self.ui)
         ex.execute()
 
         self._assert_runs(cnf, 1, 10, 10)
 
         # Execute a second time, should not add any data points,
         # because goal is already reached
-        ds2 = DataStore(self._ui)
+        ds2 = DataStore(self.ui)
         cnf2 = Configurator(load_config(self._path + '/persistency.conf'),
-                            ds2, self._ui, data_file=self._tmp_file)
+                            ds2, self.ui, data_file=self._tmp_file)
         ds2.load_data(None, False)
 
         self._assert_runs(cnf2, 1, 10, 10)
 
-        ex2 = Executor(cnf2.get_runs(), False, self._ui)
+        ex2 = Executor(cnf2.get_runs(), False, self.ui)
         ex2.execute()
 
         self._assert_runs(cnf2, 1, 10, 10)
 
     def test_data_discarding(self):
         # Executes first time
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
         cnf = Configurator(load_config(self._path + '/persistency.conf'),
-                           ds, self._ui, data_file=self._tmp_file)
+                           ds, self.ui, data_file=self._tmp_file)
         ds.load_data(None, False)
 
         self._assert_runs(cnf, 1, 0, 0)
 
-        ex = Executor(cnf.get_runs(), False, self._ui)
+        ex = Executor(cnf.get_runs(), False, self.ui)
         ex.execute()
 
         self._assert_runs(cnf, 1, 10, 10)
 
         # Execute a second time, this time, discard the data first, and then rerun
-        ds2 = DataStore(self._ui)
+        ds2 = DataStore(self.ui)
         cnf2 = Configurator(load_config(self._path + '/persistency.conf'),
-                            ds2, self._ui, data_file=self._tmp_file)
+                            ds2, self.ui, data_file=self._tmp_file)
         run2 = cnf2.get_runs()
         ds2.load_data(run2, True)
 
         self._assert_runs(cnf2, 1, 0, 0)
 
-        ex2 = Executor(run2, False, self._ui)
+        ex2 = Executor(run2, False, self.ui)
         ex2.execute()
 
         self._assert_runs(cnf2, 1, 10, 10)
@@ -143,7 +143,7 @@ class PersistencyTest(ReBenchTestCase):
         port = server.get_free_port()
 
         server.start()
-        ds = DataStore(self._ui)
+        ds = DataStore(self.ui)
 
         raw_config = load_config(self._path + '/persistency.conf')
         del raw_config['reporting']['codespeed']
@@ -154,12 +154,12 @@ class PersistencyTest(ReBenchTestCase):
             'send_to_rebench_db': True,
             'record_all': True}
 
-        cnf = Configurator(raw_config, ds, self._ui, cmd_config, data_file=self._tmp_file)
+        cnf = Configurator(raw_config, ds, self.ui, cmd_config, data_file=self._tmp_file)
         ds.load_data(None, False)
 
         self._assert_runs(cnf, 1, 0, 0)
 
-        ex = Executor(cnf.get_runs(), False, self._ui)
+        ex = Executor(cnf.get_runs(), False, self.ui)
         ex.execute()
 
         run = list(cnf.get_runs())[0]

--- a/rebench/tests/rebench_test_case.py
+++ b/rebench/tests/rebench_test_case.py
@@ -42,7 +42,7 @@ class ReBenchTestCase(TestCase):
         self._tmp_file = mkstemp()[1]  # just use the file name
 
         self._sys_exit = sys.exit  # make sure that we restore sys.exit
-        self._ui = TestDummyUI()
+        self.ui = TestDummyUI()
 
     def tearDown(self):
         os.remove(self._tmp_file)

--- a/rebench/tests/reporter_test.py
+++ b/rebench/tests/reporter_test.py
@@ -18,12 +18,12 @@ class ReporterTest(ReBenchTestCase):
         option_parser = ReBench().shell_options()
         cmd_config = option_parser.parse_args([
             '--commit-id=id', '--environment=test', '--project=test', 'persistency.conf'])
-        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self._ui),
-                           self._ui, cmd_config, data_file=self._tmp_file)
+        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self.ui),
+                           self.ui, cmd_config, data_file=self._tmp_file)
 
         self._runs = cnf.get_runs()  # pylint: disable=attribute-defined-outside-init
 
-        ex = Executor(self._runs, False, self._ui)
+        ex = Executor(self._runs, False, self.ui)
         ex.execute()
         reporter = cnf.reporting.codespeed_reporter
         reporter.report_job_completed(self._runs)


### PR DESCRIPTION
Don't use `@property` if not absolutely needed.

This avoids quite a bit of code, and the use of direct fields seems more pythonic.