### PR TITLE
Make gauge adapter names in configuration case insensitive

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -16,6 +16,7 @@ ReBench currently provides builtin support for the following benchmark harnesses
 - `ValidationLog`: the format used by [SOMns](https://github.com/smarr/SOMns)'s ImpactHarness
 - `Time`: a harness that uses `/usr/bin/time` automatically
 
+
 ### `PlainSecondsLog`
 
 This adapter attempts to read every line of program output as a millisecond
@@ -34,6 +35,7 @@ Example output from a harness or benchmark:
 Implementation Notes:
 
  - Python's `float()` function is used for parsing
+
 
 ### `ReBenchLog`
 
@@ -79,6 +81,24 @@ Implementation Notes:
  - For arbitrary criteria, which may also be used for the `total` criteria,
    the following regular expression should match
    `r"^(?:.*: )?([^\s]+): ([^:]{1,30}):\s*([0-9]+)([a-zA-Z]+)")`
+
+
+## `Time`
+
+The `Time` adapter uses Unix's `/usr/bin/time` command.
+On Linux, or more generally the platforms that support it, it will also use the
+`-f` switch of the `time` command to record the maximum resident set size,
+i.e., the maximum amount of memory the program used.
+
+Example configuration for a suite:
+
+```yaml
+    Suite:
+        gauge_adapter: Time
+        benchmarks:
+          - Bench1
+```
+
 
 ## Supporting other Benchmark Harnesses
 

--- a/rebench/interop/rebench_log_adapter.py
+++ b/rebench/interop/rebench_log_adapter.py
@@ -30,6 +30,8 @@ class RebenchLogAdapter(GaugeAdapter):
     """RebenchLogPerformance is the standard log parser of ReBench.
        It reads a simple log format, which includes the number of iterations of
        a benchmark and its runtime in microseconds.
+
+       Note: regular expressions are documented in /docs/extensions.md
     """
     re_log_line = re.compile(
         r"^(?:.*: )?([^\s]+)( [\w\.]+)?: iterations=([0-9]+) runtime: ([0-9]+)([mu])s")

--- a/rebench/tests/interop/adapter_test.py
+++ b/rebench/tests/interop/adapter_test.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+from ...interop.adapter import instantiate_adapter
+
+
+class AdapterTest(TestCase):
+    def test_load_all_known_adapters(self):
+        self.assertIsNotNone(instantiate_adapter("JMH", False, None))
+        self.assertIsNotNone(instantiate_adapter("Multivariate", False, None))
+        self.assertIsNotNone(instantiate_adapter("Perf", False, None))
+        self.assertIsNotNone(instantiate_adapter("PlainSecondsLog", False, None))
+        self.assertIsNotNone(instantiate_adapter("RebenchLog", False, None))
+        self.assertIsNotNone(instantiate_adapter("SavinaLog", False, None))
+        self.assertIsNotNone(instantiate_adapter("Test", False, None))
+        self.assertIsNotNone(instantiate_adapter("TestExecutor", False, None))
+        self.assertIsNotNone(instantiate_adapter("Time", False, None))
+        self.assertIsNotNone(instantiate_adapter("ValidationLog", False, None))
+
+    def test_case_insensitive_names(self):
+        self.assertIsNotNone(instantiate_adapter("RebenchLog", False, None))
+        self.assertIsNotNone(instantiate_adapter("ReBenchLog", False, None))
+        self.assertIsNotNone(instantiate_adapter("rebenchlog", False, None))
+        self.assertIsNotNone(instantiate_adapter("REBENCHLOG", False, None))


### PR DESCRIPTION
When I looked at the loading code again, I noticed that we already traverse the module and load everything to find the adapter we are looking for.

So, this really just needs to add a bit of logic to make the check case insensitive.

Also used the chance the move the logic where it belongs, into the interop package, and add tests.

@raehik is this what you were hoping for?

This fixes #199.