### PR TITLE
Update Python Version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '2.7', '3.7', '3.9', 'pypy3.9' ]
+        python-version: [ '2.7', '3.7', '3.11', 'pypy3.9' ]
         yaml-parser: ['', 'ruamel']
         include:
           - python-version: 2.7
@@ -16,7 +16,7 @@ jobs:
         exclude:
           - python-version: 2.7
             yaml-parser: ruamel
-          - python-version: 3.9
+          - python-version: 3.11
             yaml-parser: ruamel
           - python-version: pypy3
             yaml-parser: ruamel
@@ -54,7 +54,7 @@ jobs:
         run: |
           pip install pylint
           pylint rebench
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.11'
 
       - name: Upload coverage results to Coveralls
         run: coveralls

--- a/.pylintrc
+++ b/.pylintrc
@@ -482,4 +482,4 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -98,7 +98,7 @@ class _RunFilter(object):
             elif parts[0] == "m" and len(parts) == 2:
                 self._machine_filters.append(_MachineFilter(parts[1]))
             else:
-                raise Exception("Unknown filter expression: " + run_filter)
+                raise RuntimeError("Unknown filter expression: " + run_filter)
 
     def applies_to_bench(self, bench):
         return (self._match(self._executor_filters, bench) and

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -136,4 +136,4 @@ def determine_environment():
     if _environment:
         return _environment
 
-    raise Exception("Environment was not initialized before accessing it.")
+    raise RuntimeError("Environment was not initialized before accessing it.")

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -67,7 +67,7 @@ class RunScheduler(object):
             return 0, 0, 0
 
         current = time()
-        time_per_invocation = ((current - self._start_time) / self._runs_completed)
+        time_per_invocation = (current - self._start_time) / self._runs_completed
         etl = time_per_invocation * (self._total_num_runs - self._runs_completed)
         sec = etl % 60
         minute = (etl - sec) / 60 % 60

--- a/rebench/model/profiler.py
+++ b/rebench/model/profiler.py
@@ -16,7 +16,7 @@ class Profiler(object):
                 perf = PerfProfiler(k, v)
                 profilers.append(perf)
             else:
-                raise Exception("Not yet supported profiler type: " + k)
+                raise NotImplementedError("Not yet supported profiler type: " + k)
         return profilers
 
     def __init__(self, name, gauge_name):

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -403,7 +403,7 @@ class _ReBenchDB(_ConcretePersistence):
         self._start_time = start_time
 
     def load_data(self, runs, discard_run_data):
-        raise Exception("Does not yet support data loading from ReBenchDB")
+        raise RuntimeError("Does not yet support data loading from ReBenchDB")
 
     def persist_data_point(self, data_point):
         with self._lock:

--- a/rebench/tests/mock_http_server.py
+++ b/rebench/tests/mock_http_server.py
@@ -50,7 +50,7 @@ class MockHTTPServer(object):
         self._server = HTTPServer(('localhost', self._port), _RequestHandler)
 
         self._thread = Thread(target=self._server.serve_forever)
-        self._thread.setDaemon(True)
+        self._thread.daemon = True
         self._thread.start()
 
     def shutdown(self):

--- a/rebench/ui.py
+++ b/rebench/ui.py
@@ -214,7 +214,7 @@ class UiSpinner(Spinner):
         assert not self.interactive
         label = label or self.label
         if not label:
-            raise Exception("No label set for spinner!")
+            raise RuntimeError("No label set for spinner!")
 
         if self.total:
             label = "%s: %.2f%%\n" % (label, progress / (self.total / 100.0))


### PR DESCRIPTION
Test against Python 3.11 instead of Python 3.9.
We test now Python 2.7, 3.7, and Python 3.11, and on PyPy 3.9.
This should cover all practically relevant cases.