### PR TITLE
Invoke subprocesses by absolute path in sudo

### DIFF
--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -28,7 +28,8 @@ class DenoiseResult(object):
         self.use_shielding = use_shielding
         self.details = details
 
-def find_denoise():  #Find and return the canonical absolute path to make sudo happy
+def find_denoise():
+    """Find and return the canonical absolute path to make sudo happy"""
     try:
         denoise_path = output_as_str(subprocess.check_output('realpath `which rebench-denoise`',
                                                             shell=True))
@@ -36,7 +37,8 @@ def find_denoise():  #Find and return the canonical absolute path to make sudo h
         denoise_path = '$PATH_TO/rebench-denoise'
     return denoise_path.rstrip()  #get rid of the trailing newline
 
-def find_cset():  #Find the absolute path to cset since it's not the PATH inside of sudo
+def find_cset():
+    """Find the absolute path to cset since it's not the PATH inside of sudo"""
     try:
         cset_path = output_as_str(subprocess.check_output('realpath `which cset`',
                                                             shell=True))

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -28,7 +28,7 @@ from threading import Thread, RLock
 from time import time
 
 from . import subprocess_with_timeout as subprocess_timeout
-from .denoise import find_denoise, find_cset
+from .denoise import paths as denoise_paths
 from .interop.adapter import ExecutionDeliveredNoResults, instantiate_adapter, OutputNotParseable, \
     ResultsIndicatedAsInvalid
 from .ui import escape_braces
@@ -343,14 +343,14 @@ class Executor(object):
             cmdline += "sudo "
             if run_id.env:
                 cmdline += "--preserve-env=" + ','.join(run_id.env.keys()) + " "
-            cmdline += find_denoise() + " "
+            cmdline += denoise_paths.get_denoise() + " "
             if not self._use_nice:
                 cmdline += "--without-nice "
             if not self._use_shielding:
                 cmdline += "--without-shielding "
             if run_id.is_profiling():
                 cmdline += "--for-profiling "
-            cmdline += "--cset-path " + find_cset() + " "
+            cmdline += "--cset-path " + denoise_paths.get_cset() + " "
             cmdline += "exec -- "
 
         cmdline += gauge_adapter.acquire_command(run_id)

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -28,6 +28,7 @@ from threading import Thread, RLock
 from time import time
 
 from . import subprocess_with_timeout as subprocess_timeout
+from .denoise import find_denoise, find_cset
 from .interop.adapter import ExecutionDeliveredNoResults, instantiate_adapter, OutputNotParseable, \
     ResultsIndicatedAsInvalid
 from .ui import escape_braces
@@ -342,13 +343,14 @@ class Executor(object):
             cmdline += "sudo "
             if run_id.env:
                 cmdline += "--preserve-env=" + ','.join(run_id.env.keys()) + " "
-            cmdline += "rebench-denoise "
+            cmdline += find_denoise() + " "
             if not self._use_nice:
                 cmdline += "--without-nice "
             if not self._use_shielding:
                 cmdline += "--without-shielding "
             if run_id.is_profiling():
                 cmdline += "--for-profiling "
+            cmdline += "--cset-path " + find_cset() + " "
             cmdline += "exec -- "
 
         cmdline += gauge_adapter.acquire_command(run_id)

--- a/rebench/tests/features/issue_42_test.py
+++ b/rebench/tests/features/issue_42_test.py
@@ -136,8 +136,8 @@ class Issue42SupportForEnvironmentVariables(ReBenchTestCase):
         runs = list(cnf.get_runs())
         ex = Executor(runs, True, self.ui, use_nice=True, use_shielding=True)
 
-        self.assertIn(" --preserve-env=IMPORTANT_ENV_VARIABLE,ALSO_IMPORTANT rebench-denoise",
-                      ex._construct_cmdline(runs[0], TimeManualAdapter(False, ex)))
+        self.assertRegex(ex._construct_cmdline(runs[0], TimeManualAdapter(False, ex)),
+                         r" --preserve-env=IMPORTANT_ENV_VARIABLE,ALSO_IMPORTANT [^\s]*rebench-denoise")
 
     def test_construct_cmdline_build_with_env(self):
         cnf = Configurator(load_config(self._path + '/issue_42.conf'), DataStore(self.ui),
@@ -145,8 +145,8 @@ class Issue42SupportForEnvironmentVariables(ReBenchTestCase):
         runs = list(cnf.get_runs())
         ex = Executor(runs, True, self.ui, use_nice=True, use_shielding=True)
 
-        self.assertIn(" --preserve-env=VAR1,VAR3 rebench-denoise",
-                      ex._construct_cmdline(runs[0], TimeManualAdapter(False, ex)))
+        self.assertRegex(ex._construct_cmdline(runs[0], TimeManualAdapter(False, ex)),
+                         r" --preserve-env=VAR1,VAR3 [^\s]*rebench-denoise")
 
     def _assert_empty_standard_env(self, log_remainder):
         env_parts = log_remainder.split(':')


### PR DESCRIPTION
For security, many sudo configurations (at least the ones here) refuse to invoke a program without a password unless invoked with the absolute path given in the sudoers file. This affects the ability to invoke rebench-denoise.

Rebench-denoise, running under sudo as root, then needs to invoke cset. Since sudo has replaced the PATH with a sanitized one, cset may not be on the path.

This PR adds code to find the absolute path to both rebench-denoise and cset while outside of sudo, then invokes both using the absolute path.

Please note that I am not a Python programmer, so it is rather likely that this code can be improved, but (famous last words:) "It works for me."