### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: "Ubuntu-latest: Python ${{ matrix.python-version }}"
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -67,10 +67,10 @@ jobs:
     name: "macOS: Python 3.13"
     steps:
       - name: Checkout ReBench
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.14", "pypy3.10"]
+        python-version: ["3.11", "3.14", "pypy3.11"]
         include:
-          - python-version: 3.10
+          - python-version: 3.11
             coverage: "--cov=rebench"
     name: "Ubuntu-latest: Python ${{ matrix.python-version }}"
     steps:


### PR DESCRIPTION
Python 3.10 is going to be EOL soon. This PR removes it from testing.

Though, technically, a subset is tested on MacOS still.
The system Python is 3.9, which means the `denoise.py` called with `sudo`, needs to remain Python 3.9 compatible.