### PR TITLE
Make timeout and resulting child termination more robust and handle SIGTERM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '2.7', '3.7', '3.9', 'pypy3' ]
+        python-version: [ '2.7', '3.7', '3.9', 'pypy3.9' ]
         yaml-parser: ['', 'ruamel']
         include:
           - python-version: 2.7
@@ -23,10 +23,10 @@ jobs:
     name: Python ${{ matrix.python-version }} ${{ matrix.yaml-parser }}
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -79,9 +79,9 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends time
-      
+
       - name: Checkout ReBench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PyTest
         run: pip install pytest

--- a/rebench/__init__.py
+++ b/rebench/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.dev1"
+__version__ = "1.1.dev2"

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -12,7 +12,8 @@ from multiprocessing import Pool
 from cpuinfo import get_cpu_info
 
 from .ui import escape_braces
-from .subprocess_with_timeout import output_as_str, kill_process
+from .subprocess_with_timeout import output_as_str  # pylint: disable=cyclic-import
+from .subprocess_kill import kill_process  # pylint: disable=cyclic-import
 
 try:
     from . import __version__ as rebench_version

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -476,7 +476,9 @@ class Executor(object):
                 cmdline, env=run_id.env, cwd=run_id.location, stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT, shell=True, verbose=self.debug,
                 timeout=run_id.max_invocation_time,
-                keep_alive_output=_keep_alive)
+                keep_alive_output=_keep_alive,
+                uses_sudo=self.use_denoise
+            )
         except OSError as err:
             run_id.fail_immediately()
             if err.errno == 2:

--- a/rebench/subprocess_kill.py
+++ b/rebench/subprocess_kill.py
@@ -1,0 +1,71 @@
+from os         import kill
+from signal     import SIGKILL
+from subprocess import PIPE, Popen
+
+IS_PY3 = None
+
+try:
+    _ = ProcessLookupError
+    IS_PY3 = True
+except NameError:
+    IS_PY3 = False
+
+# Indicate timeout with standard exit code
+E_TIMEOUT = -9
+
+
+def _kill_py2(proc_id, uses_sudo):
+    if uses_sudo:
+        from .denoise import deliver_kill_signal  # pylint: disable=import-outside-toplevel
+
+        deliver_kill_signal(proc_id)
+        return
+
+    try:
+        kill(proc_id, SIGKILL)
+    except IOError:
+        # there's a race condition, the process may have already terminated on its own
+        # so let's simply ignore it
+        pass
+
+
+def _kill_py3(proc_id, uses_sudo):
+    if uses_sudo:
+        from .denoise import deliver_kill_signal  # pylint: disable=import-outside-toplevel
+
+        deliver_kill_signal(proc_id)
+        return
+
+    try:
+        kill(proc_id, SIGKILL)
+    except ProcessLookupError:  # pylint: disable=undefined-variable
+        # there's a race condition, the process may have already terminated on its own
+        # so let's simply ignore it
+        pass
+
+
+def kill_process(pid, recursively, thread, uses_sudo):
+    pids = [pid]
+    if recursively:
+        pids.extend(_get_process_children(pid))
+
+    for proc_id in pids:
+        if IS_PY3:
+            _kill_py3(proc_id, uses_sudo)
+        else:
+            _kill_py2(proc_id, uses_sudo)
+
+    if thread:
+        thread.join()
+        return E_TIMEOUT, thread.stdout_result, thread.stderr_result
+    return E_TIMEOUT, None, None
+
+
+def _get_process_children(pid):
+    # pylint: disable-next=consider-using-with
+    proc = Popen('pgrep -P %d' % pid, shell=True, stdout=PIPE, stderr=PIPE)
+    stdout, _stderr = proc.communicate()
+    result = [int(p) for p in stdout.split()]
+    for child in result[:]:
+        result.extend(_get_process_children(child))
+    return result


### PR DESCRIPTION
When using `denoise`, make sure we deliver the signal directly and avoid permission issues.

Also register a signal handler for `SIGTERM`, which is hopefully what GitLab is sending.

This hopefully addresses #154.

@OctaveLarose does this look good to you?