### PR TITLE
Combine list of build commands into a single script

### DIFF
--- a/rebench/configurator.py
+++ b/rebench/configurator.py
@@ -19,11 +19,14 @@
 # IN THE SOFTWARE.
 import logging
 from os.path import dirname, abspath
+from typing import Mapping
+
 from pykwalify.core import Core
 from pykwalify.errors import SchemaError
 import yaml
 
 from .configuration_error import ConfigurationError
+from .model.build_cmd import BuildCommand
 from .model.experiment import Experiment
 from .model.exp_run_details import ExpRunDetails
 from .model.reporting import Reporting
@@ -216,7 +219,7 @@ class Configurator(object):
         self.data_store = data_store
         self._process_cli_options()
 
-        self.build_commands = {}
+        self.deduplicated_build_commands: Mapping[BuildCommand, BuildCommand] = {}
 
         self.run_filter = _RunFilter(run_filter)
 
@@ -295,7 +298,7 @@ class Configurator(object):
 
         executor = Executor.compile(
             executor_name, self._executors[executor_name],
-            run_details, variables, self.build_commands, action)
+            run_details, variables, self.deduplicated_build_commands, action)
         return executor
 
     def get_suite(self, suite_name):

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -370,18 +370,14 @@ class Executor(object):
         build = run_id.benchmark.suite.build
         self._process_builds(build, name, run_id)
 
-    def _process_builds(self, builds, name, run_id):
-        if not builds:
+    def _process_builds(self, build, name, run_id):
+        if not build or build.is_built:
             return
 
-        for build in builds:
-            if build.is_built:
-                continue
-
-            if build.build_failed:
-                run_id.fail_immediately()
-                raise FailedBuilding(name, build)
-            self._execute_build_cmd(build, name, run_id)
+        if build.build_failed:
+            run_id.fail_immediately()
+            raise FailedBuilding(name, build)
+        self._execute_build_cmd(build, name, run_id)
 
     def _execute_build_cmd(self, build_command, name, run_id):
         path = build_command.location

--- a/rebench/model/benchmark_suite.py
+++ b/rebench/model/benchmark_suite.py
@@ -27,14 +27,14 @@ from .exp_variables import ExpVariables
 class BenchmarkSuite(object):
 
     @classmethod
-    def compile(cls, suite_name, suite, executor, build_commands):
+    def compile(cls, suite_name, suite, executor, deduplicated_build_commands):
         gauge_adapter = suite.get("gauge_adapter")
         command = suite.get("command")
 
         location = suite.get("location", executor.path)
         if location and not location.startswith("~"):
             location = os.path.abspath(location)
-        build = BuildCommand.create_commands(suite.get("build"), build_commands, location)
+        build = BuildCommand.create(suite.get("build"), location, deduplicated_build_commands)
         benchmarks_config = suite.get("benchmarks")
 
         description = suite.get("description")

--- a/rebench/model/build_cmd.py
+++ b/rebench/model/build_cmd.py
@@ -17,24 +17,23 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from typing import Optional, Mapping
 
 
 class BuildCommand(object):
 
     @classmethod
-    def create_commands(cls, commands, build_commands, location):
+    def create(cls, commands: Optional[list[str]], location: Optional[str],
+               deduplicated_build_commands: Mapping["BuildCommand", "BuildCommand"]
+               ) -> Optional["BuildCommand"]:
         if not commands:
             return None
 
-        return [BuildCommand.create(cmd, build_commands, location) for cmd in commands]
+        command = "\n".join(commands)
 
-    @classmethod
-    def create(cls, cmd, build_commands, location):
-        assert cmd
-
-        build_command = BuildCommand(cmd, location)
-        if build_command in build_commands:
-            return build_commands[build_command]
+        build_command = BuildCommand(command, location)
+        if build_command in deduplicated_build_commands:
+            return deduplicated_build_commands[build_command]
         return build_command
 
     def __init__(self, cmd, location):

--- a/rebench/model/executor.py
+++ b/rebench/model/executor.py
@@ -29,14 +29,15 @@ from ..configuration_error import ConfigurationError
 class Executor(object):
 
     @classmethod
-    def compile(cls, executor_name, executor, run_details, variables, build_commands, action):
+    def compile(cls, executor_name, executor, run_details,
+                variables, deduplicated_build_commands, action):
         path = executor.get("path")
         if path and not path.startswith("~"):
             path = os.path.abspath(path)
         executable = executor.get("executable")
         args = executor.get("args")
 
-        build = BuildCommand.create_commands(executor.get("build"), build_commands, path)
+        build = BuildCommand.create(executor.get("build"), path, deduplicated_build_commands)
 
         description = executor.get("description")
         desc = executor.get("desc")

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -114,7 +114,7 @@ class Experiment(object):
             for suite_name in suites_for_executor:
                 suite = BenchmarkSuite.compile(
                     suite_name, configurator.get_suite(suite_name), executor,
-                    configurator.build_commands)
+                    configurator.deduplicated_build_commands)
                 results.append(suite)
 
         return results

--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -147,10 +147,10 @@ class RunId(object):
         commands = set()
         builds = self.benchmark.suite.executor.build
         if builds:
-            commands.update(builds)
+            commands.add(builds)
         builds = self.benchmark.suite.build
         if builds:
-            commands.update(builds)
+            commands.add(builds)
         return commands
 
     def requires_warmup(self):


### PR DESCRIPTION
The main reason for this change is to make the deduplication more sensible.

Previously, something like a `make clean` in the same location/path could have been deduplicated, even if the commands are somewhat unrelated but accidentally split into separate lines. The semantics around deduplication were not particularly intuitive. By combining everything into a single command it becomes a little more predictable. And overall simpler.

- make meaning of deduplicated_build_commands field explicit by naming it so
- the first PR that adds type annotations, I believe