### PR TITLE
Avoid shell-escaping of env vars

### DIFF
--- a/rebench/model/run_id.py
+++ b/rebench/model/run_id.py
@@ -313,6 +313,8 @@ class RunId(object):
         return self._construct_cmdline()
 
     def _expand_user(self, possible_path):
+        something_changed = False
+
         # split will change the type of quotes, which may cause issues with shell variables
         parts = shlex.split(possible_path)
         for i, part in enumerate(parts):
@@ -320,8 +322,12 @@ class RunId(object):
             if "~" in expanded and ":" in expanded:
                 path_list = expanded.split(":")
                 expanded = ":".join([os.path.expanduser(p) for p in path_list])
-            parts[i] = expanded
-        return shlex.join(parts)
+            if parts[i] != expanded:
+                something_changed = True
+                parts[i] = expanded
+        if something_changed:
+            return shlex.join(parts)
+        return possible_path
 
     def cmdline_for_next_invocation(self):
         """Replace the invocation number in the command line"""

--- a/rebench/tests/bugs/env_quote.conf
+++ b/rebench/tests/bugs/env_quote.conf
@@ -1,0 +1,22 @@
+default_experiment: Test
+
+benchmark_suites:
+    Suite:
+        gauge_adapter: Time
+        command: TestBenchMarks %(benchmark)s %(warmup)s
+        benchmarks:
+          - Bench1
+        env:
+          LUA_PATH: "?.lua;../../awfy/Lua/?.lua"
+
+executors:
+    TestRunner1:
+        path: .
+        executable: env_quote_vm.py
+
+experiments:
+    Test:
+        suites:
+          - Suite
+        executions:
+          - TestRunner1

--- a/rebench/tests/bugs/env_quote_test.py
+++ b/rebench/tests/bugs/env_quote_test.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2009-2025 Stefan Marr <https://www.stefan-marr.de/>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+from ...configurator import Configurator, load_config
+from ...executor import Executor
+from ...persistence import DataStore
+
+from ..rebench_test_case import ReBenchTestCase
+
+
+class EnvQuoteTest(ReBenchTestCase):
+
+    def setUp(self):
+        super(EnvQuoteTest, self).setUp()
+        self._set_path(__file__)
+
+    def test_execution_should_recognize_invalid_run_and_continue_normally(self):
+        cnf = Configurator(
+            load_config(self._path + "/env_quote.conf"),
+            DataStore(self.ui),
+            self.ui,
+            data_file=self._tmp_file,
+        )
+        runs = list(cnf.get_runs())
+        self.assertEqual(runs[0].get_number_of_data_points(), 0)
+
+        ex = Executor([runs[0]], False, self.ui)
+        ex.execute()
+
+        self.assertEqual(runs[0].get_number_of_data_points(), 1)

--- a/rebench/tests/bugs/env_quote_vm.py
+++ b/rebench/tests/bugs/env_quote_vm.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+# get the environemnt variable LUA_PATH
+lua_path = os.environ.get("LUA_PATH", "")
+if lua_path == "?.lua;../../awfy/Lua/?.lua":
+    print("Correct")
+    sys.exit(0)
+else:
+    print("Error: LUA_PATH has unexpected value: " + lua_path)
+    print("Previously we has stray single quotes around the value.")
+    sys.exit(1)

--- a/rebench/tests/model/run_id_test.py
+++ b/rebench/tests/model/run_id_test.py
@@ -1,6 +1,40 @@
+from os.path import expanduser
+import pytest
+
 from ...configurator import Configurator, load_config
+from ...model.run_id import expand_user
 from ...persistence import DataStore
 from ..rebench_test_case import ReBenchTestCase
+
+
+def _simple_expand(path):
+    return path.replace("~", expanduser("~"))
+
+
+def _expand(paths):
+    return [(p, _simple_expand(p)) for p in paths]
+
+
+@pytest.mark.parametrize(
+    "possible_path, after_expansion",
+    _expand(
+        ["~/foo/bar", "~/foo ~/bar -cp ~/here:~/there", "?.lua;../../awfy/Lua/?.lua"]
+    ),
+)
+def test_expand_user_no_escape(possible_path, after_expansion):
+    expanded = expand_user(possible_path, False)
+    assert expanded == after_expansion
+
+
+@pytest.mark.parametrize(
+    "possible_path, after_expansion",
+    _expand(
+        ["~/foo/bar", "~/foo ~/bar -cp ~/here:~/there", "'?.lua;../../awfy/Lua/?.lua'"]
+    ),
+)
+def test_expand_user_with_escape(possible_path, after_expansion):
+    expanded = expand_user(possible_path, True)
+    assert expanded == after_expansion
 
 
 class RunIdTest(ReBenchTestCase):


### PR DESCRIPTION
When we started to expand `~` in environment variables (https://github.com/smarr/ReBench/pull/259), we accidentally added shell escaping.

This PR fixes the issue, by making sure that env variable values are never shell-escaped, and adds a few more specific tests.

@vext01 This is hopefully "good enough" to avoid the problem you were seeing.