### PR TITLE
Add coverage tracking for the integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test-linux:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +66,7 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     name: "macOS: Python 3.13"
     steps:
       - name: Checkout ReBench
@@ -87,6 +89,7 @@ jobs:
   test-docker:
     name: "Docker: python:3"
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container:
       image: python:3
 
@@ -117,6 +120,7 @@ jobs:
   test-rocky:
     name: "Rocky Linux 10"
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     container:
       image: rockylinux/rockylinux:10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         include:
           - python-version: 3.11
             coverage: "--cov=rebench"
+            coverage_rebench_prefix: "coverage run --append --data-file=../.coverage"
     name: "Ubuntu-latest: Python ${{ matrix.python-version }}"
     steps:
       - name: Checkout ReBench
@@ -27,7 +28,7 @@ jobs:
         run: pip install pytest
 
       - name: Install coverage and coveralls
-        run: pip install pytest-cov coveralls
+        run: pip install pytest-cov coverage coveralls
         if: matrix.coverage
 
       - name: Install ReBench dependencies
@@ -36,7 +37,7 @@ jobs:
       - name: Run tests
         run: |
           pytest ${{ matrix.coverage }}
-          (cd rebench && rebench ../rebench.conf e:TestRunner2)
+          (cd rebench && ${{ matrix.coverage_rebench_prefix }} `which rebench` ../rebench.conf e:TestRunner2)
 
       - name: Install and run pylint
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "pykwalify.*"
 ignore_missing_imports = true
+
+[tool.coverage.run]
+parallel = true
+source = ["rebench"]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "py-cpuinfo==9.0.0",
         "psutil>=5.9.5",
     ],
-    test_require=["pytest>=7.2.2"],
+    test_require=["pytest>=7.2.2", "coverage>=7.16.0"],
     entry_points={
         "console_scripts": [
             "rebench = rebench.rebench:main_func",


### PR DESCRIPTION
Use coverage.py to collect data also for the direct `rebench` run.

Makes only a small difference, but it's included now.
I guess, this means, the tests are not too bad :)