### PR TITLE
Move to PyTest for running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         yaml-parser: ['', 'ruamel']
         include:
           - python-version: 2.7
-            coverage: "--with-coverage --cover-package=rebench"
+            coverage: "--cov=rebench"
         exclude:
           - python-version: 2.7
             yaml-parser: ruamel
@@ -31,15 +31,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: Install nose
-        run: pip install nose
+      - name: Install PyTest
+        run: pip install pytest
 
       - name: Install ruamel.yaml
         run: pip install ruamel.yaml
         if: matrix.yaml-parser == 'ruamel'
 
       - name: Install coverage and coveralls
-        run: pip install coverage coveralls
+        run: pip install pytest-cov coveralls
         if: matrix.coverage
 
       - name: Install ReBench dependencies
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run tests
         run: |
-          nosetests ${{ matrix.coverage }}
+          pytest ${{ matrix.coverage }}
           (cd rebench && rebench ../rebench.conf e:TestRunner2)
 
       - name: Install and run pylint

--- a/rebench/interop/test_adapter.py
+++ b/rebench/interop/test_adapter.py
@@ -23,6 +23,7 @@ from ..model.measurement import Measurement
 
 
 class TestAdapter(GaugeAdapter):
+    __test__ = False # This is not a test class
 
     test_data = [45872, 45871, 45868, 45869, 45873,
                  45865, 45869, 45874, 45863, 45873,

--- a/rebench/interop/test_vm_adapter.py
+++ b/rebench/interop/test_vm_adapter.py
@@ -29,6 +29,7 @@ class TestExecutorAdapter(GaugeAdapter):
        in test/test.conf
     """
 
+    __test__ = False  # This is not a test class
     re_time = re.compile(r"RESULT-(\w+):\s*(\d+\.\d+)")
 
     def __init__(self, include_faulty, executor):

--- a/rebench/tests/features/issue_19_one_data_point_test.py
+++ b/rebench/tests/features/issue_19_one_data_point_test.py
@@ -27,6 +27,7 @@ from ..rebench_test_case import ReBenchTestCase
 
 
 class TestReporter(Reporter):
+    __test__ = False  # This is not a test class
 
     def __init__(self, test_case):
         super(TestReporter, self).__init__()

--- a/rebench/tests/persistence.py
+++ b/rebench/tests/persistence.py
@@ -1,4 +1,5 @@
 class TestPersistence(object):
+    __test__ = False  # This is not a test class
 
     def __init__(self):
         self._data_points = []


### PR DESCRIPTION
nose does not seem to be maintained any longer and it fails on Python 3.10.
Using to PyTest seems the best, and low effort option.
It "just works" it seems.