### PR TITLE
Handle running on bare-bone setup more gracefully

### DIFF
--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -115,9 +115,14 @@ def init_environment(denoise_result, ui):
     }
 
     try:
+        if 'PATH' not in os.environ:
+            os.environ['PATH'] = ''
+
         cpu_info = _get_cpu_info_internal()
+
         if cpu_info:
-            result['cpu'] = cpu_info['brand_raw']
+            if 'brand_raw' in cpu_info:
+                result['cpu'] = cpu_info['brand_raw']
             if 'hz_advertised' in cpu_info:
                 result['clockSpeed'] = (cpu_info['hz_advertised'][0]
                                         * (10 ** cpu_info['hz_advertised'][1]))

--- a/rebench/environment.py
+++ b/rebench/environment.py
@@ -22,6 +22,8 @@ def _exec(cmd):
             out = subprocess.check_output(cmd, stderr=dev_null_f)
     except subprocess.CalledProcessError:
         return None
+    except FileNotFoundError:
+        return None
     return _encode_str(out)
 
 


### PR DESCRIPTION
This attempts to solve #243.

In the case `git` isn't available, I'll handle it as any other execution issue, and just return `None`. I think handling the error is more robust than trying to see whether it's available.

`py-cpuinfo` assumes that `PATH` is always set.
Though, the way I was trying to test this was with `env -i /../rebench ...`, where it isn't set...
Strangely enough, the git command didn't seem to cause an issue in the empty environment.