### PR TITLE
Support Python 3.14, drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install and run mypy
         run: |
-          pip install mypy
+          pip install mypy types-PyYAML types-psutil types-humanfriendly
           mypy --install-types --non-interactive rebench
         if: matrix.python-version == '3.14'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: "Ubuntu-latest: Python ${{ matrix.python-version }}"
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -67,10 +67,10 @@ jobs:
     name: "macOS: Python 3.12"
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -101,7 +101,7 @@ jobs:
           apt-get install -y --no-install-recommends time
 
       - name: Checkout ReBench
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install PyTest
         run: pip3 install pytest
@@ -122,7 +122,7 @@ jobs:
       image: rockylinux/rockylinux:9
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install basic tools
         run: dnf install -y which time sudo python3-pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
             python3 -m virtualenv venv
             source venv/bin/activate
           
-            pip install pytest
+            pip install pytest setuptools
             pip install .
     
             pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.13", "pypy3.10"]
+        python-version: ["3.10", "3.14", "pypy3.10"]
         include:
-          - python-version: 3.9
+          - python-version: 3.10
             coverage: "--cov=rebench"
     name: "Ubuntu-latest: Python ${{ matrix.python-version }}"
     steps:
@@ -42,19 +42,19 @@ jobs:
         run: |
           pip install pylint
           pylint rebench
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
 
       - name: Install and run black
         run: |
           pip install black
           black --check rebench
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
 
       - name: Install and run mypy
         run: |
           pip install mypy
           mypy --install-types --non-interactive rebench
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
 
       - name: Upload coverage results to Coveralls
         run: coveralls
@@ -64,7 +64,7 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
-    name: "macOS: Python 3.12"
+    name: "macOS: Python 3.13"
     steps:
       - name: Checkout ReBench
         uses: actions/checkout@v6
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install PyTest
         run: pip install pytest
@@ -116,10 +116,10 @@ jobs:
         run: python3 -m pytest
 
   test-rocky:
-    name: "Rocky Linux: Python 3.9"
+    name: "Rocky Linux 10"
     runs-on: ubuntu-latest
     container:
-      image: rockylinux/rockylinux:9
+      image: rockylinux/rockylinux:10
     steps:
       - name: Checkout ReBench
         uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install Dependencies

--- a/.pylintrc
+++ b/.pylintrc
@@ -30,10 +30,6 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -17,7 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from codecs import open as open_with_enc
 from collections import deque
 from math import floor
 from multiprocessing import cpu_count
@@ -450,7 +449,7 @@ class Executor(object):
         build_command.mark_succeeded()
 
     def process_output(self, name, stdout_result, stderr_result):
-        with open_with_enc(self.build_log, "a", encoding="utf-8") as log_file:
+        with open(self.build_log, "a", encoding="utf-8") as log_file:
             if stdout_result:
                 log_file.write(name + "|STD:")
                 log_file.write(stdout_result)

--- a/rebench/model/__init__.py
+++ b/rebench/model/__init__.py
@@ -75,7 +75,7 @@ def none_or_dict(value) -> Optional[dict[str, Any]]:
 def value_with_optional_details(value, default_details=None):
     if isinstance(value, dict):
         assert len(value) == 1
-        (value, details) = list(value.items())[0]
+        value, details = list(value.items())[0]
     else:
         details = default_details
 

--- a/rebench/tests/configurator_compile_test.py
+++ b/rebench/tests/configurator_compile_test.py
@@ -5,7 +5,6 @@ from ..configurator import validate_config, Configurator
 from ..persistence import DataStore
 from ..ui import TestDummyUI
 
-
 # precedence order/priority, from most important to least important:
 CONFIG_ELEMENTS = [
     "benchmark",

--- a/rebench/tests/features/issue_81_unicode_test.py
+++ b/rebench/tests/features/issue_81_unicode_test.py
@@ -19,8 +19,6 @@
 # IN THE SOFTWARE.
 import os
 
-from codecs import open as open_with_enc
-
 from ...configurator     import Configurator, load_config
 from ...executor         import Executor
 from ...persistence      import DataStore
@@ -49,7 +47,7 @@ class Issue81UnicodeSuite(ReBenchTestCase):
 
         self.assertTrue(os.path.exists(self._path + "/build.log"))
 
-        with open_with_enc(self._path + "/build.log", "r", encoding="utf-8") as build_file:
+        with open(self._path + "/build.log", "r", encoding="utf-8") as build_file:
             log = build_file.read()
 
         unicode_char = chr(22234)


### PR DESCRIPTION
This PR addresses various minor details coming up with Python 3.14:
 - black formatting changes slightly
 - `codec.open` was deprecated but `open` should just work
 - mypy now wants type packages to be loaded