### PR TITLE
Base RunId comparison and hash on all details

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -104,7 +104,7 @@ So, in the case of the `input_sizes` example, the setting for `benchmark`
 overrides the settings in a suite or executor.
 
 These priorities and the ability to define different benchmarks, suites, VMs, etc,
-hopefully provides sufficient flexibility to encode all desired experiments.
+hopefully provide sufficient flexibility to encode all desired experiments.
 
 ## Root Elements
 

--- a/rebench/__init__.py
+++ b/rebench/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.3.0.dev1"
+__version__ = "1.3.0.dev2"

--- a/rebench/model/exp_run_details.py
+++ b/rebench/model/exp_run_details.py
@@ -17,15 +17,30 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-from typing import Optional
+from typing import Optional, Mapping, Any
 from . import none_or_int, none_or_float, none_or_bool, none_or_dict, \
     remove_important, prefer_important
 
+def _lt_of_env_dict(a: dict, b: dict):
+    assert a != b
+
+    if len(a) != len(b):
+        return len(a) < len(b)
+
+    for k in sorted(a.keys()):
+        if k not in b:
+            return True
+
+        if a[k] != b[k]:
+            return a[k] < b[k]
+
+    # This case should never be reached, because we already checked for equality
+    assert False, "Unexpected case reached in _lt_of_env_dict"
 
 class ExpRunDetails(object):
 
     @classmethod
-    def compile(cls, config, defaults):
+    def compile(cls, config, defaults) -> "ExpRunDetails":
         invocations = prefer_important(config.get('invocations'), defaults.invocations)
         iterations = prefer_important(config.get('iterations'), defaults.iterations)
         warmup = prefer_important(config.get('warmup'), defaults.warmup)
@@ -53,7 +68,8 @@ class ExpRunDetails(object):
 
     @classmethod
     def empty(cls):
-        return ExpRunDetails(None, None, None, None, None, None, None, None, None, None, None, None)
+        return ExpRunDetails(None, None, None, None, None, None, None, None, None,
+                             None, None, None)
 
     @classmethod
     def default(cls, invocations_override, iterations_override):
@@ -61,10 +77,10 @@ class ExpRunDetails(object):
                              invocations_override, iterations_override)
 
     def __init__(self, invocations: Optional[int], iterations: Optional[int], warmup: Optional[int],
-                 min_iteration_time: Optional[int], max_invocation_time: Optional[int],
-                 ignore_timeouts, parallel_interference_factor,
-                 execute_exclusively, retries_after_failure, env,
-                 invocations_override, iterations_override):
+                 min_iteration_time: Optional[int],
+                 max_invocation_time: Optional[int], ignore_timeouts, parallel_interference_factor,
+                 execute_exclusively, retries_after_failure, env: Optional[Mapping],
+                 invocations_override: Optional[int], iterations_override: Optional[int]):
         self.invocations = invocations
         self.iterations = iterations
         self.warmup = warmup
@@ -80,6 +96,72 @@ class ExpRunDetails(object):
         self.invocations_override = invocations_override
         self.iterations_override = iterations_override
 
+    def __eq__(self, other):
+        return self is other or (
+            isinstance(other, self.__class__) and
+            self.invocations == other.invocations and
+            self.iterations == other.iterations and
+            self.warmup == other.warmup and
+
+            self.min_iteration_time == other.min_iteration_time and
+            self.max_invocation_time == other.max_invocation_time and
+            self.ignore_timeouts == other.ignore_timeouts and
+            self.parallel_interference_factor == other.parallel_interference_factor and
+            self.execute_exclusively == other.execute_exclusively and
+            self.retries_after_failure == other.retries_after_failure and
+            self.env == other.env and
+
+            self.invocations_override == other.invocations_override and
+            self.iterations_override == other.iterations_override)
+
+    # pylint: disable-next=too-many-return-statements
+    def __lt__(self, other):
+        if self is other:
+            return False
+
+        if self.invocations != other.invocations:
+            return self.invocations < other.invocations
+
+        if self.iterations != other.iterations:
+            return self.iterations < other.iterations
+
+        if self.warmup != other.warmup:
+            return self.warmup < other.warmup
+
+        if self.min_iteration_time != other.min_iteration_time:
+            return self.min_iteration_time < other.min_iteration_time
+
+        if self.max_invocation_time != other.max_invocation_time:
+            return self.max_invocation_time < other.max_invocation_time
+
+        if self.ignore_timeouts != other.ignore_timeouts:
+            return self.ignore_timeouts < other.ignore_timeouts
+
+        if self.parallel_interference_factor != other.parallel_interference_factor:
+            return self.parallel_interference_factor < other.parallel_interference_factor
+
+        if self.execute_exclusively != other.execute_exclusively:
+            return self.execute_exclusively < other.execute_exclusively
+
+        if self.retries_after_failure != other.retries_after_failure:
+            return self.retries_after_failure < other.retries_after_failure
+
+        if self.env != other.env:
+            return _lt_of_env_dict(self.env, other.env)
+
+        if self.invocations_override != other.invocations_override:
+            return self.invocations_override < other.invocations_override
+
+        return self.iterations_override < other.iterations_override
+
+    def __hash__(self):
+        return hash((self.invocations, self.iterations, self.warmup,
+                     self.min_iteration_time, self.max_invocation_time,
+                     self.ignore_timeouts, self.parallel_interference_factor,
+                     self.execute_exclusively, self.retries_after_failure,
+                     tuple(sorted(self.env.items())) if self.env else None,
+                     self.invocations_override, self.iterations_override))
+
     def resolve_override_and_important(self):
         # resolve overrides
         if self.invocations_override is not None:
