### PR TITLE
Add support for machine-specific settings

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -99,6 +99,7 @@ The priorities are, starting with highest:
 4. experiment
 5. experiments
 6. runs (as defined by the [root element](#root-elements))
+7. machine
 
 So, in the case of the `input_sizes` example, the setting for `benchmark`
 overrides the settings in a suite or executor.
@@ -179,6 +180,7 @@ be used, and each contains structural elements further detailed below.
 
 - `runs`
 - `reporting`
+- `machines`
 - `benchmark_suites`
 - `executors`
 - `experiments`
@@ -458,6 +460,28 @@ reporting:
     repo_url:     https://example.org/project.git
     project_name: Some Project that Wants Good Performance
     record_all:   true
+```
+
+---
+
+## Machines
+
+The `machines` key defines machine-specific configuration.
+This configuration is applied when `rebench` is run with the `-m|--machine` option.
+
+The configuration for a machine can contain a brief description
+to document the purpose of the machine, as well as the keys for [run details](#runs) and
+[variables](#benchmark).
+
+For example, for experiments that show scalability, one may want to configure different
+number of cores to run on:
+
+```yaml
+machines:
+  small-machine:
+    cores: [1, 2, 4, 8]
+  large-machine:
+    cores: [1, 2, 4, 8, 16, 32, 64, 128]
 ```
 
 ---

--- a/rebench/model/experiment.py
+++ b/rebench/model/experiment.py
@@ -85,7 +85,7 @@ class Experiment(object):
                             if not configurator.run_filter.applies_to_tag(tag):
                                 continue
                             run = self._data_store.create_run_id(
-                                bench, cores, input_size, var_val, tag)
+                                bench, cores, input_size, var_val, tag, configurator.machine)
                             runs.add(run)
                             run.add_reporting(self._reporting)
                             run.add_persistence(self._persistence)

--- a/rebench/persistence.py
+++ b/rebench/persistence.py
@@ -85,14 +85,17 @@ class DataStore(object):
             self._files[filename] = p
         return self._files[filename]
 
-    def create_run_id(self, benchmark: Benchmark, cores, input_size, var_value, tag):
+    def create_run_id(self, benchmark: Benchmark, cores, input_size, var_value, tag, machine):
         if isinstance(cores, str) and cores.isdigit():
             cores = int(cores)
         if input_size == "":
             input_size = None
         if var_value == "":
             var_value = None
-        run = RunId(benchmark, cores, input_size, var_value, tag)
+        if machine == "":
+            machine = None
+
+        run = RunId(benchmark, cores, input_size, var_value, tag, machine)
         return self._ensure_run_id_objects_are_unique(run)
 
     def create_benchmark_from_dict(self, d):

--- a/rebench/rebench-schema.yml
+++ b/rebench/rebench-schema.yml
@@ -141,6 +141,19 @@ schema;variables:
       sequence:
         - type: scalar
 
+schema;machine_type:
+  desc: |
+    settings for a specific machine
+  type: map
+  mapping:
+    <<: [ *EXP_RUN_DETAILS, *EXP_VARIABLES ]
+    description:
+      type: str
+      desc: Description of the machine
+    desc:
+      type: str
+      desc: Description of the machine
+
 schema;benchmark_type_str:
   type: str
   desc: The name of a benchmark, can be simply the name.
@@ -352,6 +365,11 @@ mapping:
     include: runs_type
   reporting:
     include: reporting_type
+  machines:
+    type: map
+    mapping:
+      regex;(.+):
+        include: machine_type
   benchmark_suites:
     type: map
     mapping:

--- a/rebench/rebench.py
+++ b/rebench/rebench.py
@@ -115,6 +115,8 @@ Argument:
             '-B', '--without-building', action='store_false', dest='do_builds',
             help='Disables execution of build commands for executors and suites.',
             default=True)
+        execution.add_argument('-m', '--machine', action='store', dest='machine',
+                               default=None, help='Name of the machine configuration to be used.')
         execution.add_argument(
             '-s', '--scheduler', action='store', dest='scheduler',
             default='batch',
@@ -251,7 +253,7 @@ Argument:
             config = load_config(args.config[0])
             self._config = Configurator(config, data_store, self.ui, args,
                                         cli_reporter, exp_name, args.data_file,
-                                        args.build_log, exp_filter)
+                                        args.build_log, exp_filter, args.machine)
         except ConfigurationError as exc:
             raise UIError(exc.message + "\n", exc)
         except ValueError as exc:

--- a/rebench/reporter.py
+++ b/rebench/reporter.py
@@ -62,7 +62,7 @@ class TextReporter(Reporter):
     def __init__(self):
         super(TextReporter, self).__init__()
         self.expected_columns = ['Benchmark', 'Executor', 'Suite', 'Extra', 'Core', 'Size', 'Var',
-             'Tag', '#Samples', 'Mean (ms)']
+             'Tag', 'Machine', '#Samples', 'Mean (ms)']
 
     @staticmethod
     def _path_to_string(path):
@@ -102,7 +102,7 @@ class TextReporter(Reporter):
                 column_value_sets[i].add(v)
             rows.append(out)
 
-        sorted_rows = sorted(rows, key=itemgetter(2, 1, 3, 4, 5, 6, 7))
+        sorted_rows = sorted(rows, key=itemgetter(2, 1, 3, 4, 5, 6, 7, 8))
 
         if len(sorted_rows) <= 4:
             return sorted_rows, self.expected_columns, None

--- a/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
+++ b/rebench/tests/bugs/issue_4_run_equality_and_params_test.py
@@ -39,7 +39,7 @@ class Issue4RunEquality(unittest.TestCase):
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite, None,
                               '3', ExpRunDetails.empty(), None)
-        return RunId(benchmark, 1, 2, None, None)
+        return RunId(benchmark, 1, 2, None, None, None)
 
     @staticmethod
     def _create_hardcoded_run_id():
@@ -49,7 +49,7 @@ class Issue4RunEquality(unittest.TestCase):
                                None, None, [], None, None, None)
         benchmark = Benchmark("TestBench", "TestBench", None, suite,
                               None, None, ExpRunDetails.empty(), None)
-        return RunId(benchmark, 1, None, None, None)
+        return RunId(benchmark, 1, None, None, None, None)
 
     def test_hardcoded_equals_template_constructed(self):
         hard_coded = self._create_hardcoded_run_id()

--- a/rebench/tests/model/consistent_eq_and_serialization_test.py
+++ b/rebench/tests/model/consistent_eq_and_serialization_test.py
@@ -117,7 +117,7 @@ _SAME_FIELD_TEST_CASES = [
     ),
     _P(
         RunId,
-        {"cores", "input_size", "var_value", "tag", "benchmark"},
+        {"cores", "input_size", "var_value", "tag", "benchmark", "machine"},
         {"as_dict": {"cmdline", "location"}},
     ),
     _P(

--- a/rebench/tests/persistency_test.py
+++ b/rebench/tests/persistency_test.py
@@ -51,7 +51,7 @@ class PersistencyTest(ReBenchTestCase):
                               suite, None, None, ExpRunDetails.default(None, None),
                               None)
 
-        run_id = RunId(benchmark, 1000, 44, 'sdf sdf sdf sdfsf', 'tag11')
+        run_id = RunId(benchmark, 1000, 44, 'sdf sdf sdf sdfsf', 'tag11', 'machine-22')
         measurement = Measurement(43, 45, 2222.2222, 'ms', run_id, 'foobar crit')
 
         id_to_run_id = [run_id]

--- a/rebench/tests/reporter_test.py
+++ b/rebench/tests/reporter_test.py
@@ -66,12 +66,14 @@ class ReporterTest(ReBenchTestCase):
         reporter = TextReporter()
         sorted_rows, used_cols, summary = reporter._generate_all_output(self._runs)
         self.assertEqual(40, len(sorted_rows))
-        self.assertEqual(1, len(summary))
-        self.assertEqual(len(reporter.expected_columns) - 1, len(sorted_rows[0]))
+        self.assertEqual(2, len(summary))
+        self.assertEqual(len(reporter.expected_columns) - 2, len(sorted_rows[0]))
         self.assertEqual(['Benchmark', 'Executor', 'Suite', 'Extra', 'Core', 'Size', 'Var',
              'Tag', 'Mean (ms)'], used_cols)
-        self.assertEqual('#Samples', summary[0][0])
-        self.assertEqual(0, summary[0][1])
+        self.assertEqual('Machine', summary[0][0])
+        self.assertEqual('', summary[0][1])
+        self.assertEqual('#Samples', summary[1][0])
+        self.assertEqual(0, summary[1][1])
 
     def test_text_reporter_summary_table_4_runs(self):
         self._run_benchmarks_and_do_reporting(False)


### PR DESCRIPTION
This PR adds the ability add machine-specific configuration to the config file and then select it by name when running `rebench` on the command line.

One use could be to run benchmarks with different settings depending on the availability of hardware resources. For example, with a small and a large machine:

```yaml
machines:
  small-machine:
    cores: [1, 2, 4, 8]
  large-machine:
    cores: [1, 2, 4, 8, 16, 32, 64, 128]
```

This can then be used by running rebench like this:

```bash
rebench rebench.conf -m large-machine
```

A machine setting is part of the normal composition process of configurations.
It is the new lowest level, i.e., with lowest priority.
This means, that in the above example, a `cores:` setting in a benchmark would override the setting.

This realizes part of #257.