### PR TITLE
Drop Python 2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '2.7', '3.7', '3.11', 'pypy3.9' ]
+        python-version: [ '3.7', '3.11', 'pypy3.9' ]
         yaml-parser: ['', 'ruamel']
         include:
-          - python-version: 2.7
+          - python-version: 3.7
             coverage: "--cov=rebench"
         exclude:
-          - python-version: 2.7
-            yaml-parser: ruamel
           - python-version: 3.11
             yaml-parser: ruamel
           - python-version: pypy3

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -20,11 +20,6 @@ try:
 except ValueError:
     rebench_version = "unknown"
 
-try:
-    FileNotFoundError  # pylint: disable=used-before-assignment
-except NameError:
-    FileNotFoundError = IOError  # pylint: disable=redefined-builtin
-
 
 class DenoiseResult(object):
 

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -2,16 +2,11 @@ import getpass
 import os
 import subprocess
 
+from urllib.parse import urlparse
 from cpuinfo.cpuinfo import _get_cpu_info_internal
 from psutil import virtual_memory
 
 from .subprocess_with_timeout import output_as_str
-
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    # Python 2.7
-    from urlparse import urlparse
 
 
 def _encode_str(out):

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # ReBench is a tool to run and document benchmarks.
 #
 # It is inspired by JavaStats implemented by Andy Georges.