@@ -93,9 +175,61 @@ class ExpRunDetails(object):
         self.iterations = remove_important(self.iterations)
         self.warmup = remove_important(self.warmup)
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ExpRunDetails":
+        return ExpRunDetails(data.get("invocations", None),
+                             data.get("iterations", None),
+                             data.get("warmup", None),
+                             data.get("minIterationTime", None),
+                             data.get("maxInvocationTime", None),
+                             data.get("ignore_timeouts", None),
+                             data.get("parallel_interference_factor", None),
+                             data.get("execute_exclusively", None),
+                             data.get("retries_after_failure", None),
+                             data.get("env", None),
+                             data.get("invocations_override", None),
+                             data.get("iterations_override", None))
+
     def as_dict(self):
-        return {
-            "warmup": self.warmup,
-            "minIterationTime": self.min_iteration_time,
-            "maxInvocationTime": self.max_invocation_time,
-        }
+        result = {}
+
+        if self.invocations is not None:
+            result["invocations"] = self.invocations
+
+        if self.iterations is not None:
+            result["iterations"] = self.iterations
+
+        if self.warmup is not None:
+            result["warmup"] = self.warmup
+
+        if self.min_iteration_time is not None:
+            result["minIterationTime"] = self.min_iteration_time
+
+        if self.max_invocation_time is not None:
+            result["maxInvocationTime"] = self.max_invocation_time
+
+        if self.ignore_timeouts is not None:
+            result["ignore_timeouts"] = self.ignore_timeouts
+
+        if self.parallel_interference_factor is not None:
+            result["parallel_interference_factor"] = self.parallel_interference_factor
+
+        if self.execute_exclusively is not None:
+            result["execute_exclusively"] = self.execute_exclusively
+
+        if self.retries_after_failure is not None:
+            result["retries_after_failure"] = self.retries_after_failure
+
+        if self.env is not None:
+            result["env"] = self.env
+
+        if self.invocations_override is not None:
+            result["invocations_override"] = self.invocations_override
+
+        if self.iterations_override is not None:
+            result["iterations_override"] = self.iterations_override
+
+        if not result:
+            return None
+
+        return result

--- a/rebench/model/exp_variables.py
+++ b/rebench/model/exp_variables.py
@@ -17,12 +17,13 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from typing import Mapping
 
 
 class ExpVariables(object):
 
     @classmethod
-    def compile(cls, config, defaults):
+    def compile(cls, config: dict, defaults: "ExpVariables") -> "ExpVariables":
         input_sizes = config.get("input_sizes", defaults.input_sizes)
         cores = config.get("cores", defaults.cores)
         variable_values = config.get("variable_values", defaults.variable_values)
@@ -33,8 +34,56 @@ class ExpVariables(object):
     def empty(cls):
         return ExpVariables([""], [1], [""], [None])
 
-    def __init__(self, input_sizes, cores, variable_values, tags):
+    def __init__(
+        self, input_sizes: list, cores: list, variable_values: list, tags: list
+    ):
         self.input_sizes = input_sizes
         self.cores = cores
         self.variable_values = variable_values
         self.tags = tags
+
+    @classmethod
+    def from_dict(cls, config: dict) -> "ExpVariables":
+        empty = ExpVariables.empty()
+        return ExpVariables(
+            config.get("input_sizes", empty.input_sizes),
+            config.get("cores", empty.cores),
+            config.get("variable_values", empty.variable_values),
+            config.get("tags", empty.tags),
+        )
+
+    def as_dict(self) -> Mapping:
+        return {
+            "input_sizes": self.input_sizes,
+            "cores": self.cores,
+            "variable_values": self.variable_values,
+            "tags": self.tags,
+        }
+
+    def __eq__(self, other):
+        return self is other or (
+            isinstance(other, self.__class__)
+            and self.input_sizes == other.input_sizes
+            and self.cores == other.cores
+            and self.variable_values == other.variable_values
+            and self.tags == other.tags
+        )
+
+    def __lt__(self, other):
+        if self.input_sizes != other.input_sizes:
+            return self.input_sizes < other.input_sizes
+        if self.cores != other.cores:
+            return self.cores < other.cores
+        if self.variable_values != other.variable_values:
+            return self.variable_values < other.variable_values
+        return self.tags < other.tags
+
+    def __hash__(self):
+        return hash(
+            (
+                tuple(self.input_sizes),
+                tuple(self.cores),
+                tuple(self.variable_values),
+                tuple(self.tags),
+            )
+        )

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -40,8 +40,8 @@ class Experiment(object):
         reporting = Reporting.compile(exp.get('reporting', {}), configurator.reporting,
                                       configurator.options, configurator.ui)
 
-        run_details = ExpRunDetails.compile(exp, configurator.run_details)
-        variables = ExpVariables.compile(exp, ExpVariables.empty())
+        run_details = ExpRunDetails.compile(exp, configurator.base_run_details)
+        variables = ExpVariables.compile(exp, configurator.base_variables)
 
         executions = exp.get("executions")
         suites = exp.get("suites")
@@ -86,7 +86,6 @@ class Experiment(object):
                                 continue
                             run = self._data_store.create_run_id(
                                 bench, cores, input_size, var_val, tag)
-                            bench.add_run(run)
                             runs.add(run)
                             run.add_reporting(self._reporting)
                             run.add_persistence(self._persistence)
@@ -123,6 +122,5 @@ class Experiment(object):
         bench_cfgs = []
         for suite in self._suites:
             for bench in suite.benchmarks_config:
-                bench_cfgs.append(Benchmark.compile(
-                    bench, suite, self._data_store))
+                bench_cfgs.append(Benchmark.compile(bench, suite))
         return bench_cfgs

