### PR TITLE
Support Python 3.13 as latest version, drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.12", "pypy3.10"]
+        python-version: ["3.9", "3.12", "pypy3.10"]
         include:
-          - python-version: 3.8
+          - python-version: 3.9
             coverage: "--cov=rebench"
     name: "Ubuntu-latest: Python ${{ matrix.python-version }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12", "pypy3.10"]
+        python-version: ["3.9", "3.13", "pypy3.10"]
         include:
           - python-version: 3.9
             coverage: "--cov=rebench"
@@ -42,13 +42,13 @@ jobs:
         run: |
           pip install pylint
           pylint rebench
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
 
       - name: Install and run black
         run: |
           pip install black
           black --check rebench
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
 
       - name: Upload coverage results to Coveralls
         run: coveralls
@@ -58,7 +58,7 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
-    name: "macOS: Python 3.11"
+    name: "macOS: Python 3.12"
     steps:
       - name: Checkout ReBench
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install PyTest
         run: pip install pytest

--- a/rebench/rebenchdb.py
+++ b/rebench/rebenchdb.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime
 from time import sleep
 
 from http.client import HTTPException
@@ -7,10 +6,23 @@ from urllib.request import urlopen, Request as HttpRequest
 
 from .output import UIError
 
+try:
+    from datetime import datetime, UTC
 
-def get_current_time():
-    """Return the current time as string for use with ReBenchDB and other persistency backends."""
-    return datetime.utcnow().isoformat() + "+00:00"
+    def get_current_time():
+        """
+        Return the current time as string for use with ReBenchDB and other persistency backends.
+        """
+        return datetime.now(UTC).isoformat()
+
+except ImportError:
+    from datetime import datetime
+
+    def get_current_time():
+        """
+        Return the current time as string for use with ReBenchDB and other persistency backends.
+        """
+        return datetime.utcnow().isoformat() + "+00:00"
 
 
 class ReBenchDB(object):


### PR DESCRIPTION
This PR changes the CI to use 3.13 as latest supported version and 3.9 as oldest supported version. Thus, 3.8 is no longer supported.

We run the macOS CI usually on one version behind, just to have variety, so that's now moving from 3.11 to 3.12.

In an attempt to get ahead of depreciations, the PR address the `utcnow()` deprecation by using try/except and defining the version that's compatible with the Python used. Should be dropped once all supported Python version have the UTC constant defined, which is probably with 3.11.