### PR TITLE
Enable denoise.py to work as script to avoid need for PYTHONPATH in env

### DIFF
--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import json
 import os
 import sys
@@ -7,13 +8,21 @@ from math import log, floor
 from multiprocessing import Pool
 from subprocess import check_output, CalledProcessError, DEVNULL, STDOUT
 
-from .output import output_as_str, UIError
-from .subprocess_kill import kill_process
+denoise_py = os.path.abspath(__file__)
 
-try:
-    from . import __version__ as rebench_version
-except ValueError:
-    rebench_version = "unknown"
+if __name__ == "__main__":
+    # ensure that the rebench module is available
+    rebench_module = os.path.dirname(denoise_py)
+    sys.path.append(os.path.dirname(rebench_module))
+
+    # pylint: disable-next=import-error
+    from output import output_as_str, UIError  # type: ignore
+
+    # pylint: disable-next=import-error
+    from subprocess_kill import kill_process  # type: ignore
+else:
+    from .output import output_as_str, UIError
+    from .subprocess_kill import kill_process
 
 
 class CommandsPaths:
@@ -23,7 +32,6 @@ class CommandsPaths:
         self._cset_path = None
         self._denoise_path = None
         self._which_path = None
-        self._denoise_python_path = None
 
     def get_which(self):
         if not self._which_path:
@@ -75,30 +83,20 @@ class CommandsPaths:
 
     def has_denoise(self):
         if self._denoise_path is None:
-            self._denoise_path = self._absolute_path_for_command(
-                "rebench-denoise", ["--version"]
-            )
+            self._denoise_path = denoise_py
 
         return self._denoise_path is not None and self._denoise_path is not False
 
     def get_denoise(self):
         if not self.has_denoise():
             raise UIError(
-                "rebench-denoise not found. "
-                "Was ReBench installed so that `rebench` and `rebench-denoise` are on the PATH? "
-                "Python's bin directory for packages may need to be added to PATH manually.\n\n"
-                "To use ReBench without rebench-denoise, use the --no-denoise option.\n",
+                f"{denoise_py} not found. "
+                "Could it be that the user has no access to the file? "
+                "To use ReBench without denoise, use the --no-denoise option.\n",
                 None,
             )
 
         return self._denoise_path
-
-    def get_denoise_python_path(self):
-        if self._denoise_python_path is None:
-            current_file = os.path.abspath(__file__)
-            self._denoise_python_path = os.path.dirname(os.path.dirname(current_file))
-
-        return self._denoise_python_path
 
 
 paths = CommandsPaths()
@@ -353,9 +351,6 @@ def _test(num_cores):
 
 def _shell_options():
     parser = ArgumentParser()