--- a/rebench/model/measurement.py
+++ b/rebench/model/measurement.py
@@ -22,7 +22,7 @@ from .run_id import RunId
 
 class Measurement(object):
     def __init__(self, invocation, iteration, value, unit,
-                 run_id, criterion='total', line_number=None, filename=None):
+                 run_id: RunId, criterion='total', line_number=None, filename=None):
         self.invocation = invocation
         self.iteration = iteration
         self.value = value
@@ -36,7 +36,7 @@ class Measurement(object):
     def is_total(self):
         return self.criterion == "total"
 
-    def as_str_list(self):
+    def as_str_list(self, persisted_run_id: int):
         if isinstance(self.value, float):
             val = "%f" % self.value
         else:
@@ -45,16 +45,16 @@ class Measurement(object):
         return [str(self.invocation), str(self.iteration),
                 val,
                 self.unit,
-                self.criterion] + self.run_id.as_str_list()
+                self.criterion] + self.run_id.as_str_list(persisted_run_id)
 
     @classmethod
-    def from_str_list(cls, data_store, str_list, line_number=None, filename=None):
+    def from_str_list(cls, id_to_run_id: list[RunId], str_list, line_number=None, filename=None):
         invocation = int(str_list[0])
         iteration = int(str_list[1])
         value = float(str_list[2])
         unit = str_list[3]
         criterion = str_list[4]
-        run_id = RunId.from_str_list(data_store, str_list[5:])
+        run_id = RunId.from_str_list(id_to_run_id, str_list[5:])
 
         return Measurement(invocation, iteration, value, unit, run_id,
                            criterion, line_number, filename)

--- a/rebench/model/profile_data.py
+++ b/rebench/model/profile_data.py
@@ -25,16 +25,17 @@ class ProfileData(object):
             "in": self.invocation,
         }
 
-    def as_str_list(self):
+    def as_str_list(self, persisted_run_id: int):
         as_json = json.dumps(self.processed_data)
         return ([str(self.invocation), str(self.num_iterations)]
-                + self.run_id.as_str_list() + [as_json])
+                + self.run_id.as_str_list(persisted_run_id) + [as_json])
 
     @classmethod
-    def from_str_list(cls, data_store, str_list, _line_number=None, _filename=None):
+    def from_str_list(cls, id_to_run_id: list["RunId"], str_list, _line_number=None,
+                      _filename=None):
         invocation = int(str_list[0])
         num_iterations = int(str_list[1])
-        run_id = RunId.from_str_list(data_store, str_list[2:-1])
+        run_id = RunId.from_str_list(id_to_run_id, str_list[2:-1])
         processed_data = str_list[-1]
 
         return ProfileData(run_id, processed_data, num_iterations, invocation)

--- a/rebench/output.py
+++ b/rebench/output.py
@@ -22,3 +22,6 @@ class UIError(Exception):
 
     def __str__(self):
         return self._message
+
+    def __repr__(self):
+        return f"UIError({self._message})"

--- a/rebench/output.py
+++ b/rebench/output.py
@@ -1,6 +1,6 @@
 def output_as_str(string_like):
     if string_like is not None and type(string_like) != str:  # pylint: disable=unidiomatic-typecheck
-        return string_like.decode("utf-8")
+        return string_like.decode("utf-8", errors="replace")
     else:
         return string_like
 

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -91,8 +91,8 @@ class TextReporter(Reporter):
         for run_id in run_ids:
             mean = run_id.get_mean_of_totals()
             num_samples = run_id.get_number_of_data_points()
-            out = run_id.as_str_list()
-            out.append(num_samples)
+            out = run_id.as_str_list(0)
+            out[-1] = num_samples # can just overwrite the last value, which is the run_id_id
             if num_samples == 0:
                 out.append("Failed")
             else:

--- a/rebench/subprocess_kill.py
+++ b/rebench/subprocess_kill.py
@@ -1,7 +1,7 @@
 from os         import kill
 from signal     import SIGKILL
 from subprocess import PIPE, Popen
-
+from typing     import Optional, Tuple
 
 # Indicate timeout with standard exit code
 E_TIMEOUT = -9
@@ -20,7 +20,8 @@ def _kill(proc_id, sudo_kill_delivery_fn):
         pass
 
 
-def kill_process(pid, recursively, thread, sudo_kill_delivery_fn):
+def kill_process(pid, recursively, thread, sudo_kill_delivery_fn
+                 ) -> Tuple[int, Optional[str], Optional[str]]:
     pids = [pid]
     if recursively:
         pids.extend(_get_process_children(pid))

--- a/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
+++ b/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
@@ -24,8 +24,6 @@ from ...model.benchmark_suite  import BenchmarkSuite
 from ...model.run_id           import RunId
 from ...model.exp_run_details  import ExpRunDetails
 from ...model.executor  import Executor
-from ...persistence            import DataStore
-from ...ui                     import TestDummyUI
 
 
 class Issue4RunEquality(unittest.TestCase):
@@ -40,7 +38,7 @@ class Issue4RunEquality(unittest.TestCase):
         suite = BenchmarkSuite("MySuite", executor, '', '%(benchmark)s %(cores)s %(input)s',
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite, None,
-                              '3', ExpRunDetails.empty(), None, DataStore(TestDummyUI()))
+                              '3', ExpRunDetails.empty(), None)
         return RunId(benchmark, 1, 2, None, None)
 
     @staticmethod
@@ -50,7 +48,7 @@ class Issue4RunEquality(unittest.TestCase):
         suite = BenchmarkSuite('MySuite', executor, '', '%(benchmark)s %(cores)s 2 3',
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite,
-                              None, None, ExpRunDetails.empty(), None, DataStore(TestDummyUI()))
+                              None, None, ExpRunDetails.empty(), None)
         return RunId(benchmark, 1, None, None, None)
 
     def test_hardcoded_equals_template_constructed(self):
