### PR TITLE
Add --execution-plan to print commands a benchmark run would execute

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,11 +145,13 @@ For this purpose we use *schedulers* to determine the execution order.
 
 To check whether a configuration is correct, it can be useful to avoid
 execution altogether. For such *testing* or *dry run*, we have the following
-option:
+options:
 
 ```text
 -E, --no-execution    Disables execution. It allows to verify the
                       configuration file and other parameters.
+-p, --execution-plan  Print execution plan. This outputs all executions
+                      that would be performed, without executing them.
 ```  
 
 #### Continuous Performance Tracking

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -248,6 +248,8 @@ Argument:
                                         args.build_log, exp_filter)
         except ConfigurationError as exc:
             raise UIError(exc.message + "\n", exc)
+        except ValueError as exc:
+            raise UIError(exc.args[0] + "\n", exc)
 
         if args.report_completion:
             return self._report_completion()

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -124,6 +124,11 @@ Argument:
             default=False,
             help='Disables execution.'
                  ' It allows to verify the configuration file and other parameters.')
+        execution.add_argument(
+            '-p', '--execution-plan', action='store_true', dest='execution_plan',
+            default=False,
+            help='Print execution plan.'
+                 ' This outputs all executions that would be performed, without executing them.')
 
         data = parser.add_argument_group(
             'Data and Reporting',
@@ -250,8 +255,11 @@ Argument:
         runs = self._config.get_runs()
 
         denoise_result = None
+        show_denoise_warnings = not (self._config.artifact_review
+                                     or self._config.options.execution_plan)
+
         try:
-            denoise_result = minimize_noise(not self._config.artifact_review, self.ui)
+            denoise_result = minimize_noise(show_denoise_warnings, self.ui)
             init_environment(denoise_result, self.ui)
 
             data_store.load_data(runs, self._config.options.do_rerun)
@@ -261,7 +269,7 @@ Argument:
 
             return self.execute_experiment(runs, use_nice, use_shielding)
         finally:
-            restore_noise(denoise_result, not self._config.artifact_review, self.ui)
+            restore_noise(denoise_result, show_denoise_warnings, self.ui)
 
     def execute_experiment(self, runs, use_nice, use_shielding):
         self.ui.verbose_output_info("Execute experiment: " + self._config.experiment_name + "\n")
@@ -276,7 +284,7 @@ Argument:
                             self._config.options.debug,
                             scheduler_class,
                             self._config.build_log, self._config.artifact_review,
-                            use_nice, use_shielding)
+                            use_nice, use_shielding, self._config.options.execution_plan)
 
         if self._config.options.no_execution:
             return True

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -125,7 +125,7 @@ def run(args, cwd=None, shell=False, kill_tree=True, timeout=-1,
     Run a command with a timeout after which it will be forcibly
     killed.
     """
-    executable_name = args.split(' ')[0]
+    executable_name = args.split(' ', 1)[0]
 
     thread = _SubprocessThread(executable_name, args, shell, cwd, verbose, stdout,
                                stderr, stdin_input)

--- a/rebench/tests/mock_http_server.py
+++ b/rebench/tests/mock_http_server.py
@@ -44,6 +44,9 @@ class MockHTTPServer(object):
         return port
 
     def start(self):
+        global _put_requests  # pylint: disable=global-statement
+        _put_requests = 0
+
         self._server = HTTPServer(('localhost', self._port), _RequestHandler)
 
         self._thread = Thread(target=self._server.serve_forever)
@@ -53,6 +56,9 @@ class MockHTTPServer(object):
     def shutdown(self):
         self._server.shutdown()
 
-    def get_number_of_put_requests(self):
-        global _put_requests  # pylint: disable=global-statement,global-variable-not-assigned
-        return _put_requests
+    @staticmethod
+    def get_number_of_put_requests():
+        global _put_requests  # pylint: disable=global-statement
+        result = _put_requests
+        _put_requests = 0
+        return result


### PR DESCRIPTION
This PR adds the --execution-plan option as a way to have an idea of what's going to happen when running ReBench.

This is something I wanted to have for a long time, perhaps to run benchmarks manually, or simply to see what needs to be done to complete the current data set.

This PR also does some more minor maintenance.