### PR TITLE
Use pip install —editable to avoid incorrect coverage reporting.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         if: matrix.coverage
 
       - name: Install ReBench dependencies
-        run: pip install .
+        run: pip install --editable .
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Because the package is installed, we get duplicate file details from coverage tracking. This resolves the issue and avoids incorrect coverage reporting.