### PR TITLE
Make the output for the current benchmark that's running more compact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
     name: "macOS: Python 3.11"
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -91,7 +91,7 @@ jobs:
           apt-get install -y --no-install-recommends time
 
       - name: Checkout ReBench
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PyTest
         run: pip3 install pytest


### PR DESCRIPTION
Currently, the output does not really fit on the screen when looking for instance at the GitLab log.

A single line is for instance:

```
Running Benchmarks:  WhileLoop (TruffleSOM-native-interp-bc-ee, micro-startup, 30) 1 yuria	mean:       38.9	time left: 00:01:54: 87.84%
```

After shortening, the output is reduced to:

```
Running    Bench1 (TestRunner2, TestSuite2, 3) 7 1 val2	   45872.0ms	left: 00:00:01: 35.00%
```

The shorter output comes from removing strings (`Benchmarks`, `mean:` `time `), and by calculating the number of characters needed to print all run descriptions, instead of hardcoding it to 70.