### PR TITLE
When perf fails, turn error into ExecutionDeliveredNoResults

### DIFF
--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -622,6 +622,8 @@ class Executor(object):
                 self.ui.error("{ind}Output of run could not be parsed.\n", run_id, cmdline)
             elif isinstance(e, ResultsIndicatedAsInvalid):
                 self.ui.error("{ind}Results were marked as invalid.\n", run_id, cmdline)
+            else:
+                self.ui.error("{ind}" + e.get_message() + "\n", run_id, cmdline)
             run_id.indicate_failed_execution()
             run_id.report_run_failed(cmdline, 0, output)
 

--- a/rebench/interop/adapter.py
+++ b/rebench/interop/adapter.py
@@ -74,6 +74,9 @@ class ExecutionDeliveredNoResults(Exception):
         super(ExecutionDeliveredNoResults, self).__init__()
         self._unparseable_data = unparsable_data
 
+    def get_message(self):
+        return self._unparseable_data
+
 
 class OutputNotParseable(ExecutionDeliveredNoResults):
     pass

--- a/rebench/model/profiler.py
+++ b/rebench/model/profiler.py
@@ -1,6 +1,6 @@
+from ..interop.adapter import ExecutionDeliveredNoResults
 from ..interop.perf_parser import PerfParser
 from ..subprocess_with_timeout import run
-from ..ui import UIError
 
 
 class Profiler(object):
@@ -45,9 +45,9 @@ class PerfProfiler(Profiler):
                                        verbose=executor.debug)
 
         if return_code != 0:
-            raise UIError(
+            raise ExecutionDeliveredNoResults(
                 "perf failed with error code when processing the profile to create a report: "
-                + str(return_code), None)
+                + str(return_code))
 
         parser = PerfParser()
         parser.parse_lines(output.split("\n"))


### PR DESCRIPTION
This should make sure that we do not abort execution, but instead just handle this as any other case that produced errors for some reason.

This fixes #252.