### PR TITLE
Avoid checking for time binary more than once and don't show progress update in execution plan

### DIFF
--- a/rebench/interop/time_adapter.py
+++ b/rebench/interop/time_adapter.py
@@ -66,7 +66,7 @@ class TimeAdapter(GaugeAdapter):
         time_bin = '/usr/bin/time'
         try:
             formatted_output = subprocess.call(
-                ['/usr/bin/time', '-f', TimeAdapter.time_format, '/bin/sleep', '1'],
+                ['/usr/bin/time', '-f', TimeAdapter.time_format, '/bin/sleep', '0'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError:
             formatted_output = 1
@@ -74,7 +74,7 @@ class TimeAdapter(GaugeAdapter):
         if formatted_output == 1:
             try:
                 formatted_output = subprocess.call(
-                    ['/opt/local/bin/gtime', '-f', TimeAdapter.time_format, '/bin/sleep', '1'],
+                    ['/opt/local/bin/gtime', '-f', TimeAdapter.time_format, '/bin/sleep', '0'],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 if formatted_output == 0:
                     time_bin = '/opt/local/bin/gtime'

--- a/rebench/tests/interop/time_adapter_test.py
+++ b/rebench/tests/interop/time_adapter_test.py
@@ -40,6 +40,7 @@ class TimeAdapterTest(TestCase):
 user         5.00
 sys          1.00"""
         adapter = TimeAdapter(False, None)
+        TimeAdapter._use_formatted_time = False
         data = adapter.parse_data(data, None, 1)
         self.assertEqual(1, len(data))
 


### PR DESCRIPTION
This PR optimizes the TimeAdapter. Previously, it would try to find the available `time` binary for every new runId. Now, it's done only on first use.
The problem with doing it every time is that I used `sleep 1`, which added up fast.

The PR also suppress progress updates from the scheduler.