### PR TITLE
fix RebenchLog case; error on missing gauge adapter

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -407,6 +407,9 @@ all of them.
 Name of the parser that interprets the output of the benchmark harness.
 For a list of supported options see the list of [extensions](extensions.md#available-harness-support).
 
+Note that case matters -- `ReBenchLog` (with a capital 'B') will fail to be
+found on systems with case-sensitive paths (Linux).
+
 This key is mandatory.
 
 Example:
@@ -414,7 +417,7 @@ Example:
 ```yaml
 benchmark_suites:
   ExampleSuite:
-    gauge_adapter: ReBenchLog
+    gauge_adapter: RebenchLog
 ```
 
 ---

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -11,10 +11,13 @@ ReBench currently provides builtin support for the following benchmark harnesses
 
 - `JMH`: [JMH](http://openjdk.java.net/projects/code-tools/jmh/), Java's microbenchmark harness
 - `PlainSecondsLog`: a plain seconds log, i.e., a floating point number per line
-- `ReBenchLog`: the ReBench log format, which indicates benchmark name and run time in milliseconds or microseconds
+- `RebenchLog`: the ReBench log format, which indicates benchmark name and run time in milliseconds or microseconds
 - `SavinaLog`: the harness of the [Savina](https://github.com/shamsimam/savina) benchmarks
 - `ValidationLog`: the format used by [SOMns](https://github.com/smarr/SOMns)'s ImpactHarness
 - `Time`: a harness that uses `/usr/bin/time` automatically
+
+Note that case matters -- `ReBenchLog` (with a capital 'B') may fail to be
+found.
 
 ### `PlainSecondsLog`
 
@@ -35,9 +38,9 @@ Implementation Notes:
 
  - Python's `float()` function is used for parsing
 
-### `ReBenchLog`
+### `RebenchLog`
 
-The ReBenchLog parser is the most commonly used and has most features.
+The `RebenchLog` parser is the most commonly used and has most features.
 It supports parsing of microseconds and milliseconds values.
 Though, internally, ReBench stores all values as milliseconds using Python's
 floating point numbers, i.e., as 64-bit values.
@@ -47,7 +50,7 @@ run time, which can be useful to measure the time of subtasks or metrics such
 as memory use. When other criteria a provided, the `total` time is expected to
 be the last in the output, concluding the overall data point.
 
-The approximate format that `ReBenchLog` parses is as follows:
+The approximate format that `RebenchLog` parses is as follows:
 
     optional_prefix benchmark_name: iterations=123 runtime: 1000[ms|us]
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -404,8 +404,14 @@ class Executor(object):
                 log_file.write(stderr_result)
 
     def execute_run(self, run_id):
-        gauge_adapter = self._get_gauge_adapter_instance(
-            run_id.get_gauge_adapter_name())
+        # obtain gauge adapter module from provided name or die trying
+        gauge_adapter_name = run_id.get_gauge_adapter_name()
+        gauge_adapter = self._get_gauge_adapter_instance(gauge_adapter_name)
+        if gauge_adapter is None:
+            run_id.fail_immediately()
+            msg = "{ind}Couldn't find gauge adapter: %s\n" % gauge_adapter_name
+            self.ui.error(msg, run_id)
+            # TODO exit early here (how?)
 
         cmdline = self._construct_cmdline(run_id, gauge_adapter)
 


### PR DESCRIPTION
Addresses #199 . Fixes the case of the `RebenchLog` gauge adapter and adds some notes on case sensitivity in relevant places. In the gauge adapter resolver, we emit an error message for missing gauge adapters instead of leaving it to the Python stack trace.