### PR TITLE
Don’t turn extra args into a string if it is None (#215)

### DIFF
--- a/rebench/model/data_point.py
+++ b/rebench/model/data_point.py
@@ -76,3 +76,6 @@ class DataPoint(object):
             'it': iteration,
             'm': data
         }
+
+    def __repr__(self):
+        return "DataPoint(" + str(self.run_id) + ", " + str(self._measurements) + ")"

--- a/rebench/model/measurement.py
+++ b/rebench/model/measurement.py
@@ -71,3 +71,6 @@ class Measurement(object):
             'u': self.unit,
             'v': self.value
         }
+
+    def __repr__(self):
+        return "Measurement(%s, %s, %s)" % (self.value, self.unit, self.criterion)

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -327,13 +327,14 @@ class RunId(object):
         return result
 
     def as_dict(self):
+        extra_args = self.benchmark.extra_args
         return {
             'benchmark': self.benchmark.as_dict(),
             'cores': self.cores,
             'inputSize': self.input_size,
             'varValue': self.var_value,
             'machine': self.machine,
-            'extraArgs': str(self.benchmark.extra_args),
+            'extraArgs': extra_args if extra_args is None else str(extra_args),
             'cmdline': self.cmdline(),
             'location': self.location
         }

--- a/rebench/tests/features/issue_16_vm2.py
+++ b/rebench/tests/features/issue_16_vm2.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# simple script emulating an executor generating benchmark results
+import sys
+
+print(sys.argv)
+
+print("Harness Name: ", sys.argv[1])
+print("Bench Name:", sys.argv[2])
+print("Input Size: ", sys.argv[3])
+
+INPUT_SIZE = int(sys.argv[3])
+
+for i in range(0, INPUT_SIZE):
+    if i % 2 == 0:
+        print("RESULT-bar:   %d.%d" % (i, i))
+    if i % 3 == 0:
+        print("RESULT-baz:   %d.%d" % (i, i))
+    if i % 2 == 1:
+        print("RESULT-foo:   %d.%d" % (i, i))
+
+    print("RESULT-total: %d.%d" % (i, i))


### PR DESCRIPTION
This PR fixes #215.
It also a test for something unrelated but happens to catch the issue.

And adds some `__repr__` methods for debugging convenience.