@@ -58,6 +56,11 @@ class Issue4RunEquality(unittest.TestCase):
         template = self._create_template_run_id()
 
         self.assertEqual(hard_coded.cmdline(), template.cmdline())
-        self.assertEqual(hard_coded, template)
-        self.assertTrue(hard_coded == template)
         self.assertFalse(hard_coded is template)
+
+        # While it would be fantastic to recognize these as equal, it is simpler to break
+        # this feature for the moment and consider them different. This way,
+        # we have one consistent way of detecting equality of run_ids, that includes all,
+        # and not only the command-line-based configuration details.
+        self.assertNotEqual(hard_coded, template)
+        self.assertFalse(hard_coded == template)

--- a/rebench/tests/configurator_compile_test.py
+++ b/rebench/tests/configurator_compile_test.py
@@ -1,0 +1,160 @@
+# pylint: disable=redefined-outer-name
+import pytest
+
+from ..configurator import validate_config, Configurator
+from ..persistence import DataStore
+from ..ui import TestDummyUI
+
+
+# precedence order/priority, from most important to least important:
+CONFIG_ELEMENTS = [
+    "benchmark",
+    "benchmark suite",
+    "executor",
+    "experiment",
+    "experiments",
+    "runs",
+]
+
+
+def create_list_of_pairs_to_check():
+    result = set()
+    for i, high in enumerate(CONFIG_ELEMENTS):
+        for j, low in enumerate(CONFIG_ELEMENTS):
+            if i < j:
+                result.add((high, low))
+    return result
+
+
+def test_precedence_order_pairs():
+    pairs = create_list_of_pairs_to_check()
+    assert len(pairs) == 15
+
+
+# the run details, with a low priority [0] and a high priority [1] setting
+RUN_DETAILS = {
+    "invocations": [11, 22],
+    "iterations": [33, 44],
+    "warmup": [3, 5],
+    "min_iteration_time": [100, 200],
+    "max_invocation_time": [1000, 2000],
+    "ignore_timeouts": [True, False],
+    "retries_after_failure": [8, 9],
+    "env": [{"MY_VAR": "value"}, {"MY_VAR": "value2"}],
+}
+
+# the variables, with a low priority [0] and a high priority [1] setting
+VARIABLES = {
+    "input_sizes": [[100], [300]],
+    "cores": [[5], [7]],
+    "variable_values": [["lowVar"], ["highVar"]],
+    "tags": [["lowTag"], ["highTag"]],
+}
+
+
+@pytest.fixture
+def ui():
+    return TestDummyUI()
+
+
+@pytest.fixture
+def data_store(ui):
+    return DataStore(ui)
+
+
+def create_raw_configuration():
+    return {
+        "benchmark_suites": {
+            "TestSuite": {
+                "gauge_adapter": "test",
+                "command": "cmd",
+                "benchmarks": [
+                    {"Bench1": {}},
+                ],
+            }
+        },
+        "executors": {"TestExec": {"path": "path", "executable": "exec"}},
+        "experiments": {
+            "testExp": {"suites": ["TestSuite"], "executions": [{"TestExec": {}}]}
+        },
+    }
+
+
+def add_setting(config, elem_name, key, value):
+    if elem_name == "benchmark":
+        config["benchmark_suites"]["TestSuite"]["benchmarks"][0]["Bench1"][key] = value
+    elif elem_name == "benchmark suite":
+        config["benchmark_suites"]["TestSuite"][key] = value
+    elif elem_name == "executor":
+        config["executors"]["TestExec"][key] = value
+    elif elem_name == "experiment":
+        config["experiments"]["testExp"]["executions"][0]["TestExec"][key] = value
+    elif elem_name == "experiments":
+        config["experiments"]["testExp"][key] = value
+    elif elem_name == "runs":
+        config["runs"] = {key: value}
+
+
+def create_test_input():
+    result = []
+    for highElem, lowElem in create_list_of_pairs_to_check():
+        for key, value in RUN_DETAILS.items():
+            result.append((highElem, lowElem, key, value[1], value[0]))
+        if highElem != "runs" and lowElem != "runs":
+            # runs do not have EXP_VARIABLES, it's inconsistent,
+            # but also not obviously wrong
+            for key, value in VARIABLES.items():
+                result.append((highElem, lowElem, key, value[1], value[0]))
+    return result
+
+
+def create_config(high_elem, low_elem, val_key, high_val, low_val):
+    raw_config = create_raw_configuration()
+    add_setting(raw_config, high_elem, val_key, high_val)
+    add_setting(raw_config, low_elem, val_key, low_val)
+    return raw_config
+
+
+@pytest.mark.parametrize(
+    "high_elem, low_elem, val_key, high_val, low_val", create_test_input()
+)
+def test_generated_config_is_valid(high_elem, low_elem, val_key, high_val, low_val):
+    raw_config = create_config(high_elem, low_elem, val_key, high_val, low_val)
+    assert raw_config is not None
+    validate_config(raw_config)
+
+
+@pytest.mark.parametrize(
+    "high_elem, low_elem, val_key, high_val, low_val", create_test_input()
+)
+def test_experiment_with_higher_priority_setting(
+    ui, data_store, high_elem, low_elem, val_key, high_val, low_val
+):
+    raw_config = create_config(high_elem, low_elem, val_key, high_val, low_val)
+    assert_expected_value_in_config(ui, data_store, raw_config, val_key, high_val)
+
+
+def assert_expected_value_in_config(ui, data_store, raw_config, val_key, high_val):
+    cnf = Configurator(raw_config, data_store, ui)
+    runs = list(cnf.get_runs())
+    assert len(runs) == 1
+
+    run = runs[0]
+
+    # need to do just a little bit of mapping
+    # the names are not a 1:1 match, and some of the lists will turn into distinct runs
+    if val_key == "warmup":
+        val_key = "warmup_iterations"
+    elif val_key == "input_sizes":
+        val_key = "input_size"
+        high_val = high_val[0]
+    elif val_key == "cores":
+        high_val = high_val[0]
+    elif val_key == "variable_values":
+        val_key = "var_value"
+        high_val = high_val[0]
+    elif val_key == "tags":
+        val_key = "tag"
+        high_val = high_val[0]
+
+    assert getattr(run, val_key) == high_val

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -47,11 +47,11 @@ class ConfiguratorTest(ReBenchTestCase):
                            self.ui, None)
         self.assertEqual(1, len(cnf.get_experiments()))
 
