### PR TITLE
Add support for GNU time on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ ReBench.egg-info
 cover-results
 .coverage
 .idea
-
+.p3-env

--- a/.pydevproject
+++ b/.pydevproject
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?eclipse-pydev version="1.0"?><pydev_project>
-<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
-<path>/ReBench</path>
-</pydev_pathproperty>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Python 2.7 (MacPorts)</pydev_property>
-</pydev_project>

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -86,7 +86,7 @@ Implementation Notes:
 ## `Time`
 
 The `Time` adapter uses Unix's `/usr/bin/time` command.
-On Linux, or more generally the platforms that support it, it will also use the
+If it the `time` program supports it, we will also use the
 `-f` switch of the `time` command to record the maximum resident set size,
 i.e., the maximum amount of memory the program used.
 
@@ -99,6 +99,13 @@ Example configuration for a suite:
           - Bench1
 ```
 
+Note:
+
+Compatible `time` binaries are looked for in:
+ - `/usr/bin/time`
+ - `/opt/local/bin/gtime`
+
+On MacOS, a GNU time command can be installed for instance with Homebrew and MacPorts.
 
 ## Supporting other Benchmark Harnesses
 

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -121,8 +121,11 @@ def init_environment(denoise_result, ui):
         cpu_info = _get_cpu_info_internal()
         if cpu_info:
             result['cpu'] = cpu_info['brand_raw']
-            result['clockSpeed'] = (cpu_info['hz_advertised'][0]
-                                    * (10 ** cpu_info['hz_advertised'][1]))
+            if 'hz_advertised' in cpu_info:
+                result['clockSpeed'] = (cpu_info['hz_advertised'][0]
+                                        * (10 ** cpu_info['hz_advertised'][1]))
+            else:
+                result['clockSpeed'] = 0
     except ValueError:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,10 @@ with open("README.md", "r") as fh:
 
 if sys.version_info[0] < 3:
     pykwalify_version = 'pykwalify==1.7.0'
+    py_cpuinfo_version = 'py-cpuinfo==7.0.0'
 else:
     pykwalify_version = 'pykwalify>=1.8.0'
+    py_cpuinfo_version = 'py-cpuinfo==9.0.0'
 
 setup(name='ReBench',
       version=rebench_version,
@@ -46,7 +48,7 @@ setup(name='ReBench',
           'PyYAML>=3.12',
           pykwalify_version,
           'humanfriendly>=8.0',
-          'py-cpuinfo==7.0.0',
+          py_cpuinfo_version,
           'psutil>=5.6.7'
       ],
       entry_points = {


### PR DESCRIPTION
This improves a little the macOS compatibility.
The latest py-cpuinfo also works now on ARM macs.
Though, it doesn't provide all the information we get on Linux.

The `Time` adapter now also checks whether there is a `gtime` command in `/opt/local/bin/gtime`, which MacPorts installs there.
With it, we can also read out the MaxRSS on macOS.