### PR TITLE
Document gauge adapter expected output formats

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,17 +15,69 @@ ReBench currently provides builtin support for the following benchmark harnesses
 - `ValidationLog`: the format used by [SOMns](https://github.com/smarr/SOMns)'s ImpactHarness
 - `Time`: a harness that uses `/usr/bin/time` automatically
 
+### `PlainSecondsLog`
+
+This adapter attempts to read every line of program output as a millisecond
+measurement. Lines which cannot be parsed as floats are skipped, e.g. `1.0` and
+`  2 ` are valid, while `out: 1` and `1, 2, 3` are not and would be ignored.
+
+Example output from a harness or benchmark:
+
+```
+342
+543
+100.23
+54.12
+```
+
+Implementation Notes:
+
+ - Python's `float()` function is used for parsing
+
 ### `ReBenchLog`
+
+The ReBenchLog parser is the most commonly used and has most features.
+It supports parsing of microseconds and milliseconds values.
+Though, internally, ReBench stores all values as milliseconds using Python's
+floating point numbers, i.e., as 64-bit values.
+
+Furthermore, it supports capturing other criteria in addition to the overall
+run time, which can be useful to measure the time of subtasks or metrics such
+as memory use. When other criteria a provided, the `total` time is expected to
+be the last in the output, concluding the overall data point.
+
 The approximate format that `ReBenchLog` parses is as follows:
 
     optional_prefix benchmark_name: iterations=123 runtime: 1000[ms|us]
 
-(Note that measurements may be normalized to milliseconds.)
+Example output from a harness or benchmark, each a different value for total
+run time:
 
-### `PlainSecondsLog`
-This adapter attempts to read every line of program output as a millisecond
-measurement. Lines which cannot be parsed as floats are skipped, e.g. `1.0` and
-`  2 ` are valid, while `out: 1` and `1, 2, 3` are not and would be ignored.
+```
+Dispatch: iterations=1 runtime: 557ms
+LanguageFeatures.Dispatch: iterations=1 runtime: 309557us
+LanguageFeatures.Dispatch total: iterations=2342 runtime: 557ms
+```
+
+Example output with additional criteria, that indicate memory use:
+
+```
+Savina.Chameneos: trace size:    3903398byte
+Savina.Chameneos: external data: 40byte
+Savina.Chameneos: iterations=1 runtime: 64208us
+Savina.Chameneos: trace size:    3903414byte
+Savina.Chameneos: external data: 40byte
+Savina.Chameneos: iterations=1 runtime: 48581us
+```
+
+Implementation Notes:
+
+ - For parsing of the total run time, the following regular expression is used:
+   `r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: ([0-9]+)([mu])s")`
+
+ - For arbitrary criteria, which may also be used for the `total` criteria,
+   the following regular expression should match
+   `r"^(?:.*: )?([^\s]+): ([^:]{1,30}):\s*([0-9]+)([a-zA-Z]+)")`
 
 ## Supporting other Benchmark Harnesses
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -8,11 +8,16 @@ and store it in its own data files for later processing.
 
 ReBench currently provides builtin support for the following benchmark harnesses:
 
-- `JMH`: [JMH](http://openjdk.java.net/projects/code-tools/jmh/), Java's mircobenchmark harness
+- `JMH`: [JMH](http://openjdk.java.net/projects/code-tools/jmh/), Java's microbenchmark harness
 - `PlainSecondsLog`: a plain seconds log, i.e., a floating point number per line
 - `ReBenchLog`: the ReBench log format, which indicates benchmark name and run time in milliseconds or microseconds
 - `SavinaLog`: the harness of the [Savina](https://github.com/shamsimam/savina) benchmarks
 - `Time`: a harness that uses `/usr/bin/time` automatically
+
+### `PlainSecondsLog`
+This adapter attempts to read every line of program output as a millisecond
+measurement. Lines which cannot be parsed as floats are skipped, e.g. `1.0` and
+`  2 ` are valid, while `out: 1` and `1, 2, 3` are not and would be ignored.
 
 ## Supporting other Benchmark Harnesses
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -12,7 +12,15 @@ ReBench currently provides builtin support for the following benchmark harnesses
 - `PlainSecondsLog`: a plain seconds log, i.e., a floating point number per line
 - `ReBenchLog`: the ReBench log format, which indicates benchmark name and run time in milliseconds or microseconds
 - `SavinaLog`: the harness of the [Savina](https://github.com/shamsimam/savina) benchmarks
+- `ValidationLog`: the format used by [SOMns](https://github.com/smarr/SOMns)'s ImpactHarness
 - `Time`: a harness that uses `/usr/bin/time` automatically
+
+### `ReBenchLog`
+The approximate format that `ReBenchLog` parses is as follows:
+
+    optional_prefix benchmark_name: iterations=123 runtime: 1000[ms|us]
+
+(Note that measurements may be normalized to milliseconds.)
 
 ### `PlainSecondsLog`
 This adapter attempts to read every line of program output as a millisecond


### PR DESCRIPTION
Related to #186 . Some gauge adapters are intended to be plug-and-play, supporting common benchmark formats. `PlainSecondsLog` and `ReBenchLog` are custom and deserve some detail on the output format they expect.