-    @unittest.skip("needs to be fixed, see #21")
     def test_number_of_experiments_testconf(self):
         cnf = Configurator(load_config(self._path + '/test.conf'), DataStore(self.ui),
                            self.ui, None, None, 'all')
-        self.assertEqual(6, len(cnf.get_experiments()))
+        self.assertEqual(5, len(cnf.get_experiments()))
+        self.assertEqual(53, len(cnf.get_runs()))
 
     def _get_experiment(self):
         cnf = Configurator(load_config(self._path + '/small.conf'), DataStore(self.ui),

--- a/rebench/tests/configurator_test.py
+++ b/rebench/tests/configurator_test.py
@@ -127,7 +127,7 @@ class ConfiguratorTest(ReBenchTestCase):
                            self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
-        self.assertEqual(14, len(runs))
+        self.assertEqual(16, len(runs))
 
     def test_tag_filter_m1_and_m2(self):
         filter_args = ['t:machine1', 't:machine2']
@@ -135,7 +135,7 @@ class ConfiguratorTest(ReBenchTestCase):
                            self.ui, run_filter=filter_args)
 
         runs = cnf.get_runs()
-        self.assertEqual(14 + 24, len(runs))
+        self.assertEqual(16 + 24, len(runs))
 
     def test_validate_gauge_adapters_with_all_correct_settings(self):
         result = validate_gauge_adapters({

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -82,9 +82,9 @@ class ExecutorTest(ReBenchTestCase):
 
         ex = Executor(initial_runs, False, self.ui, False, False, scheduler)
         ex.execute()
-        self.assertEqual(len(reporter.runs_completed), 28)
+        self.assertEqual(len(reporter.runs_completed), 40)
         self.assertEqual(len(reporter.runs_failed), 1)
-        self.assertEqual(len(reporter.runs_failed_without_return_code), 13)
+        self.assertEqual(len(reporter.runs_failed_without_return_code), 23)
 
     def test_remove_executors_with_missing_exe_batch(self):
         self._remove_executors_with_missing_exe(BatchScheduler)

--- a/rebench/tests/features/issue_58_build_vm_test.py
+++ b/rebench/tests/features/issue_58_build_vm_test.py
@@ -120,5 +120,4 @@ class Issue58BuildExecutor(ReBenchTestCase):
 
         log = self._read_log()
 
-        self.assertEqual(
-            "E:BashA|STD:standard\nE:BashA|ERR:error\n", log)
+        self.assertRegex(log, r"^E:BashAA?|STD:standard\nE:BashAA?|ERR:error\n$")

--- a/rebench/tests/model/consistent_eq_and_serialization_test.py
+++ b/rebench/tests/model/consistent_eq_and_serialization_test.py
@@ -1,0 +1,240 @@
+from ast import Module, NodeVisitor, Name, FunctionDef, parse
+from inspect import getsource
+from typing import Any
+
+import pytest
+
+from ...model.benchmark import Benchmark
+from ...model.benchmark_suite import BenchmarkSuite
+from ...model.build_cmd import BuildCommand
+from ...model.executor import Executor
+from ...model.exp_variables import ExpVariables
+from ...model.exp_run_details import ExpRunDetails
+from ...model.profiler import Profiler, PerfProfiler
+from ...model.run_id import RunId
+
+
+class _FieldAccesses(NodeVisitor):
+    def __init__(self):
+        self.fields = set()
+
+    def reset(self):
+        self.fields = set()
+
+    def visit_Attribute(self, node):
+        if isinstance(node.value, Name) and node.value.id == "self":
+            self.fields.add(node.attr)
+
+        self.generic_visit(node)
+
+
+def _get_ast(obj: Any) -> Module:
+    source = getsource(obj)
+    return parse(source)
+
+
+def _get_methods(ast: Module, method_names) -> dict[str, FunctionDef]:
+    result = {}
+
+    clazz = ast.body[0]
+    methods = clazz.body  # type: ignore
+
+    for mn in method_names:
+        found = False
+        for m in methods:
+            if not isinstance(m, FunctionDef):
+                continue
+            if m.name == mn:
+                result[m.name] = m
+                found = True
+                break
+        if not found:
+            raise AttributeError(f"Method {mn} not found in class {clazz.name}")  # type: ignore
+
+    return result
+
+
+def _get_accessed_fields(method: FunctionDef) -> set[str]:
+    visitor = _FieldAccesses()
+    visitor.visit(method)
+    return visitor.fields
+
+
+class _P:
+    def __init__(self, cls, expected_fields, additional_expected_fields=None):
+        self.cls = cls
+        self.method_names = ["as_dict", "__lt__", "__eq__", "__hash__"]
+        self.expected_fields = expected_fields
+        self.additional_expected_fields = additional_expected_fields
+
+    def __str__(self):
+        return self.cls.__name__
+
+
+_SAME_FIELD_TEST_CASES = [
+    _P(
+        Benchmark,
+        {"command", "suite", "extra_args", "run_details", "name", "variables"},
+    ),
+    _P(
+        Executor,
+        {
+            "action",
+            "path",
+            "executable",
+            "args",
+            "name",
+            "description",
+            "build",
+            "run_details",
+            "variables",
+        },
+    ),
+    _P(
+        BenchmarkSuite,
+        {"command", "location", "executor", "name", "build", "_desc"},
+    ),
+    _P(
+        ExpRunDetails,
+        {
+            "env",
+            "warmup",
+            "max_invocation_time",
+            "min_iteration_time",
+            "invocations",
+            "iterations",
+            "ignore_timeouts",
+            "parallel_interference_factor",
+            "execute_exclusively",
+            "retries_after_failure",
+            "invocations_override",
+            "iterations_override",
+        },
+    ),
+    _P(
+        ExpVariables,
+        {"input_sizes", "cores", "variable_values", "tags"},
+    ),
+    _P(
+        RunId,
+        {"cores", "input_size", "var_value", "tag", "benchmark"},
+        {"as_dict": {"cmdline", "location"}},
+    ),
+    _P(
+        BuildCommand,
+        {"command"},
+        {"__lt__": {"location"}, "__eq__": {"location"}, "__hash__": {"location"}},
+    ),
+    _P(
+        PerfProfiler,
+        {"name", "record_args", "report_args"},
+    ),
+]
+
+
+@pytest.mark.parametrize("p", _SAME_FIELD_TEST_CASES, ids=lambda p: p.cls.__name__)
+def test_access_same_fields(p):
+    """
+    The tests here should make sure that the as_dict(), from_dict(), equal_as_part_of_run_id(),
+    and less_then_as_part_of_run_id() methods use the same fields.
+    """
+    ast = _get_ast(p.cls)
+    selected_methods = _get_methods(ast, p.method_names)
+
+    for m_name in p.method_names:
+        accessed_fields = _get_accessed_fields(selected_methods[m_name])
+
+        accessed_fields -= {"__class__", "_hash"}
+        expected_fields = p.expected_fields
+
+        if p.additional_expected_fields and m_name in p.additional_expected_fields:
+            expected_fields = expected_fields.union(
+                p.additional_expected_fields[m_name]
+            )
+        assert accessed_fields == expected_fields, "Method " + str(m_name)
+
+
+_EXP_RUN_DETAILS_DATA = {
+    "env": {"a": "b"},
+    "warmup": 1,
+    "maxInvocationTime": 2,
+    "minIterationTime": 3,
+}
+
+_PROF_DATA = [
+    {"name": "perf", "record_args": "record-args", "report_args": "report-args"}
+]
+
+_VAR_DATA = {
+    "input_sizes": [1, 2, 3],
+    "cores": [4, 5, 6],
+    "variable_values": ["a", "b", "c"],
+    "tags": ["x", "y", "z"],
+}
+
+_EXECUTOR_DATA = {
+    "name": "exe",
+    "executable": "binary",
+    "path": "/path",
+    "action": "benchmark",
+    "args": "a b c d",
+    "desc": "test desc",
+    "build": "some script\nwith multiple lines",
+    "runDetails": _EXP_RUN_DETAILS_DATA,
+    "variables": _VAR_DATA,
+}
+
+_BENCH_SUITE_DATA = {
+    "name": "a-suite",
+    "command": "a-suite-command",
+    "location": "/suite-path",
+    "desc": "suite-desc",
+    "executor": _EXECUTOR_DATA,
+    "build": "suite build script\nwith multiple lines",
+}
+
+_BENCHMARK_DATA = {
+    "name": "a-name",
+    "command": "a-command",
+    "runDetails": _EXP_RUN_DETAILS_DATA,
+    "suite": _BENCH_SUITE_DATA,
+    "extra_args": "some extra args",
+    "variables": _VAR_DATA,
+}
+
+
+_RUN_ID_DATA = {
+    "benchmark": _BENCHMARK_DATA,
+    "cmdline": "a-cmdline",
+    "cores": 1,
+    "inputSize": "an input-size",
+    "varValue": "a-varval",
+    "tag": "a-tag",
+    "extraArgs": "some extra args",
+    "location": "/suite-path",
+}
+
+_SER_TEST_CASES = [
+    [ExpRunDetails, [_EXP_RUN_DETAILS_DATA]],
+    [Benchmark, [_BENCHMARK_DATA]],
+    [Executor, [_EXECUTOR_DATA]],
+    [BenchmarkSuite, [_BENCH_SUITE_DATA]],
+    [RunId, [_RUN_ID_DATA]],
+    [BuildCommand, ["script", "location"]],
+    [ExpVariables, [_VAR_DATA]],
+    [Profiler, [_PROF_DATA]],
+]
+
+
+@pytest.mark.parametrize("cls, data", _SER_TEST_CASES)
+def test_serialization_deserialization_and_equality(cls, data):
+    obj = cls.from_dict(*data)
+    if cls is Profiler:
+        assert isinstance(obj, list)
+        assert len(obj) == 1
+        assert obj[0].as_dict() == data[0][0]
+    else:
+        assert obj.as_dict() == data[0]
+
+    obj2 = cls.from_dict(*data)
+    assert obj == obj2

--- a/rebench/tests/model/run_id_test.conf
+++ b/rebench/tests/model/run_id_test.conf
@@ -1,0 +1,75 @@
+# Config file for ReBench
+# Config format is YAML (see http://yaml.org/ for detailed spec)
+
+# this run definition will be chosen if no parameters are given to rebench.py
+default_experiment: all
+default_data_file:  'small.data'
+
+# general configuration for runs
+runs:
+    invocations:  10
+    retries_after_failure: 3
+
+benchmark_suites:
+    Suite:
+        gauge_adapter: TestExecutor
+        command: Bench ~/suiteFolder/%(benchmark)s -message "a string with a ~"
+        variable_values: [ 'var1', 'var2' ]
+        benchmarks:
+            - Bench1
+            - Bench2
+
+executors:
+    TestRunner1:
+        path: ~/tests
+        executable: vm1.py %(cores)s
+        args: '-cp ~/foo:~/bar'
+        cores: [ 1 ]
+        env:
+            PATH: /usr/bin:/bin:~/bin
+            WORKDIR: ~/work
+        profiler: { perf: {} }
+
+    TestRunner2:
+        path: ~/tests
+        executable: vm2.py %(cores)s
+        args: '-cp ~/foo:~/bar'
+        cores: [ 1 ]
+        env:
+            PATH: /bin:~/bin
+            WORKDIR: ~/work2
+        profiler: { perf: {} }
+
+    TestRunner3:
+        path: ~/tests
+        executable: vm2.py %(cores)s
+        args: '-cp ~/foo:~/bar'
+        cores: [ 1 ]
+        env:
+            PATH: /bin:~/bin3
+            WORKDIR: ~/work3
+        profiler: { perf: {} }
+
+experiments:
+    TestBenchmark1:
+        suites:
+            - Suite
+        executions:
+            - TestRunner1
+            - TestRunner2
+            - TestRunner3
+
+    TestBenchmark2:
+        suites:
+            - Suite
+        executions:
+            - TestRunner1
+
+    TestProfile:
+        action: profile
+        suites:
+            - Suite
+        executions:
+            - TestRunner1
+            - TestRunner2
+            - TestRunner3

--- a/rebench/tests/model/run_id_test.py
+++ b/rebench/tests/model/run_id_test.py
@@ -1,0 +1,168 @@
+from ...configurator import Configurator, load_config
+from ...persistence import DataStore
+from ..rebench_test_case import ReBenchTestCase
+
+
+class RunIdTest(ReBenchTestCase):
+    def setUp(self):
+        super(RunIdTest, self).setUp()
+        self._cnf = Configurator(
+            load_config(self._path + "/model/run_id_test.conf"),
+            DataStore(self.ui),
+            self.ui,
+            None,
+            data_file=self._tmp_file,
+        )
+        self._runs = sorted(list(self._cnf.get_runs()))
+
+    def test_basic_equality(self):
+        # this one is a bit silly, because get_runs() returns a set...
+        num_runs = 24
+        self.assertEqual(len(self._runs), num_runs)
+        for i in range(0, num_runs):
+            for j in range(0, num_runs):
+                if i == j:
+                    self.assertEqual(self._runs[i], self._runs[j])
+                else:
+                    self.assertNotEqual(self._runs[i], self._runs[j])
+
+    def test_equality_with_env_settings(self):
+        """We expect both, the run_id from TestRunner2 and TestRunner3 to be in the list"""
+        has_test_runner2 = False
+        has_test_runner3 = False
+
+        run2 = None
+        run3 = None
+
+        for run in self._runs:
+            if run.benchmark.name == "Bench1":
+                if run.benchmark.suite.executor.name == "TestRunner2":
+                    has_test_runner2 = True
+                    run2 = run
+                elif run.benchmark.suite.executor.name == "TestRunner3":
+                    has_test_runner3 = True
+                    run3 = run
+
+        self.assertTrue(has_test_runner2)
+        self.assertTrue(has_test_runner3)
+
+        # trivially true, because they come out of a set
+        self.assertNotEqual(run2, run3)
+        self.assertNotEqual(run2.env["PATH"], run3.env["PATH"])
+        self.assertNotEqual(run2.env["WORKDIR"], run3.env["WORKDIR"])
+
+    def test_equality_with_non_cmdline_settings(self):
+        """
+        Even so the command line does not capture the variable_values, we expect separate run_ids.
+        """
+        has_var1 = False
+        has_var2 = False
+
+        run1 = None
+        run2 = None
+
+        for run in self._runs:
+            if run.benchmark.name == "Bench1":
+                if run.var_value == "var1":
+                    has_var1 = True
+                    run1 = run
+                elif run.var_value == "var2":
+                    has_var2 = True
+                    run2 = run
+
+        self.assertTrue(has_var1)
+        self.assertTrue(has_var2)
+
+        # trivially true, because they come out of a set
+        self.assertNotEqual(run1, run2)
+
+        self.assertNotEqual(run1.var_value, run2.var_value)
+
+    def test_action_makes_difference(self):
+        """We expect one run_id for action=profile and one for action=benchmark."""
+        has_profile = False
+        has_benchmark = False
+
+        run_profile = None
+        run_benchmark = None
+
+        for run in self._runs:
+            if run.benchmark.name == "Bench1":
+                if run.is_profiling():
+                    has_profile = True
+                    run_profile = run
+                else:
+                    has_benchmark = True
+                    run_benchmark = run
+
+        self.assertTrue(has_profile)
+        self.assertTrue(has_benchmark)
+
+        # trivially true, because they come out of a set
+        self.assertNotEqual(run_profile, run_benchmark)
+
+        self.assertEqual(run_profile.benchmark.suite.executor.action, "profile")
+        self.assertEqual(run_benchmark.benchmark.suite.executor.action, "benchmark")
+
+    def test_as_dict(self):
+        """Check that as_dict returns the expected information. This is only a very basic test."""
+        self.assertEqual(
+            self._runs[0].as_dict(),
+            {
+                "benchmark": {
+                    "command": "Bench1",
+                    "name": "Bench1",
+                    "runDetails": {
+                        "env": {"PATH": "/usr/bin:/bin:~/bin", "WORKDIR": "~/work"},
+                        "execute_exclusively": True,
+                        "invocations": 10,
+                        "iterations": 1,
+                        "maxInvocationTime": -1,
+                        "minIterationTime": 50,
+                        "retries_after_failure": 3,
+                    },
+                    "suite": {
+                        "command": "Bench ~/suiteFolder/%(benchmark)s "
+                        '-message "a string with a ~"',
+                        "executor": {
+                            "action": "benchmark",
+                            "args": "-cp ~/foo:~/bar",
+                            "executable": "vm1.py %(cores)s",
+                            "name": "TestRunner1",
+                            "path": "~/tests",
+                            "runDetails": {
+                                "env": {
+                                    "PATH": "/usr/bin:/bin:~/bin",
+                                    "WORKDIR": "~/work",
+                                },
+                                "execute_exclusively": True,
+                                "invocations": 10,
+                                "iterations": 1,
+                                "maxInvocationTime": -1,
+                                "minIterationTime": 50,
+                                "retries_after_failure": 3,
+                            },
+                            "variables": {
+                                "cores": [1],
+                                "input_sizes": [""],
+                                "tags": [None],
+                                "variable_values": [""],
+                            },
+                        },
+                        "location": "~/tests",
+                        "name": "Suite",
+                    },
+                    "variables": {
+                        "cores": [1],
+                        "input_sizes": [""],
+                        "tags": [None],
+                        "variable_values": ["var1", "var2"],
+                    },
+                },
+                "cmdline": "~/tests/vm1.py 1 -cp ~/foo:~/bar Bench ~/suiteFolder/Bench1 "
+                '-message "a string with a ~"',
+                "cores": 1,
+                "location": "~/tests",
+                "varValue": "var1",
+            },
+        )

--- a/rebench/tests/reporter_test.py
+++ b/rebench/tests/reporter_test.py
@@ -65,7 +65,8 @@ class ReporterTest(ReBenchTestCase):
         self._run_benchmarks_and_do_reporting(False)
         reporter = TextReporter()
         sorted_rows, used_cols, summary = reporter._generate_all_output(self._runs)
-        self.assertEqual(38, len(sorted_rows))
+        self.assertEqual(40, len(sorted_rows))
+        self.assertEqual(1, len(summary))
         self.assertEqual(len(reporter.expected_columns) - 1, len(sorted_rows[0]))
         self.assertEqual(['Benchmark', 'Executor', 'Suite', 'Extra', 'Core', 'Size', 'Var',
              'Tag', 'Mean (ms)'], used_cols)

--- a/rebench/tests/test.conf
+++ b/rebench/tests/test.conf
@@ -44,7 +44,7 @@ benchmark_suites:
             - machine1
     TestSuite2:
         gauge_adapter: TestExecutor
-        command: TestBenchMarks %(benchmark)s %(input)s %(variable)s
+        command: TestBenchMarks %(benchmark)s %(input)s var
         input_sizes: [100, 1000]
         cores: [7, 13]
         benchmarks:
@@ -73,8 +73,7 @@ executors:
         path: tests
         executable: test-vm1.py %(cores)s
         cores: [1, 4]
-        ## This requests ReBench to execute all benchmarks on this executor without
-        ## any other benchmarks in parallel.
+        ## This requests ReBench to execute benchmarks on this executor in parallel.
         ## true is the standard setting
         execute_exclusively: false
 
@@ -84,7 +83,7 @@ executors:
         ## This requests ReBench to execute all benchmarks on this executor without
         ## any other benchmarks in parallel.
         ## true is the standard setting
-        execute_exclusively: false
+        execute_exclusively: true
         profiler:
           perf: {}
 

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,15 @@ setup(name='ReBench',
           'py-cpuinfo==9.0.0',
           'psutil>=5.9.5'
       ],
-      entry_points = {
-          'console_scripts' : [
+      test_require=[
+          'pytest>=7.2.2'
+      ],
+      entry_points={
+          'console_scripts': [
               'rebench = rebench.rebench:main_func',
               'rebench-denoise = rebench.denoise:main_func'
           ]
       },
-      test_suite = 'rebench.tests',
-      license = 'MIT'
+      test_suite='rebench.tests',
+      license='MIT'
 )


### PR DESCRIPTION
This PR is in preparation for the support of https://github.com/smarr/ReBench/issues/257, which will add machine and denoise configuration support.
Though, it’s also useful without, because it allows us to distinguish RunIds that differ in their environment variables, for instance. Or more generally, RunIds that differ based on any property that is not strictly part of the command line, which is was previously used to establish equality.

This as a consequence means, we have a much weaker ability to determine equality of RunIds than before, but I think that’s fine and less surprising/buggy. It consequently undos some of #4.
On the other hand, it should be everything needed to resolve #119.

The main changes are a proper implementation of the `__eq__`, `__lt__`, and `__hash__` methods, as well as the serialization of RunIds into the data file, and deserialization when loading a data file.

This change includes some minor refactorings, because it is split from a too huge and unmanageable patch.

Minor refactorings:
 - configurator: extract config validation and assembling of run details
 - executor: use exe name and suite name directly in indicate_build
 - executor/BuildCommand: location is in BuildCommand only for equality, but semantically, we should use the location/path of the suite/executor when processing the build command. That’s now made explicit, and asserted for correctness.
 - BuildCommand is now storing only the command, since the location is used from suite/exe

TODO:
 - [x] make sure #119 is fully addressed
 - [x] check #21 and #4