### PR TITLE
Give the build commands the env of run_id

### DIFF
--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -355,7 +355,7 @@ class Executor(object):
 
         try:
             return_code, stdout_result, stderr_result = subprocess_timeout.run(
-                '/bin/sh', {}, path, False, True,
+                '/bin/sh', run_id.env, path, False, True,
                 stdin_input=str.encode(script),
                 keep_alive_output=_keep_alive)
         except OSError as err:

--- a/rebench/tests/features/issue_42_test.py
+++ b/rebench/tests/features/issue_42_test.py
@@ -90,7 +90,7 @@ class Issue42SupportForEnvironmentVariables(ReBenchTestCase):
         self.assertEqual("no-env", runs[0].benchmark.name)
         self.assertFalse(runs[0].is_failed)
 
-    def test_build_with_env_but_build_env_should_be_empty(self):
+    def test_build_with_env_should_see_a_run_env(self):
         cnf = Configurator(load_config(self._path + '/issue_42.conf'), DataStore(self.ui),
                            self.ui, data_file=self._tmp_file, exp_name='build-with-env')
         runs = list(cnf.get_runs())
@@ -103,9 +103,20 @@ class Issue42SupportForEnvironmentVariables(ReBenchTestCase):
         parts = log.split('|', 2)
         self.assertEqual("E:exe-with-build-and-env", parts[0])
 
-        self._assert_empty_standard_env(parts[1])
+        env_parts = parts[1].split(':')
+        env = sorted(env_parts[1].split('\n'))
+        self.assertEqual('', env[0])
+        self.assertTrue(env[1].startswith("PWD="))
+        if env[2].startswith("SHLVL"):  # Platform differences
+            self.assertEqual("SHLVL=1", env[2])
+            self.assertEqual("VAR1=test", env[3])
+            self.assertEqual("VAR3=another test", env[4])
+            self.assertTrue(env[5].startswith("_="))
+        else:
+            self.assertEqual("VAR1=test", env[2])
+            self.assertEqual("VAR3=another test", env[3])
 
-    def test_build_without_env_and_build_env_should_be_empty(self):
+    def test_build_and_run_without_env_should_have_empty_env(self):
         cnf = Configurator(load_config(self._path + '/issue_42.conf'), DataStore(self.ui),
                            self.ui, data_file=self._tmp_file, exp_name='build-without-env')
         runs = list(cnf.get_runs())


### PR DESCRIPTION
The build scripts may need some environment, which may have been defined for the executor or suite.
The current use case is as simple as having a `Makefile` that needs to be able to access utils on the standard PATH.

The current solution takes the environment from the `run_id`, and there’s a risk that this env might be contaminated/be specific to the run. Though, for now, it's good enough. And if it turns out to be problematic, we can fix it later.

@tolauwae this is for you. It should fix your immediate issue of not being able to specify any environment.

This PR is an extension  of #174.