### PR TITLE
Allow float values for metrics captured in RebenchLog

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -76,7 +76,7 @@ Savina.Chameneos: iterations=1 runtime: 48581us
 Implementation Notes:
 
  - For parsing of the total run time, the following regular expression is used:
-   `r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: ([0-9]+)([mu])s")`
+   `^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: (?P<runtime>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)(?P<unit>[mu])s`
 
  - For arbitrary criteria, which may also be used for the `total` criteria,
    the following regular expression should match

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -80,7 +80,7 @@ Implementation Notes:
 
  - For arbitrary criteria, which may also be used for the `total` criteria,
    the following regular expression should match
-   `r"^(?:.*: )?([^\s]+): ([^:]{1,30}):\s*([0-9]+)([a-zA-Z]+)")`
+   `^(?:.*: )?([^\s]+): (?P<criterion>[^:]{1,30}):\s*(?P<value>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)(?P<unit>[a-zA-Z]+)`
 
 
 ## `Time`

--- a/rebench/interop/rebench_log_adapter.py
+++ b/rebench/interop/rebench_log_adapter.py
@@ -34,7 +34,7 @@ class RebenchLogAdapter(GaugeAdapter):
        Note: regular expressions are documented in /docs/extensions.md
     """
     re_log_line = re.compile(
-        r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: ([0-9]+)([mu])s")
+        r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: (?P<runtime>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)(?P<unit>[mu])s")
     re_extra_criterion_log_line = re.compile(
         r"^(?:.*: )?([^\s]+): ([^:]{1,30}):\s*([0-9]+)([a-zA-Z]+)")
 
@@ -60,8 +60,8 @@ class RebenchLogAdapter(GaugeAdapter):
             measure = None
             match = self.re_log_line.match(line)
             if match:
-                time = float(match.group(4))
-                if match.group(5) == "u":
+                time = float(match.group("runtime"))
+                if match.group("unit") == "u":
                     time /= 1000
                 criterion = (match.group(2) or 'total').strip()
 

--- a/rebench/interop/rebench_log_adapter.py
+++ b/rebench/interop/rebench_log_adapter.py
@@ -36,7 +36,7 @@ class RebenchLogAdapter(GaugeAdapter):
     re_log_line = re.compile(
         r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: (?P<runtime>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)(?P<unit>[mu])s")
     re_extra_criterion_log_line = re.compile(
-        r"^(?:.*: )?([^\s]+): ([^:]{1,30}):\s*([0-9]+)([a-zA-Z]+)")
+        r"^(?:.*: )?([^\s]+): (?P<criterion>[^:]{1,30}):\s*(?P<value>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)(?P<unit>[a-zA-Z]+)")
 
     re_NPB_partial_invalid = re.compile(r".*Failed.*verification")
     re_NPB_invalid = re.compile(r".*Benchmark done.*verification failed")
@@ -70,9 +70,9 @@ class RebenchLogAdapter(GaugeAdapter):
             else:
                 match = self.re_extra_criterion_log_line.match(line)
                 if match:
-                    value = float(match.group(3))
-                    criterion = match.group(2)
-                    unit = match.group(4)
+                    value = float(match.group("value"))
+                    criterion = match.group("criterion")
+                    unit = match.group("unit")
 
                     measure = Measurement(invocation, iteration, value, unit, run_id, criterion)
 

--- a/rebench/interop/rebench_log_adapter.py
+++ b/rebench/interop/rebench_log_adapter.py
@@ -34,9 +34,13 @@ class RebenchLogAdapter(GaugeAdapter):
        Note: regular expressions are documented in /docs/extensions.md
     """
     re_log_line = re.compile(
-        r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: (?P<runtime>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)(?P<unit>[mu])s")
+        r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) "
+        + r"runtime: (?P<runtime>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)"
+        + r"(?P<unit>[mu])s")
     re_extra_criterion_log_line = re.compile(
-        r"^(?:.*: )?([^\s]+): (?P<criterion>[^:]{1,30}):\s*(?P<value>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)(?P<unit>[a-zA-Z]+)")
+        r"^(?:.*: )?([^\s]+): (?P<criterion>[^:]{1,30}):\s*"
+        + r"(?P<value>(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)"
+        + r"(?P<unit>[a-zA-Z]+)")
 
     re_NPB_partial_invalid = re.compile(r".*Failed.*verification")
     re_NPB_invalid = re.compile(r".*Benchmark done.*verification failed")

