### PR TITLE
Update Github Actions and Avoid GIL Issues and Races with MockHTTPServer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,17 @@ jobs:
       matrix:
         # Don't test pypy3.10, it currently is broken on GitHub Actions.
         # re-enable once PyYAML can be installed again. See #225
-        python-version: [ '3.7', '3.11' ]  # 'pypy3.10'
+        python-version: ["3.7", "3.12", "pypy3.10"]
         include:
           - python-version: 3.7
             coverage: "--cov=rebench"
     name: "Ubuntu-latest: Python ${{ matrix.python-version }}"
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/rebench/tests/mock_http_server.py
+++ b/rebench/tests/mock_http_server.py
@@ -2,6 +2,7 @@ import socket
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
+from time import sleep
 
 
 class _RequestHandler(BaseHTTPRequestHandler):
@@ -32,6 +33,7 @@ class MockHTTPServer(object):
         self._port = -1
         self._server = None
         self._thread = None
+        self._is_shutdown = False
 
     def get_free_port(self):
         s = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
@@ -49,7 +51,13 @@ class MockHTTPServer(object):
         self._thread.daemon = True
         self._thread.start()
 
-    def shutdown(self):
+    def process_and_shutdown(self):
+        if self._is_shutdown:
+            return
+
+        sleep(1)  # yield GIL and give server time to process request
+
+        self._is_shutdown = True
         self._server.shutdown()
 
     def get_number_of_put_requests(self):

--- a/rebench/tests/perf/issue_166_profiling_test.py
+++ b/rebench/tests/perf/issue_166_profiling_test.py
@@ -1,4 +1,5 @@
 from unittest import skipIf
+
 from ..mock_http_server import MockHTTPServer
 from ...configurator import Configurator, load_config
 from ...environment import git_not_available, git_repo_not_initialized
@@ -184,9 +185,11 @@ class Issue166ProfilingSupportTest(ReBenchTestCase):
             self.assertEqual(1, run_id.completed_invocations)
             self.assertEqual(1, run_id.get_number_of_data_points())
 
+            server.process_and_shutdown()
+
             self.assertEqual(1, server.get_number_of_put_requests())
         finally:
-            server.shutdown()
+            server.process_and_shutdown()
 
     @staticmethod
     def _make_profiler_return_small_report(run_id):

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -129,9 +129,11 @@ class PersistencyTest(ReBenchTestCase):
 
         try:
             self._exec_rebench_db(cmd_config, server)
+            server.process_and_shutdown()
+
             self.assertEqual(1, server.get_number_of_put_requests())
         finally:
-            server.shutdown()
+            server.process_and_shutdown()
 
     def test_disabled_rebench_db(self):
         option_parser = ReBench().shell_options()
@@ -141,9 +143,11 @@ class PersistencyTest(ReBenchTestCase):
 
         try:
             self._exec_rebench_db(cmd_config, server)
+            server.process_and_shutdown()
+
             self.assertEqual(0, server.get_number_of_put_requests())
         finally:
-            server.shutdown()
+            server.process_and_shutdown()
 
     def _exec_rebench_db(self, cmd_config, server):
         port = server.get_free_port()


### PR DESCRIPTION
- GitHub Actions resulted in deprecation warnings, which are now resolved
- reenable testing on PyPy, and test on Python 3.12
- make sure that Python gave the MockHTTPServer a chance to run and process the requests