-    parser.add_argument(
-        "--version", action="version", version="%(prog)s " + rebench_version
-    )
     parser.add_argument(
         "--json",
         action="store_true",

--- a/rebench/denoise.py
+++ b/rebench/denoise.py
@@ -81,21 +81,29 @@ class CommandsPaths:
     def set_cset(self, cset_path):
         self._cset_path = cset_path
 
-    def has_denoise(self):
+    def ensure_denoise(self):
         if self._denoise_path is None:
-            self._denoise_path = denoise_py
+            if os.access(denoise_py, os.X_OK):
+                self._denoise_path = denoise_py
+            elif not os.path.isfile(denoise_py):
+                raise UIError(
+                    f"{denoise_py} not found. "
+                    "Could it be that the user has no access to the file? "
+                    "To use ReBench without denoise, use the --no-denoise option.\n",
+                    None,
+                )
+            else:
+                raise UIError(
+                    f"{denoise_py} not marked executable. "
+                    f"Please run something similar to `chmod a+x {denoise_py}`. "
+                    "To use ReBench without denoise, use the --no-denoise option.\n",
+                    None,
+                )
 
         return self._denoise_path is not None and self._denoise_path is not False
 
     def get_denoise(self):
-        if not self.has_denoise():
-            raise UIError(
-                f"{denoise_py} not found. "
-                "Could it be that the user has no access to the file? "
-                "To use ReBench without denoise, use the --no-denoise option.\n",
-                None,
-            )
-
+        self.ensure_denoise()
         return self._denoise_path
 
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Optional
 
 from . import subprocess_with_timeout as subprocess_timeout
 from .denoise import paths as denoise_paths
-from .denoise_client import add_denoise_python_path_to_env, get_number_of_cores
+from .denoise_client import get_number_of_cores
 from .interop.adapter import ExecutionDeliveredNoResults, instantiate_adapter, OutputNotParseable, \
     ResultsIndicatedAsInvalid
 from .model.build_cmd import BuildCommand
@@ -346,7 +346,7 @@ class Executor(object):
 
     def _construct_cmdline(self, run_id, gauge_adapter):
         num_cores = get_number_of_cores()
-        env = add_denoise_python_path_to_env(run_id.env)
+        env = run_id.env
         cmdline = ""
 
         if self.use_denoise:
@@ -534,7 +534,7 @@ class Executor(object):
             location = run_id.location
             if location:
                 location = os.path.expanduser(location)
-            env = add_denoise_python_path_to_env(run_id.env)
+            env = run_id.env
 
             self.ui.debug_output_info("{ind}Starting run\n", run_id, cmdline, location, env)
 

--- a/rebench/tests/features/issue_42_test.py
+++ b/rebench/tests/features/issue_42_test.py
@@ -138,8 +138,8 @@ class Issue42SupportForEnvironmentVariables(ReBenchTestCase):
 
         self.assertRegex(
             ex._construct_cmdline(runs[0], TimeManualAdapter(False, ex)),
-            r" --preserve-env=IMPORTANT_ENV_VARIABLE,ALSO_IMPORTANT,PYTHONPATH " +
-            r"[^\s]*rebench-denoise")
+            r" --preserve-env=IMPORTANT_ENV_VARIABLE,ALSO_IMPORTANT " +
+            r"[^\s]*denoise\.py")
 
     def test_construct_cmdline_build_with_env(self):
         cnf = Configurator(load_config(self._path + '/issue_42.conf'), DataStore(self.ui),
@@ -148,7 +148,7 @@ class Issue42SupportForEnvironmentVariables(ReBenchTestCase):
         ex = Executor(runs, True, self.ui, use_nice=True, use_shielding=True)
 
         self.assertRegex(ex._construct_cmdline(runs[0], TimeManualAdapter(False, ex)),
-                         r" --preserve-env=VAR1,VAR3,PYTHONPATH [^\s]*rebench-denoise")
+                         r" --preserve-env=VAR1,VAR3 [^\s]*denoise\.py")
 
     def _assert_empty_standard_env(self, log_remainder):
         env_parts = log_remainder.split(":")

--- a/rebench/tests/features/issue_42_vm.py
+++ b/rebench/tests/features/issue_42_vm.py
@@ -13,7 +13,7 @@ print(env)
 
 known_envvars = ["PWD", "SHLVL", "VERSIONER_PYTHON_VERSION",
                  "_", "__CF_USER_TEXT_ENCODING", "LC_CTYPE",
-                 "CPATH", "LIBRARY_PATH", "MANPATH", "SDKROOT", "PYTHONPATH"]
+                 "CPATH", "LIBRARY_PATH", "MANPATH", "SDKROOT"]
 
 if test == "as-expected":
     if os.environ.get("IMPORTANT_ENV_VARIABLE", None) != "exists":

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,24 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import sys
+import os
+import stat
 
 from setuptools import setup, find_packages
+from setuptools.command.install import install
 from rebench import __version__ as rebench_version
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+class InstallAndSetDenoisePermissions(install):
+    def run(self):
+        install.run(self)
+        install_path = os.path.join(self.install_lib, "rebench")
+        denoise_path = os.path.join(install_path, "denoise.py")
+        if os.path.exists(denoise_path):
+            st = os.stat(denoise_path)
+            os.chmod(denoise_path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 setup(name='ReBench',
       version=rebench_version,
@@ -53,6 +64,8 @@ setup(name='ReBench',
               'rebench-denoise = rebench.denoise:main_func'
           ]
       },
+      scripts=['rebench/denoise.py'],
+      cmdclass={'install': InstallAndSetDenoisePermissions},
       test_suite='rebench.tests',
       license='MIT'
 )


### PR DESCRIPTION
This PR does away with some of the complexity around the `rebench-denoise` command when used directly from rebench.

`denoise.py` is now an executable script with a shebang line, and executed directly.
While `rebench-denoise` is convenient for command-line users, it expects a proper setup of Python and a `PYTHONPATH` that allows the launcher script (generated by pip) to find the actual implementation.
This meant we had to set `PYTHONPATH` when using sudo to run `rebench-denoise` (as per #260), which could possibly interfere with Python programs running.

#### Minor Changes

- make `denoise.py` executable for all
- `denoise.py`/`rebench-denoise` does not support `--version` any longer, but that seems like an ok tradeoff


#### Related Issues
 - https://github.com/smarr/ReBench/pull/238
 - https://github.com/smarr/ReBench/pull/260, introduced setting the `PYTHONPATH`
 - https://github.com/smarr/ReBench/pull/273 did already remove some of the need for `PYTHONPATH`

@martinmcclure this might impact you
@vext01 and you possibly, too.