### PR TITLE
Extract branch name

### DIFF
--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -33,6 +33,14 @@ def _exec(cmd):
 _source = None
 
 
+def extract_base(branch_or_tag):
+    # in local working copies things may look like HEAD -> branch, remote/branch, otherBranch
+    if ',' in branch_or_tag:
+        branch_or_tag = branch_or_tag.split(',')[0]
+
+    return branch_or_tag.replace('HEAD -> ', '')
+
+
 def determine_source_details(configurator):
     global _source  # pylint: disable=global-statement
     if _source:
@@ -67,7 +75,7 @@ def determine_source_details(configurator):
             netloc="{}@{}".format(parsed.username, parsed.hostname))
     result['repoURL'] = _encode_str(parsed.geturl())
 
-    result['branchOrTag'] = _exec(git_cmd + ['show', '-s', '--format=%D', 'HEAD'])
+    result['branchOrTag'] = extract_base(_exec(git_cmd + ['show', '-s', '--format=%D', 'HEAD']))
     result['commitId'] = _exec(git_cmd + ['rev-parse', 'HEAD'])
     result['commitMsg'] = _exec(git_cmd + ['show', '-s', '--format=%B', 'HEAD'])
     result['authorName'] = _exec(git_cmd + ['show', '-s', '--format=%aN', 'HEAD'])

--- a/rebench/tests/environment_test.py
+++ b/rebench/tests/environment_test.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
 from ..denoise import DenoiseResult
-from ..environment import determine_source_details, determine_environment, init_environment
+from ..environment import determine_source_details, determine_environment,\
+    init_environment, extract_base
 from ..ui import TestDummyUI
 
 
@@ -34,3 +35,12 @@ class ReBenchTestCase(TestCase):
         self.assertGreater(env['clockSpeed'], 0)
 
         self.assertGreaterEqual(len(env['software']), 3)
+
+    def test_extract_base(self):
+        self.assertEqual('', extract_base(''))
+        self.assertEqual('branch', extract_base('branch'))
+        self.assertEqual('tag/tag', extract_base('tag/tag'))
+        self.assertEqual('branch', extract_base('HEAD -> branch'))
+        self.assertEqual('branch', extract_base('HEAD -> branch, otherBranch'))
+        self.assertEqual('develop', extract_base(
+            'HEAD -> develop, origin/master, origin/develop, origin/HEAD, master'))


### PR DESCRIPTION
In local checkouts, the branch name is a little more complicated to extract since git tells us about related branches/tags and when the HEAD is different from the branch.

Closes #193.