### PR TITLE
Fix handling of environment variables when sudo is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Other new features:
  - 
 
 Other changes:
+ - fix handling of environment variables when sudo is used (#210)
  - 
 
 ## [1.1.0] Denoise - 2023-02-21

--- a/rebench/__init__.py
+++ b/rebench/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.0-dev1"
+__version__ = "1.2.0-dev2"

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -302,7 +302,7 @@ class Executor(object):
         if self.use_denoise:
             cmdline += "sudo "
             if run_id.env:
-                cmdline += "--preserve-env=" + ','.join(run_id.keys()) + " "
+                cmdline += "--preserve-env=" + ','.join(run_id.env.keys()) + " "
             cmdline += "rebench-denoise "
             if not self._use_nice:
                 cmdline += "--without-nice "


### PR DESCRIPTION
Asking sudo to preserve environment variables was seemingly broken.
We didn't actually ask the `env` for its `keys`.
This PR fixes it.

@OctaveLarose this is hopefully fixing your issue.