### PR TITLE
Avoid columns with all same value in summary table

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -244,11 +244,12 @@ class Configurator(object):
 
         if not self.options.experiment_name:
             raise ConfigurationError(
-                "The experiment was not named, which is mandatory. "
-                "This is needed to identify the data uniquely. "
-                "It should also help to remember in which context it "
+                "Reporting to ReBenchDB is enabled, but "
+                "the required experiment name is not set. "
+                "It is needed to identify the data uniquely "
+                "and helps to remember in which context data "
                 "was recorded, perhaps relating to a specific CI job "
-                "or confirming some hypothesis."
+                "or to confirm some hypothesis."
                 "\n\n"
                 "Use the --experiment option to set the name.")
 

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -1,6 +1,6 @@
 from select     import select
 from subprocess import PIPE, STDOUT, Popen
-from threading  import Thread, Condition
+from threading  import Thread, Condition, current_thread, main_thread
 from time       import time
 
 import sys
@@ -27,6 +27,9 @@ def keyboard_interrupt_on_sigterm(signum, frame):
 
 
 def _setup_signal_handling_if_needed():
+    if current_thread() is not main_thread():
+        return
+
     global _signals_setup  # pylint: disable=global-statement
     if not _signals_setup:
         _signals_setup = True

--- a/rebench/tests/reporter_test.py
+++ b/rebench/tests/reporter_test.py
@@ -6,24 +6,28 @@ from ..configurator import Configurator, load_config
 from ..executor import Executor
 from ..persistence import DataStore
 from ..rebench import ReBench
-from ..reporter import CodespeedReporter
+from ..reporter import CodespeedReporter, TextReporter
 
 
 class ReporterTest(ReBenchTestCase):
 
-    def _run_benchmarks_and_do_reporting(self):
+    def _run_benchmarks_and_do_reporting(self, rebench_db=True):
         option_parser = ReBench().shell_options()
-        cmd_config = option_parser.parse_args([
-            '--commit-id=id', '--environment=test', '--project=test', 'persistency.conf'])
-        cnf = Configurator(load_config(self._path + '/persistency.conf'), DataStore(self.ui),
+        if rebench_db:
+            args = ['--commit-id=id', '--environment=test', '--project=test', 'persistency.conf']
+            config = load_config(self._path + '/persistency.conf')
+        else:
+            args = ['-R', 'test.conf', 'Test']
+            config = load_config(self._path + '/test.conf')
+
+        cmd_config = option_parser.parse_args(args)
+        cnf = Configurator(config, DataStore(self.ui),
                            self.ui, cmd_config, data_file=self._tmp_file)
 
         self._runs = cnf.get_runs()  # pylint: disable=attribute-defined-outside-init
 
         ex = Executor(self._runs, False, self.ui)
         ex.execute()
-        reporter = cnf.reporting.codespeed_reporter
-        reporter.report_job_completed(self._runs)
 
     def test_send_to_codespeed(self):
         sent_results = [False]
@@ -56,3 +60,25 @@ class ReporterTest(ReBenchTestCase):
             self.assertTrue(sent_results[0])
         finally:
             CodespeedReporter._send_payload = old_send_payload
+
+    def test_text_reporter_summary_table(self):
+        self._run_benchmarks_and_do_reporting(False)
+        reporter = TextReporter()
+        sorted_rows, used_cols, summary = reporter._generate_all_output(self._runs)
+        self.assertEqual(38, len(sorted_rows))
+        self.assertEqual(len(reporter.expected_columns) - 1, len(sorted_rows[0]))
+        self.assertEqual(['Benchmark', 'Executor', 'Suite', 'Extra', 'Core', 'Size', 'Var',
+             'Machine', 'Mean (ms)'], used_cols)
+        self.assertEqual('#Samples', summary[0][0])
+        self.assertEqual(0, summary[0][1])
+
+    def test_text_reporter_summary_table_4_runs(self):
+        self._run_benchmarks_and_do_reporting(False)
+        reporter = TextReporter()
+
+        filter_runs = list(self._runs)[:4]
+
+        sorted_rows, used_cols, summary = reporter._generate_all_output(filter_runs)
+        self.assertEqual(4, len(sorted_rows))
+        self.assertEqual(reporter.expected_columns, used_cols)
+        self.assertIsNone(summary)


### PR DESCRIPTION
This PR finds which columns have all the same value in the summary table and then renders these information once at the top, and skips the column in the table.
The idea here is that we have an easier to read table with the most relevant info at the end.

This is especially useful when viewing things on a small screen.