@@ -54,7 +54,7 @@ class ReBench(object):
 
     def shell_options(self):
         usage = """%(prog)s [options] <config> [exp_name] [e:$]* [s:$]* [m:$]*
-        
+
 Argument:
   config    required argument, file containing the experiment to be executed
   exp_name  optional argument, the name of an experiment definition

--- a/rebench/rebenchdb.py
+++ b/rebench/rebenchdb.py
@@ -2,25 +2,10 @@ import json
 from datetime import datetime
 from time import sleep
 
+from http.client import HTTPException
+from urllib.request import urlopen, Request as PutRequest
+
 from .ui import UIError
-
-try:
-    from http.client import HTTPException
-    from urllib.request import urlopen, Request as PutRequest
-except ImportError:
-    # Python 2.7
-    from httplib import HTTPException
-    from urllib2 import urlopen, Request
-
-
-    class PutRequest(Request):
-        def __init__(self, *args, **kwargs):
-            if 'method' in kwargs:
-                del kwargs['method']
-            Request.__init__(self, *args, **kwargs)
-
-        def get_method(self, *_args, **_kwargs):  # pylint: disable=arguments-differ
-            return 'PUT'
 
 
 def get_current_time():

--- a/rebench/rebenchdb.py
+++ b/rebench/rebenchdb.py
@@ -62,10 +62,9 @@ class ReBenchDB(object):
     def _send_payload(payload, url):
         req = PutRequest(url, payload,
                          {'Content-Type': 'application/json'}, method='PUT')
-        socket = urlopen(req)
-        response = socket.read()
-        socket.close()
-        return response
+        with urlopen(req) as socket:
+            response = socket.read()
+            return response
 
     def _send_to_rebench_db(self, payload_data, operation):
         payload_data['projectName'] = self._project_name

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -202,10 +202,9 @@ class CodespeedReporter(Reporter):
         return result
 
     def _send_payload(self, payload):
-        socket = urlopen(self._cfg.url, payload)
-        response = socket.read()
-        socket.close()
-        return response
+        with urlopen(self._cfg.url, payload) as socket:
+            response = socket.read()
+            return response
 
     def _send_to_codespeed(self, results, run_id):
         payload = urlencode({'json': json.dumps(results)})

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -24,17 +24,10 @@ from operator import itemgetter
 import json
 import re
 
+from http.client import HTTPException
+from urllib.request import urlopen
+from urllib.parse import urlencode
 from humanfriendly.tables import format_pretty_table
-
-
-try:
-    from http.client import HTTPException
-    from urllib.request import urlopen
-    from urllib.parse import urlencode
-except ImportError:
-    from httplib import HTTPException
-    from urllib import urlencode # pylint: disable=ungrouped-imports
-    from urllib2 import urlopen
 
 
 class Reporter(object):

--- a/rebench/subprocess_kill.py
+++ b/rebench/subprocess_kill.py
@@ -2,34 +2,12 @@ from os         import kill
 from signal     import SIGKILL
 from subprocess import PIPE, Popen
 
-IS_PY3 = None
-
-try:
-    _ = ProcessLookupError
-    IS_PY3 = True
-except NameError:
-    IS_PY3 = False
 
 # Indicate timeout with standard exit code
 E_TIMEOUT = -9
 
 
-def _kill_py2(proc_id, uses_sudo):
-    if uses_sudo:
-        from .denoise import deliver_kill_signal  # pylint: disable=import-outside-toplevel
-
-        deliver_kill_signal(proc_id)
-        return
-
-    try:
-        kill(proc_id, SIGKILL)
-    except IOError:
-        # there's a race condition, the process may have already terminated on its own
-        # so let's simply ignore it
-        pass
-
-
-def _kill_py3(proc_id, uses_sudo):
+def _kill(proc_id, uses_sudo):
     if uses_sudo:
         from .denoise import deliver_kill_signal  # pylint: disable=import-outside-toplevel
 
@@ -50,10 +28,7 @@ def kill_process(pid, recursively, thread, uses_sudo):
         pids.extend(_get_process_children(pid))
 
     for proc_id in pids:
-        if IS_PY3:
-            _kill_py3(proc_id, uses_sudo)
-        else:
-            _kill_py2(proc_id, uses_sudo)
+        _kill(proc_id, uses_sudo)
 
     if thread:
         thread.join()

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -10,29 +10,16 @@ import signal
 
 from .subprocess_kill import kill_process
 
-IS_PY3 = None
-
-try:
-    _ = ProcessLookupError
-    IS_PY3 = True
-except NameError:
-    IS_PY3 = False
 
 # Indicate timeout with standard exit code
 E_TIMEOUT = -9
 
-if IS_PY3:
-    def output_as_str(string_like):
-        if string_like is not None and type(string_like) != str:  # pylint: disable=unidiomatic-typecheck
-            return string_like.decode('utf-8')
-        else:
-            return string_like
-else:
-    def output_as_str(string_like):
-        if string_like is not None and type(string_like) == str:  # pylint: disable=unidiomatic-typecheck
-            return string_like.decode('utf-8')
-        else:
-            return string_like
+
+def output_as_str(string_like):
+    if string_like is not None and type(string_like) != str:  # pylint: disable=unidiomatic-typecheck
+        return string_like.decode('utf-8')
+    else:
+        return string_like
 
 _signals_setup = False
 

--- a/rebench/tests/features/issue_81_unicode_test.py
+++ b/rebench/tests/features/issue_81_unicode_test.py
@@ -53,10 +53,7 @@ class Issue81UnicodeSuite(ReBenchTestCase):
         with open_with_enc(self._path + '/build.log', 'r', encoding='utf-8') as build_file:
             log = build_file.read()
 
-        try:
-            unicode_char = unichr(22234)
-        except NameError:
-            unicode_char = chr(22234)
+        unicode_char = chr(22234)
 
         self.assertGreaterEqual(15, log.find(unicode_char))  # Executor:VM1|STD:
         self.assertGreaterEqual(log.find(unicode_char, 16), 36)  # Executor:VM1|ERR:

--- a/rebench/tests/mock_http_server.py
+++ b/rebench/tests/mock_http_server.py
@@ -1,11 +1,6 @@
-try:
-    # Python 3
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-except ImportError:
-    # Python 2
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-
 import socket
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 
 

--- a/rebench/tests/reporter_test.py
+++ b/rebench/tests/reporter_test.py
@@ -1,3 +1,5 @@
+from http.client import HTTPException
+
 from .rebench_test_case import ReBenchTestCase
 
 from ..configurator import Configurator, load_config
@@ -5,11 +7,6 @@ from ..executor import Executor
 from ..persistence import DataStore
 from ..rebench import ReBench
 from ..reporter import CodespeedReporter
-
-try:
-    from http.client import HTTPException
-except ImportError:
-    from httplib import HTTPException
 
 
 class ReporterTest(ReBenchTestCase):

--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,6 @@ from rebench import __version__ as rebench_version
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-if sys.version_info[0] < 3:
-    pykwalify_version = 'pykwalify==1.7.0'
-    py_cpuinfo_version = 'py-cpuinfo==7.0.0'
-else:
-    pykwalify_version = 'pykwalify>=1.8.0'
-    py_cpuinfo_version = 'py-cpuinfo==9.0.0'
-
 setup(name='ReBench',
       version=rebench_version,
       description='Execute and document benchmarks reproducibly.',
@@ -46,9 +39,9 @@ setup(name='ReBench',
       package_data={'rebench': ['rebench-schema.yml']},
       install_requires=[
           'PyYAML>=3.12',
-          pykwalify_version,
+          'pykwalify>=1.8.0',
           'humanfriendly>=8.0',
-          py_cpuinfo_version,
+          'py-cpuinfo==9.0.0',
           'psutil>=5.6.7'
       ],
       entry_points = {


### PR DESCRIPTION
In anticipation that #206 yields "yes" at some point, here the PR that hopefully removes most version-specific code.

Overall, it seems to be a fairly small Python 2 to 3 difference.
So, it doesn't seem particularly urgent.