### PR TITLE
Make sure to read all data from stdout and stderr

### DIFF
--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -108,6 +108,8 @@ class RunScheduler(object):
 
         art_mean = run.get_mean_of_totals()
         art_unit = run.total_unit
+        if art_unit is None:
+            art_unit = ""
 
         hour, minute, sec = self._estimate_time_left()
 

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -91,27 +91,39 @@ class _SubprocessThread(Thread):
             self.stdout_result = ""
             self.stderr_result = ""
 
+            stdout_eof = False
+            stderr_eof = False
+
             while True:
                 reads = []
 
-                if proc.stdout and not proc.stdout.closed:
+                if proc.stdout and not proc.stdout.closed and not stdout_eof:
                     reads.append(proc.stdout.fileno())
-                if self._stderr == PIPE and proc.stderr and not proc.stderr.closed:
+                if (self._stderr == PIPE and
+                        proc.stderr and
+                        not proc.stderr.closed and
+                        not stderr_eof):
                     reads.append(proc.stderr.fileno())
 
                 if not reads:
                     break
 
-                ret = select(reads, [], [])
+                ret = select(reads, [], [], 0.1)
                 for file_no in ret[0]:
                     if file_no == proc.stdout.fileno():
                         read = output_as_str(proc.stdout.readline())
-                        sys.stdout.write(read)
-                        self.stdout_result += read
+                        if read == "":
+                            stdout_eof = True
+                        else:
+                            sys.stdout.write(read)
+                            self.stdout_result += read
                     if self._stderr == PIPE and file_no == proc.stderr.fileno():
                         read = output_as_str(proc.stderr.readline())
-                        sys.stderr.write(read)
-                        self.stderr_result += read
+                        if read == "":
+                            stderr_eof = True
+                        else:
+                            sys.stderr.write(read)
+                            self.stderr_result += read
         else:
             stdout_r, stderr_r = proc.communicate()
             self.stdout_result = output_as_str(stdout_r)

--- a/rebench/subprocess_with_timeout.py
+++ b/rebench/subprocess_with_timeout.py
@@ -106,6 +106,7 @@ class _SubprocessThread(Thread):
                     reads.append(proc.stderr.fileno())
 
                 if not reads:
+                    proc.wait()
                     break
 
                 ret = select(reads, [], [], 0.1)


### PR DESCRIPTION
This PR changes how data is read from a benchmarking process when we run in verbose mode.

We need to make sure we read all data, thus:
 - read until the channel is closed
 - read until we find an EOF marker

Before returning, we need to wait for the process to terminate, so that we have the return code.

This fixes #289.

@OctaveLarose could you review this?

I debugged it and tried it out on yuria2.