--- a/rebench/tests/interop/rebench_log_adapter_test.py
+++ b/rebench/tests/interop/rebench_log_adapter_test.py
@@ -130,3 +130,29 @@ Savina.Chameneos: iterations=1 runtime: 48581us""", None, 13)
         self.assertEqual(40, measure.value)
         self.assertEqual('external data', measure.criterion)
         self.assertEqual('byte', measure.unit)
+
+    def test_float_value(self):
+        adapter = RebenchLogAdapter(True, None)
+        data = adapter.parse_data("Dispatch: iterations=1 runtime: 557.123ms", None, 1)
+        self._assert_basics(data, 557.123, 'ms', 'total', True)
+
+    def test_float_value_in_scientific_notation(self):
+        adapter = RebenchLogAdapter(True, None)
+        data = adapter.parse_data("Dispatch: iterations=1 runtime: 5.57123e2ms", None, 1)
+        self._assert_basics(data, 557.123, 'ms', 'total', True)
+
+        adapter = RebenchLogAdapter(True, None)
+        data = adapter.parse_data("Dispatch: iterations=1 runtime: 5.57123e-2ms", None, 1)
+        self._assert_basics(data, 0.0557123, 'ms', 'total', True)
+
+        adapter = RebenchLogAdapter(True, None)
+        data = adapter.parse_data("Dispatch: iterations=1 runtime: 5.57123E-2ms", None, 1)
+        self._assert_basics(data, 0.0557123, 'ms', 'total', True)
+
+        adapter = RebenchLogAdapter(True, None)
+        data = adapter.parse_data("Dispatch: iterations=1 runtime: .57ms", None, 1)
+        self._assert_basics(data, 0.57, 'ms', 'total', True)
+
+        adapter = RebenchLogAdapter(True, None)
+        data = adapter.parse_data("Dispatch: iterations=1 runtime: 57.ms", None, 1)
+        self._assert_basics(data, 57, 'ms', 'total', True)

--- a/rebench/tests/interop/rebench_log_adapter_test.py
+++ b/rebench/tests/interop/rebench_log_adapter_test.py
@@ -131,6 +131,24 @@ Savina.Chameneos: iterations=1 runtime: 48581us""", None, 13)
         self.assertEqual('external data', measure.criterion)
         self.assertEqual('byte', measure.unit)
 
+    def test_other_data_with_float_values(self):
+        adapter = RebenchLogAdapter(True, None)
+        data = adapter.parse_data("""Savina.Chameneos: some metrics:    5.7foobar
+Savina.Chameneos: external data: 5.2e1GB
+Savina.Chameneos: iterations=1 runtime: 64208us""", None, 13)
+
+        point = data[0]
+        measure = point.get_measurements()[0]
+
+        self.assertEqual(5.7, measure.value)
+        self.assertEqual('some metrics', measure.criterion)
+        self.assertEqual('foobar', measure.unit)
+
+        measure = point.get_measurements()[1]
+        self.assertEqual(52, measure.value)
+        self.assertEqual('external data', measure.criterion)
+        self.assertEqual('GB', measure.unit)
+
     def test_float_value(self):
         adapter = RebenchLogAdapter(True, None)
         data = adapter.parse_data("Dispatch: iterations=1 runtime: 557.123ms", None, 1)


### PR DESCRIPTION
~Documenting a point on the `RebenchLog` gauge adapter that may be unintuitive.~
Allows float values for `runtime` in the RebenchLog gauge adapter.
Previously, `... runtime: 1.23ms` would fail to parse. Now it parses just fine. Users should need to perform less conversion. On our side, we always parsed the value as a `float` - this simply expands the regex to allow more forms.