### PR TITLE
Improve error reporting when sudo fails or location doesn't exist

### DIFF
--- a/rebench/denoise_client.py
+++ b/rebench/denoise_client.py
@@ -256,22 +256,24 @@ def get_initial_settings_and_capabilities(
 
 
 def _report_on_failure(output):
-    if "password is required" in output:
+    if "password is required" in output or "sudo" in output:
         return (
-            "{ind}Please make sure `sudo " + paths.get_denoise() + "`"
-            " can be used without password.\n"
+            "{ind}sudo currently can't be used to run denoise to manage the system.\n"
+            + "{ind}{ind} Error: "
+            + escape_braces(output)
+            + "{ind}Please make sure `sudo "
+            + paths.get_denoise()
+            + "` can be used without password.\n\n"
             "{ind}To be able to run denoise without password,\n"
-            "{ind}add the following to the end of your sudoers file (using visudo):\n"
+            "{ind}you may need to add the following to your sudoers file (using visudo):\n"
             "{ind}{ind}"
             + getpass.getuser()
             + " ALL = (root) NOPASSWD:SETENV: "
             + paths.get_denoise()
-            + "\n"
+            + "\n\n"
         )
     elif "command not found" in output:
         return "{ind}Please make sure " + paths.get_denoise() + " is accessible.\n"
-    elif "No such file or directory: 'sudo'" in output:
-        return "{ind}sudo is not available. Can't use denoise to manage the system.\n"
     else:
         return "{ind}Error: " + escape_braces(output)
 

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -694,6 +694,8 @@ class Executor(object):
                 msg = str(err)
             self.ui.error(msg, run_id, cmdline, location, env)
             run_id.report_run_failed(cmdline, 0, output)
+            if err.filename == cmdline[0]:
+                run_id.executable_missing = True
             return True
 
         if return_code == 127:

--- a/rebench/executor.py
+++ b/rebench/executor.py
@@ -690,11 +690,17 @@ class Executor(object):
                     + "{ind}{ind}It failed with: %s.\n"
                     + "{ind}{ind}File name: %s\n"
                 ) % (err.strerror, err.filename)
+            elif err.errno == 20:
+                msg = (
+                    "{ind}Failed executing run\n"
+                    + "{ind}{ind}It failed because the location caused an error: %s.\n"
+                    + "{ind}{ind}File name: %s\n"
+                ) % (err.strerror, err.filename)
             else:
                 msg = str(err)
             self.ui.error(msg, run_id, cmdline, location, env)
             run_id.report_run_failed(cmdline, 0, output)
-            if err.filename == cmdline[0]:
+            if err.filename in (cmdline, location):
                 run_id.executable_missing = True
             return True
 

--- a/rebench/tests/executor_test.py
+++ b/rebench/tests/executor_test.py
@@ -69,7 +69,7 @@ class ExecutorTest(ReBenchTestCase):
             ex.execute()
         self.assertIsInstance(err.exception.source_exception, ValueError)
 
-    def _remove_executors_with_missing_exe(self, scheduler):
+    def _adapt_yaml(self):
         yaml = load_config(self._path + "/test.conf")
 
         # change config to use executable that doesn't exist
@@ -82,7 +82,9 @@ class ExecutorTest(ReBenchTestCase):
         # by setting this to true, we avoid running things in parallel on multiple threads
         yaml["executors"]["TestRunner1"]["execute_exclusively"] = True
         yaml["executors"]["TestRunner2"]["execute_exclusively"] = True
+        return yaml
 
+    def _remove_executors_with_missing_exe(self, scheduler, yaml):
         cnf = Configurator(
             yaml, DataStore(self.ui), self.ui, exp_name="Test", data_file=self._tmp_file
         )
@@ -95,18 +97,47 @@ class ExecutorTest(ReBenchTestCase):
 
         ex = Executor(initial_runs, False, self.ui, False, False, scheduler)
         ex.execute()
+        return reporter
+
+    def test_remove_executors_with_missing_exe_batch(self):
+        reporter = self._remove_executors_with_missing_exe(
+            BatchScheduler, self._adapt_yaml()
+        )
         self.assertEqual(len(reporter.runs_completed), 40)
         self.assertEqual(len(reporter.runs_failed), 1)
         self.assertEqual(len(reporter.runs_failed_without_return_code), 23)
 
-    def test_remove_executors_with_missing_exe_batch(self):
-        self._remove_executors_with_missing_exe(BatchScheduler)
-
     def test_remove_executors_with_missing_exe_round_robin(self):
-        self._remove_executors_with_missing_exe(RoundRobinScheduler)
+        reporter = self._remove_executors_with_missing_exe(
+            RoundRobinScheduler, self._adapt_yaml()
+        )
+        self.assertEqual(len(reporter.runs_completed), 40)
+        self.assertEqual(len(reporter.runs_failed), 1)
+        self.assertEqual(len(reporter.runs_failed_without_return_code), 23)
 
     def test_remove_executors_with_missing_exe_random(self):
-        self._remove_executors_with_missing_exe(RandomScheduler)
+        reporter = self._remove_executors_with_missing_exe(
+            RandomScheduler, self._adapt_yaml()
+        )
+        self.assertEqual(len(reporter.runs_completed), 40)
+        self.assertEqual(len(reporter.runs_failed), 1)
+        self.assertEqual(len(reporter.runs_failed_without_return_code), 23)
+
+    def test_with_location_being_file(self):
+        yaml = self._adapt_yaml()
+        yaml["benchmark_suites"]["TestSuite1"]["location"] = self._path + "/test.conf"
+        reporter = self._remove_executors_with_missing_exe(BatchScheduler, yaml)
+        self.assertEqual(len(reporter.runs_completed), 40)
+        self.assertEqual(len(reporter.runs_failed), 2)
+        self.assertEqual(len(reporter.runs_failed_without_return_code), 38)
+
+    def test_with_location_not_existing(self):
+        yaml = self._adapt_yaml()
+        yaml["benchmark_suites"]["TestSuite1"]["location"] = self._path + "-dont-exist"
+        reporter = self._remove_executors_with_missing_exe(BatchScheduler, yaml)
+        self.assertEqual(len(reporter.runs_completed), 40)
+        self.assertEqual(len(reporter.runs_failed), 2)
+        self.assertEqual(len(reporter.runs_failed_without_return_code), 38)
 
     def test_broken_command_format_with_TypeError(self):
         with self.assertRaises(UIError) as err:


### PR DESCRIPTION
This improves the error reporting a bit to cover more cases.
The location, i.e., the current working directory for the run, was not reported on properly before.